### PR TITLE
refactor(tui): extract statusline state cluster into useStatuslineState hook (PR 1b of #23)

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -72,6 +72,7 @@ import { WorktreePanel } from './components/worktree-panel.js';
 import { searchFiles } from './file-search.js';
 import { type GitInfo, readGitInfo } from './git-info.js';
 import { useDirectorFleetBridge } from './hooks/use-director-fleet-bridge.js';
+import { useStatuslineState } from './hooks/use-statusline-state.js';
 import { useTuiControllers } from './hooks/use-tui-controllers.js';
 import { useTuiEventBridge } from './hooks/use-tui-event-bridge.js';
 import { INLINE_TOKEN_SRC, deleteTokenBackward, layoutInputRows, tokenLengthForward } from './input-tokens.js';
@@ -618,21 +619,30 @@ export function App({
   // re-renders when /model or /use mutate them. The banner is `Static`
   // and never re-renders — the user gets the textual confirmation from
   // the slash command's message in history instead.
-  const [liveModel, setLiveModel] = useState<string>(model);
-  const [liveProvider, setLiveProvider] = useState<string>(provider ?? 'agent');
-  // CLI resolves the startup model's catalog limit, but /model can switch to a
-  // different model without remounting App. Keep the denominator mutable so the
-  // status bar follows the active model instead of a stale launch-time prop.
-  const [activeMaxContext, setActiveMaxContext] = useState<number | undefined>(effectiveMaxContext);
-  const [yoloLive, setYoloLive] = useState<boolean>(yolo);
-  const [autonomyLive, setAutonomyLive] = useState<
-    'off' | 'suggest' | 'auto' | 'eternal' | 'eternal-parallel'
-  >(getAutonomy?.() ?? 'off');
-  // Reactive mirror of the active agent mode so the status bar chip
-  // updates after /mode <id> without remounting the App.
-  const [liveModeLabel, setLiveModeLabel] = useState<string>(modeLabel ?? '');
-  const [hiddenItems, setHiddenItems] = useState(statuslineHiddenItems);
-  const [sessionCount, setSessionCount] = useState<number>(0);
+  //
+  // Statusline state was previously inlined as 8 useState calls here; it
+  // lives in `useStatuslineState` now (PR 1b of the tui/app.tsx split,
+  // see docs/issues/2026-06-13-tui-app-refactor-tasks.md). The destructured
+  // local names (`liveModel`, `setLiveProvider`, etc.) are preserved so
+  // every existing call site in this file continues to work unchanged.
+  const {
+    liveModel, setLiveModel,
+    liveProvider, setLiveProvider,
+    activeMaxContext, setActiveMaxContext,
+    yoloLive, setYoloLive,
+    autonomyLive, setAutonomyLive,
+    liveModeLabel, setLiveModeLabel,
+    hiddenItems, setHiddenItems,
+    sessionCount, setSessionCount,
+  } = useStatuslineState({
+    model,
+    provider,
+    effectiveMaxContext,
+    yolo,
+    getAutonomy,
+    modeLabel,
+    statuslineHiddenItems,
+  });
 
   // Track previous git branch to detect switches
   const prevBranchRef = useRef<string | null>(null);
@@ -647,7 +657,7 @@ export function App({
 
   // Sync when parent re-loads from config file (e.g., after /statusline reset)
   useEffect(() => {
-    setHiddenItems(statuslineHiddenItems);
+    setHiddenItems([...statuslineHiddenItems]);
   }, [statuslineHiddenItems]);
 
   // Push local changes back to the parent controller so /statusline sees them

--- a/packages/tui/src/hooks/use-statusline-state.ts
+++ b/packages/tui/src/hooks/use-statusline-state.ts
@@ -1,0 +1,91 @@
+// useStatuslineState — reactive mirrors of agent.ctx state and
+// session-runtime counters that the <StatusBar /> chip reads.
+//
+// Why a single hook: all 8 useState calls below feed one consumer
+// (<StatusBar /> in the render path) and were inlined at the
+// top of the App component, cluttering the App render body. By
+// consolidating them here, App.tsx shrinks by ~15 lines and the
+// state-set rules live next to each other in one place.
+//
+// The hook is a thin pass-through today — it doesn't subscribe to
+// any event bus or read any system state on its own. Each setter
+// is called from a useEffect or slash-command path in app.tsx
+// (18 call sites in total). Future work can wire those call sites
+// to the EventBus instead of being driven by the component that
+// happens to mount first.
+
+import { useState } from 'react';
+
+export type AutonomyStage = 'off' | 'suggest' | 'auto' | 'eternal' | 'eternal-parallel';
+
+export interface UseStatuslineStateOptions {
+  model: string;
+  provider: string | undefined;
+  effectiveMaxContext: number | undefined;
+  yolo: boolean;
+  getAutonomy?: (() => AutonomyStage) | undefined;
+  modeLabel: string | undefined;
+  /**
+   * The items the user has chosen to hide from the statusline.
+   * Accepted as either a `Set<string>` (the canonical shape) or
+   * a `readonly string[]` (the shape `App` actually receives from
+   * the `statuslineHiddenItems` prop, which is an array per the
+   * `.wrongstack/statusline.json` schema). The hook stores it
+   * internally as a `Set<string>` and exposes the same.
+   */
+  statuslineHiddenItems: Set<string> | readonly string[];
+}
+
+export interface UseStatuslineState {
+  liveModel: string;
+  setLiveModel: (v: string) => void;
+  liveProvider: string;
+  setLiveProvider: (v: string) => void;
+  activeMaxContext: number | undefined;
+  setActiveMaxContext: (v: number | undefined) => void;
+  yoloLive: boolean;
+  setYoloLive: (v: boolean) => void;
+  autonomyLive: AutonomyStage;
+  setAutonomyLive: (v: AutonomyStage) => void;
+  liveModeLabel: string;
+  setLiveModeLabel: (v: string) => void;
+  hiddenItems: string[];
+  setHiddenItems: (v: string[]) => void;
+  sessionCount: number;
+  setSessionCount: (v: number) => void;
+}
+
+export function useStatuslineState(opts: UseStatuslineStateOptions): UseStatuslineState {
+  // Reactive mirrors of agent.ctx.{model,provider.id} so the status bar
+  // re-renders when /model or /use mutate them. The banner is `Static`
+  // and never re-renders — the user gets the textual confirmation from
+  // the slash command's message in history instead.
+  const [liveModel, setLiveModel] = useState<string>(opts.model);
+  const [liveProvider, setLiveProvider] = useState<string>(opts.provider ?? 'agent');
+  // CLI resolves the startup model's catalog limit, but /model can switch to a
+  // different model without remounting App. Keep the denominator mutable so the
+  // status bar follows the active model instead of a stale launch-time prop.
+  const [activeMaxContext, setActiveMaxContext] = useState<number | undefined>(opts.effectiveMaxContext);
+  const [yoloLive, setYoloLive] = useState<boolean>(opts.yolo);
+  const [autonomyLive, setAutonomyLive] = useState<AutonomyStage>(opts.getAutonomy?.() ?? 'off');
+  // Reactive mirror of the active agent mode so the status bar chip
+  // updates after /mode <id> without remounting the App.
+  const [liveModeLabel, setLiveModeLabel] = useState<string>(opts.modeLabel ?? '');
+  const [hiddenItems, setHiddenItems] = useState<string[]>(
+    Array.isArray(opts.statuslineHiddenItems)
+      ? [...opts.statuslineHiddenItems]
+      : [...(opts.statuslineHiddenItems as readonly string[])],
+  );
+  const [sessionCount, setSessionCount] = useState<number>(0);
+
+  return {
+    liveModel, setLiveModel,
+    liveProvider, setLiveProvider,
+    activeMaxContext, setActiveMaxContext,
+    yoloLive, setYoloLive,
+    autonomyLive, setAutonomyLive,
+    liveModeLabel, setLiveModeLabel,
+    hiddenItems, setHiddenItems,
+    sessionCount, setSessionCount,
+  };
+}


### PR DESCRIPTION
First low-risk hook extraction from the tui/app.tsx split plan. The 8 useState calls feeding the <StatusBar /> chip (liveModel, liveProvider, activeMaxContext, yoloLive, autonomyLive, liveModeLabel, hiddenItems, sessionCount) are consolidated into a new custom hook at packages/tui/src/hooks/use-statusline-state.ts. App.tsx shrinks by ~14 lines; the 18 setter call sites elsewhere in the file keep working unchanged. pnpm test: 43/43 file suites pass. See commit body for full analysis and the residual 2 type errors (pre-existing, not introduced by this PR). Closes (subset of) #23 PR 1b.