### PR TITLE
refactor(webui): extract pure slices from server/index.ts (usage-cost, file-picker, errMessage)

### DIFF
--- a/next.md
+++ b/next.md
@@ -61,9 +61,8 @@ implementations.
 
 ## 2. webui/src/server/index.ts — remaining concerns
 
-**Progress.** `index.ts` is now **1923 lines** (it had grown to 2046).
-`http-server.ts` (#17), **`ws-auth.ts` (#6), `lifecycle.ts` (#18), and
-`token-estimator.ts` (#7) are extracted**.
+**Progress.** `index.ts` is now **1815 lines** (it had grown to 2046 —
+−231 this session). Extracted, each pure + tested:
 
 | # | Concern | Status | Migration cost |
 |---|---------|--------|---------------:|
@@ -71,10 +70,23 @@ implementations.
 | 6  | `ws-auth.ts` — token check, time-constant compare, DNS-rebinding | ✅ done (2026-06-03) | LOW |
 | 18 | `lifecycle.ts` — graceful shutdown + SIGINT/SIGTERM | ✅ done (2026-06-03) | LOW |
 | 7  | `token-estimator.ts` — per-section context.debug token breakdown | ✅ done (2026-06-03) | LOW |
-| 11 | `error-formatter.ts` — ⚠️ plan mismatch (see below) | re-scope | LOW |
-| 9  | `rest-routes.ts` — `/api/...` registration | ⚠️ does not exist | n/a |
 | 8a | `provider-keys.ts` — `key.*`/`provider.*` record transforms | ✅ done (2026-06-03) | LOW |
+| 11 | `errMessage()` helper — dedup err-message ternary (×18) | ✅ done (2026-06-04) | LOW |
+| —  | `usage-cost.ts` — getCostRates + computeUsageCost (cost math) | ✅ done (2026-06-04) | LOW |
+| —  | `file-picker.ts` — files.list dotfile/skip filtering + fuzzy ranking | ✅ done (2026-06-04) | LOW |
+| 9  | `rest-routes.ts` — `/api/...` registration | ⚠️ does not exist | n/a |
 | 8  | `ws-handlers.ts` — rest of the `handleMessage` switch | open | HIGH (shared state) |
+
+The pure-slice seam is now largely mined. What remains in `index.ts` is the
+genuinely stateful core: `startWebUI`'s boot/wiring (provider registry,
+session, agent, container) and the `handleMessage` cases that mutate live
+`session`/`context`/`clients`/`config` and broadcast (`user_message`,
+`session.new`, `model.switch`, `context.*`, …). Extracting those safely needs a
+**WS integration-test harness** first — which itself requires refactoring
+`startWebUI` to accept injected config + ephemeral ports and return server
+handles (it currently returns `void` and binds fixed ports). That's the next
+real unit of work, and it's a deliberate, reviewable change — not another
+mechanical pure-slice lift.
 
 **token-estimator.ts done (2026-06-03).** Extracted the `context.debug`
 per-section token breakdown (~78 lines) into pure `estimateTokens` /

--- a/packages/webui/src/server/file-picker.ts
+++ b/packages/webui/src/server/file-picker.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure filtering + ranking for the `files.list` project file picker (the chat
+ * `@`-mention popup). The directory *walk* stays in index.ts (it's I/O), but
+ * the two decisions that shape the result — which entries to hide and how to
+ * rank matches — are pure and live here so the scoring weights, depth penalty,
+ * and tie-break order can be unit tested. A silently-flipped weight would make
+ * the picker feel subtly wrong with nothing to catch it.
+ */
+/** Heavyweight build/vcs/dependency dirs the picker never descends into. */
+export const SKIP_DIRS: ReadonlySet<string> = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  '.cache',
+  'target',
+  'coverage',
+  '.nyc_output',
+  'out',
+  '.pnpm-store',
+  '.parcel-cache',
+]);
+
+/** Dotfiles/dirs kept despite the hide-dotfiles-by-default rule. */
+const KEEP_DOTFILES: ReadonlySet<string> = new Set([
+  '.wrongstack',
+  '.env.example',
+  '.gitignore',
+  '.eslintrc',
+  '.prettierrc',
+]);
+
+/**
+ * Whether a directory entry should be hidden from the picker by its name.
+ * Dotfiles are hidden by default, except a few commonly-wanted ones.
+ */
+export function isHiddenEntry(name: string): boolean {
+  return name.startsWith('.') && !KEEP_DOTFILES.has(name);
+}
+
+/**
+ * Rank `paths` against `query` and return up to `limit` paths, best first.
+ *
+ * Scoring (cheap heuristic, good enough for a picker): exact basename match
+ * (100) > basename prefix (60) > path substring (20); non-matches are dropped.
+ * Each match is penalized by its path depth so root files sort first. Ties
+ * break by lexicographic path. An empty query keeps every path (score 0), so
+ * the result is the paths sorted lexicographically, capped to `limit`.
+ */
+export function rankFiles(paths: readonly string[], query: string, limit: number): string[] {
+  const q = query.toLowerCase();
+  const scored: Array<{ path: string; score: number }> = [];
+  for (const p of paths) {
+    if (!q) {
+      scored.push({ path: p, score: 0 });
+      continue;
+    }
+    const lower = p.toLowerCase();
+    const base = lower.split('/').pop() ?? lower;
+    let score = 0;
+    if (base === q) score = 100;
+    else if (base.startsWith(q)) score = 60;
+    else if (lower.includes(q)) score = 20;
+    else continue;
+    // Penalise depth so root files come first.
+    score -= p.split('/').length;
+    scored.push({ path: p, score });
+  }
+  scored.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path));
+  return scored.slice(0, limit).map((s) => s.path);
+}

--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -47,6 +47,7 @@ import { CollaborationWebSocketHandler } from './collaboration-ws-handler.js';
 import { WorktreeWebSocketHandler } from './worktree-ws-handler.js';
 import { verifyClient as verifyWsClient } from './ws-auth.js';
 import { registerShutdownHandlers } from './lifecycle.js';
+import { computeUsageCost, getCostRates } from './usage-cost.js';
 import {
   addProvider as addProviderRecord,
   deleteKey as deleteKeyRecord,
@@ -448,12 +449,10 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
       // models.dev pricing is dollars per 1M tokens; some providers omit the
       // field for free/unmetered plans (e.g. minimax-coding-plan) — in that
       // case we report 0 and the cost chip just stays at $0.
-      const cost = (
-        m as { cost?: { input?: number; output?: number; cache_read?: number } } | undefined
-      )?.cost;
-      inputCost = cost?.input ?? 0;
-      outputCost = cost?.output ?? 0;
-      cacheReadCost = cost?.cache_read ?? 0;
+      const rates = getCostRates(m);
+      inputCost = rates.input;
+      outputCost = rates.output;
+      cacheReadCost = rates.cacheRead;
     } catch {
       // best-effort
     }
@@ -1688,15 +1687,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
         const usage = tokenCounter.total();
         const cacheStats = tokenCounter.cacheStats();
         const m = await modelsRegistry.getModel(config.provider, config.model).catch(() => null);
-        const inputCost = (m as { cost?: { input?: number } } | null)?.cost?.input ?? 0;
-        const outputCost = (m as { cost?: { output?: number } } | null)?.cost?.output ?? 0;
-        const cacheReadCost =
-          (m as { cost?: { cache_read?: number } } | null)?.cost?.cache_read ?? 0;
-        const cost =
-          (usage.input * inputCost +
-            usage.output * outputCost +
-            (usage.cacheRead ?? 0) * cacheReadCost) /
-          1_000_000;
+        const cost = computeUsageCost(usage, getCostRates(m));
         send(ws, {
           type: 'stats.get',
           payload: {

--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -61,6 +61,11 @@ import { estimateContextBreakdown } from './token-estimator.js';
 // Re-export types
 export type { WebUIOptions, BackendServices } from './types.js';
 
+/** Extract a human-readable message from an unknown thrown value. */
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 // Internal message types
 interface WSServerMessage {
   type: string;
@@ -861,7 +866,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
             type: 'error',
             payload: {
               phase: 'agent.run',
-              message: err instanceof Error ? err.message : String(err),
+              message: errMessage(err),
             },
           });
         } finally {
@@ -974,7 +979,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
             `Compacted: ${report.before} → ${report.after} tokens (saved ~${Math.max(0, report.before - report.after)})`,
           );
         } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
+          sendResult(ws, false, errMessage(err));
         }
         break;
       }
@@ -1165,7 +1170,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
             type: 'key.operation_result',
             payload: {
               success: false,
-              message: `Switch failed: ${err instanceof Error ? err.message : String(err)}`,
+              message: `Switch failed: ${errMessage(err)}`,
             },
           });
           break;
@@ -1235,7 +1240,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
         } catch (err) {
           send(ws, {
             type: 'sessions.list',
-            payload: { sessions: [], error: err instanceof Error ? err.message : String(err) },
+            payload: { sessions: [], error: errMessage(err) },
           });
         }
         break;
@@ -1251,7 +1256,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
           await sessionStore.delete(id);
           sendResult(ws, true, `Session ${id} deleted`);
         } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
+          sendResult(ws, false, errMessage(err));
         }
         break;
       }
@@ -1295,7 +1300,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
           });
           sendResult(ws, true, `Resumed session ${id}`);
         } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
+          sendResult(ws, false, errMessage(err));
         }
         break;
       }
@@ -1336,7 +1341,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
         } catch (err) {
           send(ws, {
             type: 'memory.list',
-            payload: { text: '', error: err instanceof Error ? err.message : String(err) },
+            payload: { text: '', error: errMessage(err) },
           });
         }
         break;
@@ -1352,7 +1357,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
           await memoryStore.remember(text, scope ?? 'project-memory');
           sendResult(ws, true, 'Saved to memory');
         } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
+          sendResult(ws, false, errMessage(err));
         }
         break;
       }
@@ -1373,7 +1378,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
               : 'No matching entries',
           );
         } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
+          sendResult(ws, false, errMessage(err));
         }
         break;
       }
@@ -1408,7 +1413,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
             payload: {
               skills: [],
               enabled: true,
-              error: err instanceof Error ? err.message : String(err),
+              error: errMessage(err),
             },
           });
         }
@@ -1519,7 +1524,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
             payload: { plan },
           });
         } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
+          sendResult(ws, false, errMessage(err));
         }
         break;
       }
@@ -1624,7 +1629,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
             payload: {
               modes: [],
               activeId: 'default',
-              error: err instanceof Error ? err.message : String(err),
+              error: errMessage(err),
             },
           });
         }
@@ -1673,7 +1678,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
             payload: { ...(await sessionStartPayload()) },
           });
         } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
+          sendResult(ws, false, errMessage(err));
         }
         break;
       }
@@ -1771,7 +1776,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
       if (result.ok) await saveProviders(providers);
       sendResult(ws, result.ok, result.message);
     } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
+      sendResult(ws, false, errMessage(err));
     }
   }
 
@@ -1782,7 +1787,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
       if (result.ok) await saveProviders(providers);
       sendResult(ws, result.ok, result.message);
     } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
+      sendResult(ws, false, errMessage(err));
     }
   }
 
@@ -1797,7 +1802,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
       if (result.ok) await saveProviders(providers);
       sendResult(ws, result.ok, result.message);
     } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
+      sendResult(ws, false, errMessage(err));
     }
   }
 
@@ -1811,7 +1816,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
       if (result.ok) await saveProviders(providers);
       sendResult(ws, result.ok, result.message);
     } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
+      sendResult(ws, false, errMessage(err));
     }
   }
 
@@ -1822,7 +1827,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
       if (result.ok) await saveProviders(providers);
       sendResult(ws, result.ok, result.message);
     } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
+      sendResult(ws, false, errMessage(err));
     }
   }
 

--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as http from 'node:http';
 import * as path from 'node:path';
 import { createHttpServer } from './http-server.js';
+import { SKIP_DIRS, isHiddenEntry, rankFiles } from './file-picker.js';
 import {
   Agent,
   AutoCompactionMiddleware,
@@ -1535,23 +1536,9 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
         // a fuzzy substring match against the (lowercased) query and caps
         // the result so the popup never has to paginate.
         const payload = (msg as { payload?: { query?: string; limit?: number } }).payload ?? {};
-        const query = (payload.query ?? '').toLowerCase();
         const limit = payload.limit ?? 50;
-        const SKIP_DIRS = new Set([
-          '.git',
-          'node_modules',
-          'dist',
-          'build',
-          '.next',
-          '.turbo',
-          '.cache',
-          'target',
-          'coverage',
-          '.nyc_output',
-          'out',
-          '.pnpm-store',
-          '.parcel-cache',
-        ]);
+        // Filtering (isHiddenEntry/SKIP_DIRS) and ranking (rankFiles) live in
+        // ./file-picker.ts; the walk itself stays here since it's disk I/O.
         const results: string[] = [];
         async function walk(dir: string, rel: string, depth: number): Promise<void> {
           if (depth > 8 || results.length >= 600) return;
@@ -1563,12 +1550,7 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
           }
           for (const e of entries) {
             if (results.length >= 600) return;
-            if (e.name.startsWith('.') && e.name !== '.wrongstack' && e.name !== '.env.example') {
-              // hide dotfiles by default; pick a couple common ones the user
-              // might want anyway
-              if (e.name !== '.gitignore' && e.name !== '.eslintrc' && e.name !== '.prettierrc')
-                continue;
-            }
+            if (isHiddenEntry(e.name)) continue;
             const childRel = rel ? `${rel}/${e.name}` : e.name;
             if (e.isDirectory()) {
               if (SKIP_DIRS.has(e.name)) continue;
@@ -1579,29 +1561,9 @@ export async function startWebUI(opts: { wsPort?: number; wsHost?: string } = {}
           }
         }
         await walk(projectRoot, '', 0);
-        // Score: exact basename match > prefix > substring. Cheap heuristic
-        // that's good enough for a picker.
-        const scored: Array<{ path: string; score: number }> = [];
-        for (const p of results) {
-          if (!query) {
-            scored.push({ path: p, score: 0 });
-            continue;
-          }
-          const lower = p.toLowerCase();
-          const base = lower.split('/').pop() ?? lower;
-          let score = 0;
-          if (base === query) score = 100;
-          else if (base.startsWith(query)) score = 60;
-          else if (lower.includes(query)) score = 20;
-          else continue;
-          // Penalise depth so root files come first.
-          score -= p.split('/').length;
-          scored.push({ path: p, score });
-        }
-        scored.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path));
         send(ws, {
           type: 'files.list',
-          payload: { files: scored.slice(0, limit).map((s) => s.path) },
+          payload: { files: rankFiles(results, payload.query ?? '', limit) },
         });
         break;
       }

--- a/packages/webui/src/server/usage-cost.ts
+++ b/packages/webui/src/server/usage-cost.ts
@@ -1,0 +1,58 @@
+/**
+ * Token-usage cost math for the WebUI server.
+ *
+ * models.dev pricing is expressed in **dollars per 1,000,000 tokens**, and
+ * providers omit the field entirely for free/unmetered plans. Both the
+ * `session.start` payload (which ships the per-token rates to the client) and
+ * `stats.get` (which reports an actual dollar figure) repeated the same
+ * "read `model.cost.*` with a `?? 0` fallback, then divide by 1e6" logic
+ * inline. Pulling it here keeps the rate normalization and the cost formula in
+ * one tested place — a wrong field name or a missing `/ 1e6` silently produces
+ * a plausible-but-wrong number, which is exactly what a unit test should pin.
+ */
+
+/** Per-1,000,000-token pricing, normalized to numbers (0 when unpriced). */
+export interface CostRates {
+  /** $ per 1M input tokens. */
+  input: number;
+  /** $ per 1M output tokens. */
+  output: number;
+  /** $ per 1M cache-read tokens. */
+  cacheRead: number;
+}
+
+/** Token counts for a turn/session. `cacheRead` is optional (older counters). */
+export interface TokenUsage {
+  input: number;
+  output: number;
+  cacheRead?: number;
+}
+
+/**
+ * Normalize a models.dev model object's pricing into {@link CostRates}.
+ * Missing model, missing `cost`, or missing individual fields all yield 0 —
+ * free/unmetered plans report `$0` rather than crashing.
+ */
+export function getCostRates(model: unknown): CostRates {
+  const cost = (
+    model as { cost?: { input?: number; output?: number; cache_read?: number } } | null | undefined
+  )?.cost;
+  return {
+    input: cost?.input ?? 0,
+    output: cost?.output ?? 0,
+    cacheRead: cost?.cache_read ?? 0,
+  };
+}
+
+/**
+ * Dollar cost of `usage` at the given per-1M-token `rates`. Returns 0 when all
+ * rates are 0 (unpriced plan).
+ */
+export function computeUsageCost(usage: TokenUsage, rates: CostRates): number {
+  return (
+    (usage.input * rates.input +
+      usage.output * rates.output +
+      (usage.cacheRead ?? 0) * rates.cacheRead) /
+    1_000_000
+  );
+}

--- a/packages/webui/tests/server/file-picker.test.ts
+++ b/packages/webui/tests/server/file-picker.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { SKIP_DIRS, isHiddenEntry, rankFiles } from '../../src/server/file-picker.js';
+
+/**
+ * Pure filtering + ranking behind the `files.list` `@`-mention picker. The
+ * scoring weights, depth penalty, and tie-break order are easy to regress
+ * silently, so pin them here.
+ */
+
+describe('isHiddenEntry', () => {
+  it('hides dotfiles by default', () => {
+    expect(isHiddenEntry('.DS_Store')).toBe(true);
+    expect(isHiddenEntry('.vscode')).toBe(true);
+  });
+  it('keeps a few commonly-wanted dotfiles', () => {
+    for (const name of ['.wrongstack', '.env.example', '.gitignore', '.eslintrc', '.prettierrc']) {
+      expect(isHiddenEntry(name)).toBe(false);
+    }
+  });
+  it('never hides normal files/dirs', () => {
+    expect(isHiddenEntry('src')).toBe(false);
+    expect(isHiddenEntry('index.ts')).toBe(false);
+  });
+});
+
+describe('SKIP_DIRS', () => {
+  it('includes the heavyweight build/vcs/dependency dirs', () => {
+    for (const d of ['.git', 'node_modules', 'dist', 'build', 'coverage', 'target']) {
+      expect(SKIP_DIRS.has(d)).toBe(true);
+    }
+    expect(SKIP_DIRS.has('src')).toBe(false);
+  });
+});
+
+describe('rankFiles', () => {
+  const files = ['src/index.ts', 'src/server/index.ts', 'README.md', 'src/util/index.helper.ts'];
+
+  it('returns all paths alphabetically (capped) for an empty query', () => {
+    // Empty query → every path scores 0, so the sort falls through to the
+    // lexicographic tie-break. 'README.md' sorts before the 'src/…' paths.
+    expect(rankFiles(files, '', 2)).toEqual(['README.md', 'src/index.ts']);
+  });
+
+  it('ranks exact basename match above prefix above substring', () => {
+    const ranked = rankFiles(
+      ['a/readme.md', 'b/readme.md.bak', 'c/notes-readme.md'],
+      'readme.md',
+      50,
+    );
+    // exact basename 'readme.md' (a/) first; then prefix 'readme.md...' (b/);
+    // then substring (c/).
+    expect(ranked).toEqual(['a/readme.md', 'b/readme.md.bak', 'c/notes-readme.md']);
+  });
+
+  it('drops non-matching paths', () => {
+    expect(rankFiles(['src/index.ts', 'docs/guide.md'], 'index', 50)).toEqual(['src/index.ts']);
+  });
+
+  it('prefers shallower paths on equal score (depth penalty)', () => {
+    // Both are exact basename matches for "index.ts" → depth penalty decides.
+    expect(rankFiles(['a/b/c/index.ts', 'index.ts'], 'index.ts', 50)).toEqual([
+      'index.ts',
+      'a/b/c/index.ts',
+    ]);
+  });
+
+  it('is case-insensitive and caps to limit', () => {
+    // 'SRC/App.TSX' and 'x/app.tsx' are both exact basename matches (depth 2);
+    // 'src/app.test.tsx' is neither prefix nor substring → dropped. The two
+    // survivors tie on score, so assert membership, not locale-dependent order.
+    const ranked = rankFiles(['SRC/App.TSX', 'src/app.test.tsx', 'x/app.tsx'], 'app.tsx', 2);
+    expect(ranked).toHaveLength(2);
+    expect(ranked).toContain('SRC/App.TSX');
+    expect(ranked).toContain('x/app.tsx');
+  });
+});

--- a/packages/webui/tests/server/usage-cost.test.ts
+++ b/packages/webui/tests/server/usage-cost.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { computeUsageCost, getCostRates } from '../../src/server/usage-cost.js';
+
+/**
+ * Cost math used by `session.start` (rates) and `stats.get` (dollar figure).
+ * The per-1M-token scaling and the `?? 0` fallbacks are exactly the kind of
+ * thing that silently produces a plausible-but-wrong number, so pin them.
+ */
+
+describe('getCostRates', () => {
+  it('reads input/output/cache_read into normalized rates', () => {
+    expect(getCostRates({ cost: { input: 3, output: 15, cache_read: 0.3 } })).toEqual({
+      input: 3,
+      output: 15,
+      cacheRead: 0.3,
+    });
+  });
+
+  it('defaults every field to 0 for unpriced / missing models', () => {
+    const zero = { input: 0, output: 0, cacheRead: 0 };
+    expect(getCostRates({ cost: {} })).toEqual(zero);
+    expect(getCostRates({})).toEqual(zero);
+    expect(getCostRates(null)).toEqual(zero);
+    expect(getCostRates(undefined)).toEqual(zero);
+  });
+
+  it('fills only the present fields, zeroing the rest', () => {
+    expect(getCostRates({ cost: { input: 2 } })).toEqual({ input: 2, output: 0, cacheRead: 0 });
+  });
+});
+
+describe('computeUsageCost', () => {
+  const rates = { input: 3, output: 15, cacheRead: 0.3 };
+
+  it('scales by per-1M-token rates', () => {
+    // 1M input @ $3 + 1M output @ $15 = $18
+    expect(computeUsageCost({ input: 1_000_000, output: 1_000_000 }, rates)).toBeCloseTo(18, 9);
+  });
+
+  it('includes cache-read tokens', () => {
+    // 2M cache-read @ $0.3 = $0.6
+    expect(computeUsageCost({ input: 0, output: 0, cacheRead: 2_000_000 }, rates)).toBeCloseTo(
+      0.6,
+      9,
+    );
+  });
+
+  it('treats missing cacheRead as zero', () => {
+    expect(computeUsageCost({ input: 500_000, output: 0 }, rates)).toBeCloseTo(1.5, 9);
+  });
+
+  it('returns 0 for an unpriced plan (all rates 0)', () => {
+    expect(
+      computeUsageCost(
+        { input: 9_999, output: 9_999, cacheRead: 9_999 },
+        { input: 0, output: 0, cacheRead: 0 },
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
Follow-on to the webui `server/index.ts` decomposition (ws-auth / lifecycle / token-estimator / provider-keys already on `main`). Continues carving **pure, unit-tested** logic out of the 1800-line server entry point — disk/socket I/O stays in `index.ts`, only the pure decisions move.

## Commits
- **`errMessage()` helper** — dedupe the `err instanceof Error ? err.message : String(err)` ternary (×18) into one module-level helper.
- **`usage-cost.ts`** — `getCostRates()` + `computeUsageCost()`. The models.dev per-1M-token cost math (used by `session.start` rates and `stats.get` dollars) was inlined in two places; a wrong field name or missing `/ 1e6` silently produces a plausible-but-wrong number. 7 tests.
- **`file-picker.ts`** — `SKIP_DIRS`, `isHiddenEntry()`, `rankFiles()` for the `files.list` `@`-mention picker. The fuzzy ranking (exact-basename 100 > prefix 60 > substring 20, minus path-depth penalty, lexicographic tie-break) is easy to regress silently. 9 tests (one caught that an empty query sorts lexicographically, not by input order).
- **`docs(next)`** — record progress; `index.ts` 2046 → 1815 this session.

## Verification
- Full webui suite green (**179 passing**)
- `index.ts` diffs verified content-only (no Biome whole-file reformat)
- typecheck + build clean across core/cli/webui

## Notes
- Each extraction is behavior-preserving; tests pin the pure logic.
- The remaining `handleMessage` core is genuinely stateful and needs a WS integration-test harness (a deliberate `startWebUI` signature refactor) before it can be extracted safely — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)