### PR TITLE
docs: file decomposition plans for cli-main, webui-server, and webui/package/server (H-1 follow-ups)

### DIFF
--- a/docs/issues/2026-06-13-cli-main-refactor.md
+++ b/docs/issues/2026-06-13-cli-main-refactor.md
@@ -1,0 +1,250 @@
+# Split `packages/cli/src/cli-main.ts` (2,424 lines) into focused boot phases
+
+**Filed:** 2026-06-13
+**Status:** Open
+**Priority:** Medium (long-running, blocked on the test-extraction harness)
+**Effort estimate:** 4–6 days, sequenced into 7 PRs
+**Risk:** High — the file owns the entire CLI boot path and zero integration test covers its end-to-end shape today
+
+## Problem
+
+`packages/cli/src/cli-main.ts` is 2,424 lines (one of four files in the
+repo over 2,000 — `tui/app.tsx: 5,671`, `cli/webui-server.ts: 3,407`,
+`webui/server/index.ts: 3,104`, and this one). The June 5 refactor
+plan (1.2) called for splitting it but no PRs have landed yet. The
+single `main()` function in this file now contains:
+
+- argv parsing and `NODE_ENV=production` boot defaulting (lines 112–129)
+- the full `createDefaultContainer` wiring (lines 130–250)
+- every `ReplOptions` callback — `onMcp`, `onYolo`, `onAutonomy`,
+  `onEternalStart`, `onEternalStop`, `onSuggestions`, `onNextPredict`,
+  `onExit`, and ~70 more (lines ~700–2,080)
+- the eternal-autonomy engine lazy-instantiation
+- the multi-agent host binding
+- the goal / session / mailbox / worktree / brain side-channel wiring
+- the recovery prompt and update-notice orchestration
+- the webui-server start / TUI launch / REPL dispatch fork
+
+With everything in a single function, every new slash command, every
+new permission callback, and every new subscription requires editing
+the same ~2,000-line block of closure-captured mutable state. The
+function has no integration test — only a handful of
+`pre-launch.test.ts` / `boot-config.test.ts` unit tests cover the
+adjacent boot helpers, and nothing exercises the full `main(argv) →
+execute(...) → REPL/TUI dispatch` path.
+
+## Why this matters
+
+1. **The `tui/app.tsx` decomposition is already running.** That work
+   will cascade into `cli-main.ts`: every new TUI-side effect needs a
+   matching callback in the `ReplOptions` object, which means another
+   closure in `main()`. Splitting `cli-main.ts` first is a
+   prerequisite for finishing the TUI refactor cheaply.
+2. **Three of the four >2,000-line files are untracked.** Only
+   `tui/app.tsx` has a sequenced decomposition plan
+   (`docs/issues/2026-06-13-tui-app-refactor.md`, 8 PRs). The other
+   three — `cli-main.ts`, `webui-server.ts`, `webui/server/index.ts` —
+   drift in silence, growing every week. Each new feature adds 50–200
+   lines to whichever is the closest match, accelerating the
+   regression. The file-size gate (`scripts/check-file-size.mjs`)
+   prints a warning but does not block the merge.
+
+## Proposed approach (sequenced, one PR per step)
+
+The same `PR-0 characterization test → extract → verify` template
+from the tui-app refactor applies, adapted for a non-React file.
+`cli-main.ts` is a `main()` function, not a component, so the
+extraction unit is a **boot phase** (a function that takes the
+running `BootContext` and returns a typed result), not a custom hook.
+
+### PR 0 — Baseline boot-shape integration test (must come first)
+
+Add a vitest test that invokes `main(argv)` with a stub
+`@wrongstack/runtime` container, a stub `Agent`, and a stub TUI/REPL
+host. The test should:
+
+- Call `main()` with `argv = ['node', 'wstack', '--help']` and assert
+  it returns 0 without writing to stdout.
+- Call `main()` with a flag combination that short-circuits to
+  `runPluginManagementCommand` and assert the stub was invoked with
+  the expected `argv` slice.
+- Snapshot the `ReplOptions` shape (function references) that
+  `main()` would hand to a stub REPL — call it with a `--repl-test`
+  flag (added behind `process.env['WSTACK_BOOT_INSPECT'] === '1'`) that
+  serializes the constructed `ReplOptions` to JSON-serializable form
+  and returns it as the exit code.
+
+This is the safety net for everything that follows. **All later PRs
+must keep this test green and re-run it manually after every phase
+extraction.** No test → no extraction.
+
+The June 5 plan didn't include this step; it's the lesson from the
+tui-app refactor (2026-06-13): "Big-file refactors need
+characterization tests first, not after."
+
+### PR 1 — `boot/env-defaults.ts` (low risk)
+
+Extract the `NODE_ENV=production` defaulting (lines 113–129) and the
+`WRONGSTACK_NODE_ENV_DEFAULTED` marker logic into
+`boot/env-defaults.ts`. The function is `applyNodeEnvDefaults(): void`,
+called from `main()`. Pure move + named-export; no behavior change.
+
+This is the same pattern as `tui/src/hooks/use-keyboard-handling.ts`
+in the tui refactor: an inline block becomes a named module with
+a test of its own.
+
+### PR 2 — `boot/container-wiring.ts` (low risk)
+
+Extract lines 167–250 (PathResolver, EventBus, `createDefaultContainer`
+call) into `boot/container-wiring.ts`. Returns
+`{ container, events, pathResolver }`. The `main()` function shrinks
+by ~80 lines; no behavior change. `boot-config.test.ts` already covers
+`createDefaultContainer` directly, so this PR is mostly mechanical.
+
+### PR 3 — `boot/replay-wiring.ts` (low risk)
+
+Extract the `--replay` / `--record` handling (lines 192–250) into
+`boot/replay-wiring.ts`. The block already follows the
+"check flag → bind `ReplayProviderRunner` under `TOKENS.ProviderRunner`"
+pattern that other phases (e.g. `fleet-wiring.ts`) use. Move + test.
+
+### PR 4 — `boot/repl-options.ts` (medium risk) 🔥
+
+This is the **core extraction**. The 1,400-line `ReplOptions`
+literal (lines ~700–2,080) becomes its own module
+`boot/repl-options.ts`, with a factory
+`createReplOptions(ctx: BootContext, deps: ReplDeps): ReplOptions`.
+The factory takes the assembled `BootContext` plus a small typed
+`ReplDeps` interface (agent, container, brain, multiAgentHost,
+mailbox, worktree, etc.) and returns the same `ReplOptions` object
+that `main()` currently constructs inline.
+
+After this PR, `main()` shrinks from ~2,400 lines to ~400 lines and
+reads as a sequence of `await assembleXxx();` calls. The slash-command
+callbacks stay where they are (in `repl-options.ts`) but are no longer
+nested inside `main()`. Adding a new slash-command callback becomes
+"edit `repl-options.ts`", not "edit `cli-main.ts`".
+
+Risk: medium because this is the biggest single extraction and the
+callbacks share closure state (e.g. `autonomyMode` /
+`autonomyModeRef.current`). The factory must receive all shared state
+as parameters; no closure captures.
+
+### PR 5 — `boot/eternal-engine-wiring.ts` (low risk)
+
+Extract the `eternalEngine` / `parallelEngine` lazy-instantiation
+and `onEternalStart` / `onEternalStop` callbacks (lines ~1,990–2,080)
+into `boot/eternal-engine-wiring.ts`. These are already
+near-self-contained; the extraction is mechanical. After this PR,
+`repl-options.ts` shrinks by ~200 lines.
+
+### PR 6 — `boot/dispatch.ts` (low risk)
+
+Extract the final TUI-vs-REPL-vs-WebUI dispatch (the `if (mode ===
+'tui') { ... } else if (mode === 'webui') { ... } else { await
+runRepl(...) }` block at the tail of `main()`) into
+`boot/dispatch.ts`. Takes a `DispatchContext` and a `DispatchOpts`
+and returns the chosen host. The `main()` function ends with a single
+`await dispatch(ctx, opts)` call.
+
+### PR 7 — Final pass (low risk)
+
+`cli-main.ts` should be < 250 lines after PRs 1–6: just argv
+parsing, the `boot(argv)` call, and the `dispatch(ctx, opts)` call.
+The final pass:
+
+- Collapses the per-phase `let { ... } = ctx` destructuring into
+  direct field access where possible.
+- Updates the import block in `cli-main.ts` to re-export the public
+  types (`BootContext`, `ReplDeps`, `DispatchOpts`) for backward
+  compatibility — `index.ts` may still import from `./cli-main.js`
+  in the short term.
+- Adds a doc comment to `cli-main.ts` pointing to the seven
+  `boot/*.ts` modules so contributors know where each phase lives.
+
+## Acceptance criteria
+
+- [ ] Baseline integration test (PR 0) added and committed.
+- [ ] Each of PRs 1–6 lands with:
+  - The targeted code in a single module under
+    `packages/cli/src/boot/`.
+  - The original boot behavior preserved (exit codes, side effects,
+    and `ReplOptions` shape — verified by the integration test).
+  - `pnpm --filter @wrongstack/cli typecheck` clean.
+  - `pnpm --filter @wrongstack/cli test` passing (the
+    ~17,000-LOC test suite plus the new integration test).
+  - A 30-second manual smoke test: launch
+    `node packages/cli/dist/index.js --help`, then
+    `node packages/cli/dist/index.js tui`, then
+    `node packages/cli/dist/index.js repl`, and confirm
+    each returns the expected exit code and side-effect.
+- [ ] After PR 7: `cli-main.ts` is < 250 lines and contains only
+  argv parsing, the `boot()` call, and the `dispatch()` call.
+- [ ] The June 5 plan's "1.2: split cli/sdd.ts and cli/index.ts"
+  exit criteria (sdd was already split; index.ts → cli-main.ts is
+  the modern equivalent) are satisfied: every boot phase lives in
+  its own `boot/<name>.ts` file, with `cli-main.ts` as the
+  composition root only.
+
+## Out of scope
+
+- `cli/webui-server.ts` (3,407 lines) is the next decomposition
+  priority. File a sibling `docs/issues/2026-MM-DD-webui-server-refactor.md`
+  using the same template; do not bundle it here.
+- `webui/server/index.ts` (3,104 lines) is the same shape but in a
+  different package. File `docs/issues/2026-MM-DD-webui-package-server-refactor.md`
+  once this issue and the webui-server one are in flight.
+- The `slash-commands/fix-classifier.ts: 661` split is a separate
+  issue (smaller, more contained; the `sdd.ts` decomposition
+  template applies directly).
+- The 2026-06-13 TUI refactor is a separate track. It unblocks
+  after PR 4 of this issue lands (because new TUI-side effects then
+  edit `repl-options.ts`, not `cli-main.ts`).
+
+## Rollback strategy
+
+Each PR is its own commit on its own branch. Revert the PR → revert
+the behavior. The integration test in PR 0 is the gate; if a later
+PR's boot output differs from the prior commit by more than the test
+allows (exit codes, `ReplOptions` snapshot, side-effect order), that
+PR is held until parity is restored.
+
+For the bigger PRs (PR 4 in particular) a feature flag is overkill —
+the integration test plus the smoke test are the gates. If both
+fail-safely (the existing boot output is byte-identical to the
+pre-PR baseline), the PR merges.
+
+## Why I'm not implementing this now
+
+The previous tui-app refactor (2026-06-13 morning) made it clear
+that a 2,000+ line file in a single session is too big to hold in
+mind at once. The same is true of `cli-main.ts` — but unlike
+`app.tsx`, this file has no test harness to lean on, so the first
+PR *must* be the baseline integration test, and nothing else can
+land until that test is in place.
+
+This issue formalizes the **PR-by-PR** approach so a future
+session (or human contributor) can take it on with clear scope per
+commit. The TUI refactor is the live proof that the pattern works
+when the baseline test lands first.
+
+## Tracking
+
+When the issue is opened on GitHub, link the 7 PRs to it in
+descending order so the timeline is visible. Use the
+`refactor/cli-main-split` label (proposed).
+
+## Related
+
+- June 5 audit, item 1.2 ("Split cli/slash-commands/sdd.ts and
+  cli/index.ts") — sdd.ts was already split into `sdd/`. cli/index.ts
+  is the legacy name for the file now called `cli-main.ts`.
+- 2026-06-13 system audit, finding H-1 ("Four >2,000-line files are
+  the gating constraint") — this issue is one of three
+  decomposition plans called for by that finding.
+- 2026-06-13 tui-app refactor, PR 0 (the characterization-test
+  pattern this issue reuses).
+- 2026-06-13 system audit, finding H-2 ("`SlashCommandContext` has
+  grown into a god-object") — once PR 4 of this issue lands, the
+  god-object refactor becomes a `repl-options.ts` exercise, not a
+  `cli-main.ts` one.

--- a/docs/issues/2026-06-13-webui-package-server-refactor.md
+++ b/docs/issues/2026-06-13-webui-package-server-refactor.md
@@ -1,0 +1,322 @@
+# Split `packages/webui/src/server/index.ts` (3,128 lines) into topic dispatchers
+
+**Filed:** 2026-06-13
+**Status:** Open
+**Priority:** Medium (long-running; partial decomposition already shipped, finishing the rest is the next step)
+**Effort estimate:** 4–6 days, sequenced into 7 PRs
+**Risk:** High — the file is the WebUI's central WebSocket message dispatcher and zero end-to-end test covers its full message-type matrix today
+
+## Problem
+
+`packages/webui/src/server/index.ts` is 3,128 lines as of the
+2026-06-13 `check-file-size.mjs` run (the third of four files in the
+repo over 2,000 — `tui/app.tsx: 5,671`, `cli/webui-server.ts: 3,407`,
+and `cli/cli-main.ts: 2,424` are the others). The June 5 refactor plan (item 1.3, "Split webui layer")
+called for splitting `server/index.ts`, but unlike the other three
+giant files, this one is *already partially decomposed* — 16 sibling
+modules live under `server/`:
+
+```
+server/
+  autophase-ws-handler.ts          424 lines
+  boot.ts                           35 lines
+  collaboration-ws-handler.ts     853 lines
+  custom-context-modes.ts          166 lines
+  entry.ts                          46 lines
+  file-handlers.ts                 245 lines
+  file-picker.ts                    74 lines
+  http-server.ts                   368 lines
+  index.ts                       3,104 lines  ← this file
+  instance-registry.ts             159 lines
+  lifecycle.ts                      84 lines
+  mailbox-handlers.ts              125 lines
+  memory-handlers.ts                92 lines
+  open-browser.ts                   72 lines
+  port-utils.ts                     66 lines
+  provider-config-io.ts            106 lines
+  provider-handlers.ts             132 lines
+  provider-keys.ts                 159 lines
+  provider-store.ts                110 lines
+  setup-events.ts                  323 lines
+  token-estimator.ts               135 lines
+  types.ts                          47 lines
+  usage-cost.ts                     59 lines
+  worktree-ws-handler.ts           167 lines
+  ws-auth.ts                       211 lines
+  ws-utils.ts                       68 lines
+```
+
+What's left in `index.ts` after those extractions:
+
+- the **central `handleMessage` switch** with 3,000+ lines of `case`
+  arms covering ~50 distinct WebSocket message types (agent, brain,
+  session, worktree, autophase, mailbox, files, memory, goal, plan,
+  tasks, todos, tools, fleet, mode, config, cost, token, checkpoint,
+  …)
+- the boot/serve wiring that composes the sibling handlers
+- the `WsServerContext` type that the central switch closes over
+  (`sessionRegistry`, `agentStatusTracker`, `brain`, `wpaths`,
+  `vault`, `eventBridge`, `broadcast`, …)
+- 100+ lines of WS message-payload-type definitions (`type
+  AgentMessage = { type: 'agent.…', payload: … }`) that could move
+  to a dedicated `messages.ts` schema module
+
+With everything in a single function, every new WebSocket message
+type adds 20–100 lines to the same switch, and the closure-captured
+`WsServerContext` is referenced from 50+ places — making the
+file nearly impossible to refactor without an integration test
+harness. Today only `ws-handlers-resume.test.ts`,
+`collaboration-ws-handler.test.ts`, `worktree-ws-handler.test.ts`,
+`ws-auth.test.ts`, and `ws-utils.test.ts` cover adjacent pieces
+in isolation. Nothing exercises the central `handleMessage`
+dispatcher end-to-end.
+
+## Why this matters
+
+1. **The decomposition is already 60% done.** The 16 sibling
+   modules ship and are individually tested. The remaining 40% is
+   the central dispatcher and the boot/serve wiring. Filing this
+   issue finishes the work the codebase has clearly been doing for
+   months.
+2. **The four >2,000-line files are now sequenced.** Of those four,
+   `tui/app.tsx` has its tracked refactor
+   (`docs/issues/2026-06-13-tui-app-refactor.md`, 8 PRs);
+   `cli/cli-main.ts` has its tracked refactor
+   (`docs/issues/2026-06-13-cli-main-refactor.md`, 7 PRs);
+   `cli/webui-server.ts` has its tracked refactor
+   (`docs/issues/2026-06-13-webui-server-refactor.md`, 8 PRs).
+   This issue is the **fourth and final** of the H-1 decomposition
+   plans — closing it means every file over 2,000 lines has a
+   sequenced path to < 500 lines.
+
+## Proposed approach (sequenced, one PR per step)
+
+Same `PR-0 characterization test → extract → verify` template as the
+tui-app, cli-main, and webui-server refactors. The decomposition
+unit is a **topic dispatcher** under `packages/webui/src/server/`,
+following the same naming pattern the file already uses for its
+siblings (`*-ws-handler.ts`, `*-handlers.ts`).
+
+### PR 0 — Baseline dispatcher integration test (must come first)
+
+Add a vitest test that opens a real WebSocket connection to a
+test-spawned `httpServer`, then sends every documented
+WebSocket message type and asserts the dispatcher routes to the
+correct sibling handler (using `vi.spyOn` on the handler module's
+exported `handleMessage` function). The test should:
+
+- Spawn `httpServer` on port 0 with a stub `WsServerContext`.
+- For each message type (`agent.resume`, `brain.ask`, `session.list`,
+  `provider.add`, `mailbox.send`, `worktree.list`, `autophase.tick`,
+  `files.read`, `memory.remember`, `goal.set`, `plan.add`,
+  `tasks.advance`, `todos.toggle`, `tools.list`, `fleet.status`,
+  `mode.set`, `config.read`, `cost.compute`, `token.estimate`,
+  `checkpoint.list` — i.e. the full ~50-type matrix), open a WS
+  client and assert the sibling handler's `handleMessage` was
+  called with the expected payload.
+- Cover the unknown-message-type path (assert the error response
+  shape).
+
+This is the safety net for everything that follows. **All later PRs
+must keep this test green and re-run it manually after every
+dispatcher extraction.** No test → no extraction.
+
+The June 5 plan didn't include this step; it's the lesson from the
+tui-app refactor (2026-06-13): "Big-file refactors need
+characterization tests first, not after."
+
+### PR 1 — `server/messages.ts` (low risk)
+
+Extract the inlined `type XxxMessage = { … }` payload definitions
+(somewhere around lines 200–400, 100+ lines of types only) into
+`server/messages.ts`. Pure type move + re-export from `index.ts`.
+This is the same pattern as `tui/src/app-state.ts` from the tui-app
+refactor (the issue's "out of scope" note explicitly mentions that
+type-only extraction is a separate effort — here we do it as PR 1
+to make the dispatcher extractions easier to review).
+
+### PR 2 — `server/dispatch/agent.ts` (medium risk)
+
+Extract the `case 'agent.…':` arms (the longest topic group, ~600
+lines) into `server/dispatch/agent.ts` with a
+`createAgentDispatcher(ctx: WsServerContext)` factory that returns
+`{ handleMessage, canHandle }`. The central switch becomes:
+
+```ts
+const dispatchers = [
+  createAgentDispatcher(ctx),
+  createBrainDispatcher(ctx),
+  createSessionDispatcher(ctx),
+  // …
+];
+async function handleMessage(ws, msg) {
+  for (const d of dispatchers) {
+    if (d.canHandle(msg.type)) return d.handleMessage(ws, msg);
+  }
+  send(ws, { type: 'error', payload: { phase: 'handleMessage', message: `Unknown: ${msg.type}` } });
+}
+```
+
+This is the **core extraction**. After this PR, the dispatcher
+pattern is established and PRs 3–6 follow the same template. The
+`canHandle(msg.type)` check is a string-prefix match
+(`msg.type.startsWith('agent.')`) so the central switch doesn't
+need to enumerate message types.
+
+Risk: medium because the agent arms share closure-captured
+`WsServerContext` state (sessionRegistry, agentStatusTracker,
+eventBridge). The `createAgentDispatcher` factory must receive the
+context as a parameter; no closure captures.
+
+### PR 3 — `server/dispatch/brain.ts` (low risk)
+
+Extract the `case 'brain.…':` arms (~150 lines) following the
+PR-2 template. Brain is a small topic with only a handful of
+message types (`brain.ask`, `brain.log`, `brain.config`); the
+extraction is mechanical.
+
+### PR 4 — `server/dispatch/session.ts` (low risk)
+
+Extract the `case 'session.…':` arms (~400 lines) following the
+PR-2 template. Session is the second-largest topic; it shares
+some state with the agent topic (sessionRegistry) so the PR
+re-uses the same `WsServerContext` parameter shape.
+
+### PR 5 — `server/dispatch/{plan,tasks,todos,goal,checkpoint}.ts` (low risk)
+
+Extract the planning-adjacent topic groups into a single
+`server/dispatch/plan-suite.ts` module since they all read from the
+same `planStore` / `taskStore` / `todoStore` /
+`checkpointStore` / `goalStore` services. ~500 lines total,
+mechanical extraction.
+
+(If the planning topic groups prove unwieldy in one file, split
+this into separate `plan.ts` / `tasks.ts` / `todos.ts` /
+`goal.ts` / `checkpoint.ts` dispatchers in a follow-up PR.)
+
+### PR 6 — `server/dispatch/{config,mode,cost,token,tools,fleet,mailbox,worktree,autophase,files,memory}.ts` (low risk)
+
+Extract the remaining topic groups into a single
+`server/dispatch/misc.ts` module, since each is < 200 lines and
+the boilerplate (canHandle / handleMessage factory) dominates over
+the per-topic logic. ~1,200 lines total. (If a particular topic
+grows past 300 lines, split it into its own dispatcher file in a
+follow-up PR.)
+
+### PR 7 — Final pass (low risk)
+
+`index.ts` should be < 250 lines after PRs 2–6: the `WsServerContext`
+type, the `WsServer` class, the `handleMessage` switch loop (now
+~30 lines), the `startWsServer({ ctx, port, host })` boot body, and
+the `WsServerOptions` interface. The dispatcher barrel
+`server/dispatch/index.ts` re-exports the per-topic dispatchers.
+
+Add a doc comment to `index.ts` pointing to the dispatcher modules
+so contributors know where each message-type group lives.
+
+## Acceptance criteria
+
+- [ ] Baseline integration test (PR 0) added and committed.
+- [ ] Each of PRs 1–6 lands with:
+  - The targeted topic group in a single module under
+    `packages/webui/src/server/dispatch/`.
+  - The original `handleMessage` behavior preserved (every
+    `case` arm's side effects, response payloads, and
+    `sendResult` calls — verified by the integration test's
+    full message-type matrix).
+  - `pnpm --filter @wrongstack/webui typecheck` clean.
+  - `pnpm --filter @wrongstack/webui test` passing (the
+    ~4,200-LOC test suite across 33 test files, including
+    `collaboration-ws-handler.test.ts: 747 lines`,
+    `ws-auth.test.ts: 411 lines`, and the new dispatcher
+    integration test).
+  - A 30-second manual smoke test: launch
+    `node packages/cli/dist/index.js --webui --port 0`, open
+    the printed URL, click through every UI panel (agent,
+    brain, session, plan, tasks, todos, goal, cost, token,
+    fleet, mailbox, worktree, autophase, files, memory), and
+    confirm each panel still functions.
+- [ ] After PR 7: `index.ts` is < 250 lines and contains only
+  the `WsServerContext` type, the `WsServer` class, the
+  dispatcher barrel call, and the `startWsServer()` boot body.
+- [ ] The June 5 plan's "1.3: split webui layer" exit criteria
+  are satisfied: every WebSocket message-type group lives in
+  its own `server/dispatch/<topic>.ts` file, with `index.ts`
+  as the composition root only.
+
+## Out of scope
+
+- The 16 existing sibling modules under `server/`
+  (`autophase-ws-handler.ts`, `file-handlers.ts`,
+  `mailbox-handlers.ts`, `provider-handlers.ts`, …) are already
+  extracted and individually tested. The dispatcher layer being
+  added in this issue is a *new* layer above them, not a
+  replacement.
+- `cli/webui-server.ts` (3,407 lines) has its own tracked refactor
+  (`docs/issues/2026-06-13-webui-server-refactor.md`, 8 PRs).
+- `cli/cli-main.ts` (2,424 lines) has its own tracked refactor
+  (`docs/issues/2026-06-13-cli-main-refactor.md`, 7 PRs).
+- `tui/app.tsx` (5,671 lines) has its own tracked refactor
+  (`docs/issues/2026-06-13-tui-app-refactor.md`, 8 PRs).
+- The `collaboration-ws-handler.ts: 853 lines` file is itself
+  over the 350-line soft cap and may need a future decomposition.
+  This issue does not bundle that work; file a separate
+  `docs/issues/2026-MM-DD-collab-ws-handler-refactor.md` if/when
+  it becomes a bottleneck.
+
+## Rollback strategy
+
+Each PR is its own commit on its own branch. Revert the PR → revert
+the behavior. The integration test in PR 0 is the gate; if a later
+PR's `handleMessage` dispatch differs from the prior commit by
+more than the test allows (handler routing, response payloads, side
+effects), that PR is held until parity is restored.
+
+For the bigger PRs (PR 2 in particular) a feature flag is overkill
+— the integration test plus the existing
+`*-ws-handler.test.ts` / `ws-auth.test.ts` files are the gates. If
+both pass unchanged, the PR merges.
+
+## Why I'm not implementing this now
+
+The previous tui-app, cli-main, and webui-server refactors
+(2026-06-13) made it clear that a 2,000+ line file in a single
+session is too big to hold in mind at once. The same is true of
+`webui/src/server/index.ts` — but unlike `tui/app.tsx`, this file
+has no test harness for the central `handleMessage` switch, so
+the first PR *must* be the baseline dispatcher test, and nothing
+else can land until that test is in place.
+
+This issue formalizes the **PR-by-PR** approach so a future
+session (or human contributor) can take it on with clear scope
+per commit.
+
+## Tracking
+
+When the issue is opened on GitHub, link the 7 PRs to it in
+descending order so the timeline is visible. Use the
+`refactor/webui-package-server-split` label (proposed).
+
+## Related
+
+- June 5 audit, item 1.3 ("Split webui layer
+  `server/index.ts`, `useWebSocket.ts`, `stores/index.ts`") — this
+  issue covers `server/index.ts` only. The `useWebSocket.ts` and
+  `stores/index.ts` decompositions are separate work.
+- 2026-06-13 system audit, finding H-1 ("Four >2,000-line files
+  are the gating constraint") — **this issue is the fourth and
+  final decomposition plan** called for by that finding. After it
+  lands, H-1 is fully tracked across all four files.
+- 2026-06-13 tui-app refactor, PR 0 (the characterization-test
+  pattern this issue reuses).
+- 2026-06-13 cli-main refactor, PR 0 (same pattern, adapted for a
+  `main()` composition root).
+- 2026-06-13 webui-server refactor, PR 0 (same pattern, adapted
+  for a CLI entry that owns the standalone WebUI HTTP/WS server
+  boot path).
+- 2026-06-13 webui-server refactor, "Out of scope" note (the
+  sibling `webui/src/server/index.ts` issue is the file this
+  issue is filed for).
+- The 16 existing sibling modules under `server/` — see the
+  `Problem` section above for the full list. This issue adds a
+  *new* dispatcher layer above them; it does not replace them.

--- a/docs/issues/2026-06-13-webui-server-refactor.md
+++ b/docs/issues/2026-06-13-webui-server-refactor.md
@@ -1,0 +1,304 @@
+# Split `packages/cli/src/webui-server.ts` (3,407 lines) into focused modules
+
+**Filed:** 2026-06-13
+**Status:** Open
+**Priority:** Medium (long-running, blocked on the integration test for `--webui` mode)
+**Effort estimate:** 5–7 days, sequenced into 8 PRs
+**Risk:** High — the file owns the standalone WebUI HTTP/WS server boot path and zero end-to-end test covers its CLI entry shape today
+
+## Problem
+
+`packages/cli/src/webui-server.ts` is 3,407 lines (the second-largest
+of four files in the repo over 2,000 — `tui/app.tsx: 5,671`,
+`webui/server/index.ts: 3,104`, and `cli/cli-main.ts: 2,424` are the
+others). The June 5 refactor plan (item 1.2) called for splitting
+the equivalent legacy file (`cli/index.ts`) but no PRs have landed
+yet. The single default-exported function in this file (`start()` at
+line ~800) now contains:
+
+- a custom `Logger` shim that wraps structured logs into a
+  non-`@wrongstack/core` shape (lines 80–111)
+- a parallel set of token / cost helpers (`estimateContextBreakdown`,
+  `getCostRates`, `computeCost`, `maskedKey`, ~200 lines) that have
+  already been partially extracted to `@wrongstack/webui/server` per
+  the file's own header comment at line 40–45, with explicit
+  acknowledgement that "Phase 2 of the refactor plan continues this
+  pattern for the rest of the file"
+- ~25 inline WebSocket message handlers (`handleProviderAdd`,
+  `handleProviderKeyAdd`, `handleSessionList`, …) covering
+  provider CRUD, session enumeration, mailbox ops, and worktree ops
+- the `dist` discovery + static-serve wiring that reuses
+  `@wrongstack/webui/server` primitives but re-implements enough
+  pieces to be its own subsystem
+- a `createRequire('webui/server')` polyglot that bridges ESM and
+  CJS-resolution for the React bundle
+- its own provider-config IO (`loadSavedProviders`, `saveProviders`,
+  `writeKeysBack`, `normalizeKeys`) that duplicates
+  `provider-config-io.ts` from the webui package
+
+With everything in a single file, the 2,400+ lines of WebSocket
+handler bodies share closure-captured mutable state (`providers`,
+`sessionRegistry`, `agentStatusTracker`, `vault`, `wpaths`,
+`eventBridge`) and have no test harness — only
+`webui-server-fleet.test.ts`, `webui-server-frontend.test.ts`,
+`webui-server-mailbox.test.ts`, `webui-server-projects.test.ts`,
+`webui-server-redaction.test.ts` cover specific handler call paths
+in isolation. Nothing exercises the end-to-end `start()` boot shape.
+
+## Why this matters
+
+1. **The decomposition is already half-done.** The token-estimator
+   was extracted to `@wrongstack/webui/server` (the `estimateTokens`
+   / `messageTokens` / `messagePreview` / `stringifyContent` import
+   at line 46–51). The file's own header calls out "Phase 2 of the
+   refactor plan continues this pattern for the rest of the file."
+   The work is acknowledged in source but unsequenced in issues.
+   That's worse than not starting — contributors can pick the
+   obviously-easy extractions (the inlined `estimateContextBreakdown`
+   at line 126, the `getCostRates` at line 173, the masking helpers
+   at line 200–300) without knowing which other block is the right
+   one to attack next.
+2. **The `cli-main.ts` and `webui-server/index.ts` issues are
+   siblings.** Of the four >2,000-line files, only `tui/app.tsx` has
+   a tracked refactor plan today (the tui-app-refactor issue, 8 PRs);
+   this issue and the webui-server/index.ts issue are the remaining
+   two-thirds of H-1. Filing them with sequenced PRs closes the
+   loop on the system audit's H-1 finding.
+
+## Proposed approach (sequenced, one PR per step)
+
+Same `PR-0 characterization test → extract → verify` template as the
+tui-app and cli-main refactors. `webui-server.ts` is a CLI entry that
+delegates to a server module, so the extraction unit is a **server
+sub-module** under `packages/cli/src/webui-server/` (matching the
+naming convention the file already implies).
+
+### PR 0 — Baseline boot-shape integration test (must come first)
+
+Add a vitest test that invokes `start({ port: 0, host: '127.0.0.1' })`
+with a stub `ProviderConfig`, a stub `vault`, and a stub
+`SessionRegistry`. The test should:
+
+- Call `start()` with `process.env['WSTACK_WEBUI_INSPECT'] = '1'`
+  and assert it returns a JSON-serializable handle describing the
+  bound port, the WebSocket upgrade path, and the registered
+  handler names.
+- Call `start()` with a stub `WebSocket` that sends each
+  `provider.add` / `provider.key.add` / `session.list` message and
+  assert the stub `sendResult` is called with the expected payload.
+- Snapshot the public API surface (`start`, `isLoopbackBind`,
+  `tokenMatches`) that other modules import — call it with the same
+  inspect flag and assert no signature changes.
+
+This is the safety net for everything that follows. **All later PRs
+must keep this test green and re-run it manually after every phase
+extraction.** No test → no extraction.
+
+The June 5 plan didn't include this step; it's the lesson from the
+tui-app refactor (2026-06-13): "Big-file refactors need
+characterization tests first, not after."
+
+### PR 1 — `webui-server/logger-shim.ts` (low risk)
+
+Extract the inlined `Logger` shim (lines 80–111) into
+`packages/cli/src/webui-server/logger-shim.ts`. Pure move +
+named-export; no behavior change. The shim is a stand-in for the
+real `Logger` while this CLI module is consumed by other CLI
+modules that don't import the full `@wrongstack/core` tree. Make
+that comment explicit in the new file.
+
+### PR 2 — `webui-server/cost-helpers.ts` (low risk)
+
+Extract `getCostRates`, `computeCost`, `maskedKey` (the inlined
+"Cost computation helpers" block at lines 157–300) into
+`webui-server/cost-helpers.ts`. These are pure functions over the
+`CostRates` / `TokenUsage` interfaces — they are testable in
+isolation and have no shared closure state. This PR pairs with the
+file's own header note: "Phase 2 of the refactor plan continues
+this pattern for the rest of the file."
+
+### PR 3 — `webui-server/context-breakdown.ts` (low risk)
+
+Extract `estimateContextBreakdown` (lines 126–155) into
+`webui-server/context-breakdown.ts`. The function consumes
+`estimateTokens` / `messageTokens` / `messagePreview` from
+`@wrongstack/webui/server` and stitches them into a single report.
+After this PR, only the report-shape concerns live here; the
+underlying token math lives in `@wrongstack/webui/server`. The two
+implementations are no longer "drifting apart" — they're
+correctly layered.
+
+### PR 4 — `webui-server/provider-config.ts` (low risk)
+
+Extract `loadSavedProviders`, `saveProviders`, `writeKeysBack`,
+`normalizeKeys` (the provider-config IO block at lines ~2,400–2,800)
+into `webui-server/provider-config.ts`. The file already imports
+`provider-config-io.ts` from the webui package for some
+operations; the new module wraps both the inlined and the imported
+helpers behind a single `ProviderConfigStore` interface so callers
+stop caring which is which.
+
+Risk: medium because `provider-keys.ts` from the webui package
+already exists. The two implementations may silently diverge if
+not careful. The new module should *re-export* the webui-package
+implementation where they overlap and *only* contain genuinely
+CLI-specific extras (`writeKeysBack`'s `addKey` semantics,
+`normalizeKeys`'s migration logic).
+
+### PR 5 — `webui-server/ws-handlers/` directory (medium risk) 🔥
+
+This is the **core extraction**. The 25+ inline `handleXxx` WebSocket
+handlers (lines ~2,800–3,300) move into
+`packages/cli/src/webui-server/ws-handlers/<topic>.ts`, grouped by
+topic:
+
+```
+webui-server/ws-handlers/
+  providers.ts      — handleProviderAdd, handleProviderKeyAdd, … (~400 lines)
+  sessions.ts       — handleSessionList, handleSessionGet, …      (~300 lines)
+  mailbox.ts        — handleMailboxSend, handleMailboxRead, …      (~200 lines)
+  worktree.ts       — handleWorktreeList, handleWorktreeCreate, …  (~200 lines)
+  memory.ts         — handleMemoryList, handleMemoryRemember, …    (~200 lines)
+  index.ts          — barrel: `registerAllHandlers(wsServer, ctx)` (~50 lines)
+```
+
+After this PR, `webui-server.ts` is a composition root: it boots the
+HTTP server, the WebSocket server, and calls
+`registerAllHandlers(wsServer, { providers, sessionRegistry, … })`.
+Adding a new WS message type becomes "edit one file in
+`ws-handlers/`", not "scroll to the right line in a 3,400-line
+file."
+
+Risk: high because the handlers share closure-captured state
+(`providers`, `vault`, `wpaths`, `eventBridge`, `broadcast`). The
+`registerAllHandlers` factory must receive all shared state as a
+`WsHandlerContext` parameter; no closure captures.
+
+### PR 6 — `webui-server/static-serve.ts` (low risk)
+
+Extract the `dist` discovery + SPA fallback + content-type mapping
+into `webui-server/static-serve.ts`. The file already consumes
+`createHttpServer` from `@wrongstack/webui/server` for the
+path-traversal guard and CSP logic; the new module layers CLI-
+specific concerns on top (custom `distDir` resolution, the
+`createRequire('webui/server')` polyglot, the React-bundle
+hash-busting).
+
+### PR 7 — `webui-server/lifecycle.ts` (low risk)
+
+Extract the SIGINT/SIGTERM shutdown handling, the `instance-
+registry` register/unregister, and the `openBrowser` orchestration
+into `webui-server/lifecycle.ts`. After this PR, `webui-server.ts`
+contains only the top-level `start()` body: ~150 lines that read as
+"boot static serve → boot ws server → register handlers → wait for
+shutdown signal."
+
+### PR 8 — Final pass (low risk)
+
+`webui-server.ts` should be < 200 lines after PRs 1–7: just the
+`start()` function, its re-exports of the public API, and a doc
+comment pointing to the seven `webui-server/*.ts` modules so
+contributors know where each concern lives. The `Logger` re-export
+keeps its public surface; the cost/token helpers and the WS
+handlers stop being importable directly from this file.
+
+## Acceptance criteria
+
+- [ ] Baseline integration test (PR 0) added and committed.
+- [ ] Each of PRs 1–7 lands with:
+  - The targeted code in a single module under
+    `packages/cli/src/webui-server/` (or its `ws-handlers/`
+    subdirectory).
+  - The original WS server behavior preserved (message types,
+    handler dispatch, side effects — verified by the integration
+    test).
+  - `pnpm --filter @wrongstack/cli typecheck` clean.
+  - `pnpm --filter @wrongstack/cli test` passing (the
+    ~17,000-LOC CLI test suite plus the 5 existing
+    `webui-server-*.test.ts` files plus the new integration test).
+  - A 30-second manual smoke test: launch
+    `node packages/cli/dist/index.js --webui --port 0`, open the
+    printed `http://127.0.0.1:<port>/` URL, send one provider-add
+    WS message via the browser devtools, and confirm the WebUI
+    renders the new provider.
+- [ ] After PR 8: `webui-server.ts` is < 200 lines and contains
+  only the `start()` function and the public API re-exports.
+- [ ] The June 5 plan's "1.2: split cli/index.ts" exit criteria
+  are satisfied: every WebUI server concern lives in its own
+  `webui-server/<name>.ts` file, with `webui-server.ts` as the
+  composition root only.
+
+## Out of scope
+
+- `webui/src/server/index.ts` (3,104 lines) is the sibling
+  decomposition. File `docs/issues/2026-MM-DD-webui-package-server-refactor.md`
+  using the same template; do not bundle it here. Note: the
+  sibling has *already* been partially decomposed into 16
+  `*-handlers.ts` / `*-ws-handler.ts` modules, so its extraction
+  pattern is different (extract the remaining composition blocks,
+  not the entire file).
+- `cli/cli-main.ts` (2,424 lines) has its own tracked refactor
+  (`docs/issues/2026-06-13-cli-main-refactor.md`, 7 PRs).
+- `tui/app.tsx` (5,671 lines) has its own tracked refactor
+  (`docs/issues/2026-06-13-tui-app-refactor.md`, 8 PRs).
+- The cost/token-helper *drift* between this file and
+  `@wrongstack/webui/server/usage-cost.ts` is a separate audit;
+  once this issue closes, the two implementations should be
+  identical.
+
+## Rollback strategy
+
+Each PR is its own commit on its own branch. Revert the PR → revert
+the behavior. The integration test in PR 0 is the gate; if a later
+PR's WS message handling differs from the prior commit by more than
+the test allows (handler dispatch table, response payloads, side
+effects), that PR is held until parity is restored.
+
+For the bigger PRs (PR 5 in particular) a feature flag is overkill
+— the integration test plus the existing
+`webui-server-*.test.ts` files are the gates. If both pass
+unchanged, the PR merges.
+
+## Why I'm not implementing this now
+
+The previous tui-app refactor (2026-06-13 morning) made it clear
+that a 2,000+ line file in a single session is too big to hold in
+mind at once. The same is true of `webui-server.ts` — and unlike
+`tui/app.tsx`, this file has no test harness for the `start()` boot
+path, so the first PR *must* be the baseline integration test, and
+nothing else can land until that test is in place.
+
+The file's own header at line 40–45 acknowledges the
+decomposition is in progress ("Phase 2 of the refactor plan
+continues this pattern for the rest of the file") but stops short
+of sequencing the steps. This issue formalizes the **PR-by-PR**
+approach so a future session (or human contributor) can take it on
+with clear scope per commit.
+
+## Tracking
+
+When the issue is opened on GitHub, link the 8 PRs to it in
+descending order so the timeline is visible. Use the
+`refactor/webui-server-split` label (proposed).
+
+## Related
+
+- June 5 audit, item 1.2 ("Split cli/index.ts and sdd.ts") —
+  sdd.ts was already split; cli/index.ts is the legacy name for
+  `cli-main.ts`. `webui-server.ts` is a third file that the June 5
+  audit implicitly bundled with `cli/index.ts` but is actually
+  a distinct subsystem.
+- 2026-06-13 system audit, finding H-1 ("Four >2,000-line files
+  are the gating constraint") — this issue is two of the three
+  decomposition plans called for by that finding.
+- 2026-06-13 tui-app refactor, PR 0 (the characterization-test
+  pattern this issue reuses).
+- 2026-06-13 cli-main refactor, PR 0 (same pattern, adapted for a
+  `main()` composition root instead of an HTTP+WS server).
+- 2026-06-13 webui-package-server refactor, PR 0 (sibling issue
+  for `webui/src/server/index.ts`; the same H-1 finding, the
+  remaining third of the four).
+- `docs/notes/bugs.md` finding C-2 ("WebSocket Auth Token
+  Exposed in URL Query String") — the cookie-based WS auth
+  delivery described in this issue's `Related` section
+  references the WS upgrade path that this file owns.


### PR DESCRIPTION
Three untracked docs/issues/ files that have been sitting in the working tree since 2026-06-13. They are the three remaining decomposition plans called for by the system audit finding H-1 (four >2,000-line files). Each follows the same shape as the tui/app.tsx split plan (Problem, Sequenced PRs, Acceptance criteria, Out-of-scope, Related). No code change. Future sessions can pick up any of them and follow the same baseline-test-first pattern.