### PR TITLE
fix(autophase): run todos sequentially within a phase

### DIFF
--- a/packages/cli/src/autophase-host.ts
+++ b/packages/cli/src/autophase-host.ts
@@ -183,7 +183,10 @@ export function createAutoPhaseHost(deps: AutoPhaseHostDeps): AutoPhaseHostHooks
         events: deps.events,
         autonomous: true,
         maxConcurrentPhases: 1,
-        maxConcurrentTasks: 2,
+        // Sequential within a phase: each todo is a full-tool agent editing the
+        // shared working tree, and todos in a phase typically build on one
+        // another. Running two at once risks concurrent writes / lost edits.
+        maxConcurrentTasks: 1,
       });
 
       // Re-persist on terminal graph events.

--- a/packages/webui/src/server/autophase-ws-handler.ts
+++ b/packages/webui/src/server/autophase-ws-handler.ts
@@ -178,7 +178,9 @@ export class AutoPhaseWebSocketHandler {
       },
       autonomous,
       maxConcurrentPhases: 1,
-      maxConcurrentTasks: 2,
+      // Sequential within a phase: each todo is a full-tool agent editing the
+      // shared working tree, so running two at once risks concurrent writes.
+      maxConcurrentTasks: 1,
     });
 
     this.graph = await this.runner.start();


### PR DESCRIPTION
## Summary

`maxConcurrentTasks` was `2` — a leftover from when `executeTask` was a no-op `setTimeout` stub. Now that each todo is executed by a **full-tool agent editing the shared working tree** (#3, #4), two concurrent todos can clobber each other's edits. Todos within a phase also typically build on one another, so sequential execution is the correct default.

Set `maxConcurrentTasks: 1` in both the CLI host (`autophase-host.ts`) and the webui handler. Phases still run in dependency order; this only serializes todos *within* a phase.

A future opt-in for concurrency would require per-task git-worktree isolation.

## Verification
- `pnpm --filter @wrongstack/cli --filter @wrongstack/webui typecheck` — **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)