### PR TITLE
feat(webui): add subscribeEternalIteration hook to startWebUI (PR 4 of Phase 2)

### DIFF
--- a/packages/webui/src/server/eternal-iteration-broadcast.ts
+++ b/packages/webui/src/server/eternal-iteration-broadcast.ts
@@ -1,0 +1,53 @@
+// Eternal-autonomy iteration broadcast wiring.
+//
+// The CLI's `runWebUI` owns the eternal-autonomy engine and exposes a
+// `subscribeEternalIteration` callback that lets the webui hook into
+// the journal-entry stream. This module extracts the wiring in
+// isolation so it can be unit-tested without spinning up the full
+// server (clients, WS, HTTP bring-up).
+//
+// `createEternalSubscription` is the helper that:
+//   1. Calls the caller-supplied `subscribe` function with a broadcast
+//      closure bound to the current `clients` Map.
+//   2. Captures the returned disposer so `tearDown` can invoke it on
+//      server shutdown.
+//
+// Both the disposer and the `JournalEntry` are projected by the caller
+// — this module intentionally knows nothing about the engine itself.
+
+import type { WebSocket } from 'ws';
+import type { ConnectedClient, WSServerMessage } from './types.js';
+import type { JournalEntry } from '@wrongstack/core';
+
+export type EternalSubscribe = (
+  fn: (entry: JournalEntry) => void,
+) => () => void;
+
+export type EternalBroadcast = (clients: Map<WebSocket, ConnectedClient>, msg: WSServerMessage) => void;
+
+export interface EternalSubscription {
+  /** Tear down the underlying engine subscription. Idempotent. */
+  dispose: () => void;
+}
+
+export function createEternalSubscription(
+  subscribe: EternalSubscribe,
+  broadcast: EternalBroadcast,
+  clientsRef: () => Map<WebSocket, ConnectedClient>,
+): EternalSubscription {
+  let disposed = false;
+  const dispose = subscribe((entry) => {
+    if (disposed) return;
+    broadcast(clientsRef(), {
+      type: 'eternal.iteration',
+      payload: { entry },
+    });
+  });
+  return {
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      dispose();
+    },
+  };
+}

--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -85,6 +85,7 @@ import { createCustomModeStore } from './custom-context-modes.js';
 import { maskedKey, normalizeKeys } from './provider-keys.js';
 import { send, broadcast, sendResult, errMessage, generateAuthToken } from './ws-utils.js';
 import { estimateContextBreakdown } from './token-estimator.js';
+import { createEternalSubscription } from './eternal-iteration-broadcast.js';
 // Re-export types — shared message shapes and options used by both the
 // standalone server and the CLI's `--webui` embedded mode.
 export type { WebUIOptions, BackendServices } from './types.js';
@@ -121,6 +122,12 @@ export {
 } from './instance-registry.js';
 
 // WebSocket utilities shared with CLI
+export {
+  createEternalSubscription,
+  type EternalSubscribe,
+  type EternalBroadcast,
+  type EternalSubscription,
+} from './eternal-iteration-broadcast.js';
 export {
   send,
   broadcast,
@@ -1104,6 +1111,21 @@ export async function startWebUI(
       payload: { cwd: newDir, projectRoot },
     });
   });
+
+  // ── Eternal-autonomy iteration broadcast (PR 4 of Phase 2) ─────────
+  // When the CLI passes `opts.subscribeEternalIteration`, hook the
+  // returned observer into a WS broadcast so every connected client
+  // gets a live stream of `JournalEntry` items as the engine ticks.
+  // The disposer is captured and invoked on shutdown() so the CLI's
+  // engine subscription is properly torn down with the webui.
+  let eternalSubscription: { dispose: () => void } | null = null;
+  if (opts.subscribeEternalIteration) {
+    eternalSubscription = createEternalSubscription(
+      opts.subscribeEternalIteration,
+      broadcast,
+      () => clients,
+    );
+  }
 
   // Per-connection message rate limiting: 60 messages per 60-second window.
   // Exceeding clients are temporarily blocked to prevent flooding.
@@ -3121,6 +3143,10 @@ export async function startWebUI(
     // reality. Crash exits are healed by the next register()/list() prune pass.
     onShutdown: () => {
       brainMonitor.stop();
+      if (eternalSubscription) {
+        eternalSubscription.dispose();
+        eternalSubscription = null;
+      }
       return unregisterInstance(process.pid, registryBaseDir);
     },
   });

--- a/packages/webui/src/server/types.ts
+++ b/packages/webui/src/server/types.ts
@@ -6,6 +6,7 @@ import type {
   Agent,
   ConfigStore,
   EventBus,
+  JournalEntry,
   ModelsRegistry,
   SecretVault,
   SessionStore,
@@ -50,6 +51,22 @@ export interface WebUIOptions {
    * `node dist/index.js webui` flow fully back-compatible.
    */
   services?: BackendServices | undefined;
+  /**
+   * Subscribe to live per-iteration events from the eternal-autonomy
+   * engine. When provided, `startWebUI` wires a WS broadcast that
+   * pushes each `JournalEntry` to every connected client. Observability
+   * only — starting the loop still goes through REPL/TUI or `--eternal`,
+   * since the webui has no slash-command dispatch surface yet.
+   *
+   * The argument is a *function* the caller supplies that performs the
+   * actual subscription; the returned disposer is invoked on
+   * `shutdown()`. This indirection lets the caller (most commonly
+   * `cli/webui-server.ts`) own the engine lifecycle and merely hand the
+   * webui an observer slot.
+   */
+  subscribeEternalIteration?:
+    | ((fn: (entry: JournalEntry) => void) => () => void)
+    | undefined;
 }
 
 export interface BackendServices {

--- a/packages/webui/tests/server/eternal-iteration-broadcast.test.ts
+++ b/packages/webui/tests/server/eternal-iteration-broadcast.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEternalSubscription, type EternalBroadcast, type EternalSubscribe } from '../../src/server/eternal-iteration-broadcast.js';
+
+/**
+ * PR 4 of Phase 2: extract the eternal-iteration observer wiring into
+ * a unit-testable helper. The CLI's `runWebUI` owns the engine and
+ * hands the webui a `subscribeEternalIteration` function. This helper
+ * adapts that to a WS broadcast and yields a disposable subscription
+ * that the server calls on shutdown.
+ */
+
+function makeFixture() {
+  const clients = new Map();
+  const clientsRef = () => clients;
+  const broadcast: EternalBroadcast = vi.fn((c, msg) => {
+    // Pretend each entry in the map is a WebSocket — we don't need a
+    // real one; the test only cares that broadcast is called with the
+    // right clients and message shape.
+    for (const key of c.keys()) void key;
+    void msg;
+  });
+  let observer: ((entry: unknown) => void) | null = null;
+  const subscribe: EternalSubscribe = vi.fn((fn) => {
+    observer = fn as (entry: unknown) => void;
+    return () => {
+      observer = null;
+    };
+  });
+  return { subscribe, broadcast, clientsRef, getObserver: () => observer };
+}
+
+describe('createEternalSubscription', () => {
+  it('calls subscribe with a broadcast-shaped observer', () => {
+    const f = makeFixture();
+    createEternalSubscription(f.subscribe, f.broadcast, f.clientsRef);
+    expect(f.subscribe).toHaveBeenCalledTimes(1);
+    expect(f.getObserver()).toBeTypeOf('function');
+  });
+
+  it('observer broadcasts a single eternal.iteration message per entry', () => {
+    const f = makeFixture();
+    createEternalSubscription(f.subscribe, f.broadcast, f.clientsRef);
+    const observer = f.getObserver();
+    expect(observer).not.toBeNull();
+    const entry = { kind: 'autonomy.step', id: 'a1', payload: { ok: true } };
+    observer!(entry);
+    expect(f.broadcast).toHaveBeenCalledTimes(1);
+    expect(f.broadcast).toHaveBeenCalledWith(
+      f.clientsRef(),
+      { type: 'eternal.iteration', payload: { entry } },
+    );
+  });
+
+  it('dispose() tears down the underlying subscription (no more broadcasts)', () => {
+    const f = makeFixture();
+    const sub = createEternalSubscription(f.subscribe, f.broadcast, f.clientsRef);
+    const observer = f.getObserver();
+    expect(observer).not.toBeNull();
+    observer!({ kind: 'before-dispose' });
+    sub.dispose();
+    // After dispose, the captured observer in the fixture is null —
+    // the helper no longer has a live observer to call into.
+    expect(f.getObserver()).toBeNull();
+    // The helper also drops future broadcast attempts defensively.
+    // (We can't reach the disposed observer any more, so this just
+    // verifies that the underlying subscribe's disposer ran once.)
+  });
+
+  it('dispose() is idempotent (safe to call twice)', () => {
+    const f = makeFixture();
+    const sub = createEternalSubscription(f.subscribe, f.broadcast, f.clientsRef);
+    sub.dispose();
+    expect(() => sub.dispose()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Continuation of #22 and #32.

The CLI's `runWebUI` already declares a `subscribeEternalIteration`
field on its local `WebUIOptions` shape, but the canonical standalone
`WebUIOptions` does not — so the engine hook was never reusable
from outside the CLI. This PR mirrors the field on the standalone type
and wires it through `startWebUI`.

The wiring is extracted into its own module
(`eternal-iteration-broadcast.ts`) so it can be unit-tested without
spinning up the WS / HTTP / boot stack. The helper:
  - calls the caller-supplied `subscribe` with a broadcast-shaped
    observer,
  - captures the returned disposer,
  - drops the observer on `dispose()` (idempotent).

`startWebUI` invokes the helper at port-bind time and registers the
disposer on the same `onShutdown` path as `brainMonitor.stop()`.
When the field is omitted the helper is a no-op, so the standalone
`node dist/index.js webui` flow stays fully back-compatible.

Test coverage: 4 new unit tests in
`packages/webui/tests/server/eternal-iteration-broadcast.test.ts`
covering subscribe invocation, observer broadcast shape, dispose
teardown, and idempotent dispose. webui 323/323, cli typecheck clean.

Refs: #22, #32, Phase 2 (runWebUI → startWebUI delegation).
