### PR TITLE
refactor(webui): prefer BackendServices.configStore and .vault in startWebUI (PR 5a of Phase 2)

### DIFF
--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -257,7 +257,14 @@ export async function startWebUI(
 
   // Boot configuration
   const boot = await bootConfig();
-  const { config: baseConfig, vault, globalConfigPath, wpaths, logger } = boot;
+  const { config: baseConfig, globalConfigPath, wpaths, logger } = boot;
+  // PR 5 of Phase 2: when the caller (typically the CLI) supplies a
+  // pre-built `BackendServices`, prefer its `vault` over the one the
+  // default boot would construct. This lets `runWebUI` keep owning the
+  // vault lifecycle (so it can decrypt/encrypt its own config writes
+  // in lockstep with the rest of the CLI session) instead of having
+  // the webui build a parallel vault it can never see.
+  const vault = opts.services?.vault ?? boot.vault;
   let config = baseConfig;
 
   /** Mutable project root — updated on `projects.select`. File handlers,
@@ -306,7 +313,15 @@ export async function startWebUI(
 
   // Container via shared factory
   const container = createDefaultContainer({ config, wpaths, logger, modelsRegistry });
-  const configStore = container.resolve(TOKENS.ConfigStore);
+  // PR 5 of Phase 2: when the caller (typically the CLI) supplies a
+  // pre-built `BackendServices`, prefer its `configStore` over the one
+  // the default container would resolve. This is the read+write
+  // counterpart of the `vault` injection above: together they let
+  // `runWebUI` own the global config lifecycle and have the webui
+  // operate on the *same* in-memory store, so a `provider.switch`
+  // from the webui is visible to the CLI's next call without a disk
+  // round-trip in between.
+  const configStore = opts.services?.configStore ?? container.resolve(TOKENS.ConfigStore);
 
   // Provider registry
   const providerRegistry = new ProviderRegistry();


### PR DESCRIPTION
Continuation of #22, #32, #34. The `BackendServices` interface
already declared `configStore` and `vault` as required fields, but
`startWebUI` was constructing both locally and ignoring any caller-
supplied values. This PR wires the two fields through at the two
natural consumption points:

- `vault` (`index.ts` line ~263): prefer `opts.services?.vault`,
  fall back to the value `bootConfig()` already produced.
- `configStore` (line ~318): prefer `opts.services?.configStore`,
  fall back to `container.resolve(TOKENS.ConfigStore)`.

Both branches are no-ops when `opts.services` is omitted, so the
standalone `node dist/index.js webui` flow stays fully back-
compatible (webui 323/323 + cli typecheck clean). The CLI's
`runWebUI` does not yet construct a `BackendServices` to pass
through, so this commit is the type-level + runtime-side wiring
only — a follow-up PR (PR 5b) will rewrite `runWebUI` as a thin
shim that calls `startWebUI({ services })` and removes the
duplicated 3,000 lines of CLI webui-server.ts.

Single-file diff: +17/-2.

Refs: Phase 2 (runWebUI → startWebUI delegation).
