### PR TITLE
feat(autophase): LLM-plan phases in the webui handler (parity with CLI)

### DIFF
--- a/packages/webui/src/server/autophase-ws-handler.ts
+++ b/packages/webui/src/server/autophase-ws-handler.ts
@@ -1,5 +1,6 @@
 import type { WebSocket } from 'ws';
 import {
+  AutoPhasePlanner,
   AutoPhaseRunner,
   PhaseGraphBuilder,
   PhaseOrchestrator,
@@ -131,19 +132,16 @@ export class AutoPhaseWebSocketHandler {
   }
 
   private async handleStart(payload?: Record<string, unknown>): Promise<void> {
-    const title = (payload?.title as string) || 'Untitled Project';
+    const title = (payload?.goal as string) || (payload?.title as string) || 'Untitled Project';
     const autonomous = (payload?.autonomous as boolean) ?? true;
 
-    // Varsayılan faz şablonları
-    const defaultPhases: PhaseTemplate[] = [
-      { name: 'Discovery', description: 'Requirements gathering', priority: 'high', estimateHours: 2, parallelizable: false },
-      { name: 'Design', description: 'Architecture and design', priority: 'critical', estimateHours: 4, parallelizable: false },
-      { name: 'Implementation', description: 'Core development', priority: 'critical', estimateHours: 12, parallelizable: false },
-      { name: 'Testing', description: 'Unit and integration tests', priority: 'high', estimateHours: 6, parallelizable: true },
-      { name: 'Deployment', description: 'Deploy to production', priority: 'medium', estimateHours: 2, parallelizable: false },
-    ];
-
-    const phases = (payload?.phases as PhaseTemplate[]) || defaultPhases;
+    // Phase plan resolution:
+    //   1. explicit phases in the payload win (caller override);
+    //   2. otherwise the LLM plans phases+todos for the goal;
+    //   3. failing that, fall back to the generic default phases.
+    const phases = Array.isArray(payload?.phases)
+      ? (payload.phases as PhaseTemplate[])
+      : await this.planPhases(title);
 
     this.logger.info(`[AutoPhase] Starting: ${title}`);
 
@@ -189,6 +187,43 @@ export class AutoPhaseWebSocketHandler {
     // Periyodik state broadcast başlat
     this.startBroadcast();
     this.broadcastState();
+  }
+
+  /** Generic fallback phases when the LLM planner produces nothing usable. */
+  private defaultPhases(): PhaseTemplate[] {
+    return [
+      { name: 'Discovery', description: 'Requirements gathering', priority: 'high', estimateHours: 2, parallelizable: false },
+      { name: 'Design', description: 'Architecture and design', priority: 'critical', estimateHours: 4, parallelizable: false },
+      { name: 'Implementation', description: 'Core development', priority: 'critical', estimateHours: 12, parallelizable: false },
+      { name: 'Testing', description: 'Unit and integration tests', priority: 'high', estimateHours: 6, parallelizable: true },
+      { name: 'Deployment', description: 'Deploy to production', priority: 'medium', estimateHours: 2, parallelizable: false },
+    ];
+  }
+
+  /** Plan phases+todos for the goal via the LLM; fall back to defaults on failure. */
+  private async planPhases(goal: string): Promise<PhaseTemplate[]> {
+    try {
+      const planner = new AutoPhasePlanner({
+        goal,
+        runOnce: async (prompt) => {
+          const result = (await this.agent.run(prompt, { signal: new AbortController().signal })) as {
+            status: string;
+            finalText?: string;
+          };
+          return result.status === 'done' ? (result.finalText ?? '') : '';
+        },
+      });
+      const { phases, parseFailed } = await planner.plan();
+      if (!parseFailed && phases.length > 0) {
+        const todos = phases.reduce((n, p) => n + (p.taskTemplates?.length ?? 0), 0);
+        this.logger.info(`[AutoPhase] Planned ${phases.length} phases / ${todos} todos for: ${goal}`);
+        return phases;
+      }
+      this.logger.info(`[AutoPhase] Planner produced no phases; using defaults for: ${goal}`);
+    } catch (err) {
+      this.logger.error(`[AutoPhase] Planning failed, using defaults: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return this.defaultPhases();
   }
 
   private async executeTaskWithAgent(task: import('@wrongstack/core').TaskNode, phaseId: string): Promise<unknown> {


### PR DESCRIPTION
## Summary

Follow-up to #3. The webui `AutoPhaseWebSocketHandler` hardcoded its 5 generic phases; it now runs `AutoPhasePlanner` (via the webui agent) to generate phases+todos for the goal, so the webui surface is LLM-driven like the CLI.

- `autophase.start` reads `goal` (falls back to `title`).
- Explicit `phases` in the WS payload still take precedence (caller override).
- On planner failure / empty output, falls back to the prior default phases — no behavior regression.

## Verification
- `pnpm --filter @wrongstack/webui typecheck` — **0 errors**.
- No webui autophase handler tests exist; change is additive with a preserved fallback path.

## Known pre-existing (not addressed here)
The webui handler still `await`s `runner.start()` to completion before starting its periodic broadcast — live progress during a run is a separate pre-existing issue (the CLI host already runs the orchestrator non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)