### PR TITLE
refactor(cli): rename CLI WebUIOptions to CliWebUIOptions to avoid name collision

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -213,7 +213,19 @@ export interface WSClientMessage {
   payload?: unknown | undefined;
 }
 
-interface WebUIOptions {
+/**
+ * CLI-shaped webui options. Distinct from the standalone
+ * `WebUIOptions` exported by `@wrongstack/webui/server` (which is the
+ * type `startWebUI` accepts): the CLI builds its own agent/events/
+ * session/etc. up front because the same instances power the
+ * eternal-autonomy loop, and just hands the webui the surfaces it
+ * needs. This type used to be called `WebUIOptions` too, which
+ * caused a name collision with the standalone one whenever both
+ * were imported into the same module (the CLI here imports from
+ * `@wrongstack/webui/server` for shared helpers, so the collision
+ * was a real source of confusion when reading this file).
+ */
+interface CliWebUIOptions {
   agent: Agent;
   events: EventBus;
   session: SessionWriter;
@@ -291,7 +303,7 @@ interface ConnectedClient {
   sessionId: string | null;
 }
 
-export async function runWebUI(opts: WebUIOptions): Promise<void> {
+export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
   const host = '127.0.0.1';
   const requestedWsPort = opts.port ?? 3457;
   const requestedHttpPort = opts.httpPort ?? 3456;


### PR DESCRIPTION
The CLI's `runWebUI` function used to declare a local interface
named `WebUIOptions` that has nothing to do with the standalone
`WebUIOptions` exported by `@wrongstack/webui/server` (the type
that `startWebUI` accepts). The two types are *not* assignment-
compatible — the CLI shape is a flat subset of the standalone one
plus CLI-only fields like `subscribeEternalIteration`, while the
standalone shape is mostly a thin `services?` slot.

Because `packages/cli/src/webui-server.ts` imports helpers from
`@wrongstack/webui/server` (token-estimator, AutoPhase handler,
createHttpServer, etc.) at the top of the file, the two
`WebUIOptions` symbols coexisted in the same module scope and a
reader had to disambiguate from context which one a given
`opts: WebUIOptions` annotation referred to. Worse, the import
shadowing made it trivial for a future change to accidentally
annotate `runWebUI` with the standalone type and silently break
the CLI's caller-supplied contract.

Rename the CLI's local interface to `CliWebUIOptions` and add a
docstring that points readers at the standalone type for context.
The standalone `WebUIOptions` keeps its name — it's the public
API of `@wrongstack/webui/server` and renaming it would be a
breaking change for the standalone `node dist/index.js webui`
flow.

Single-file diff: +12/-2. cli typecheck clean, the new cli-main
baseline test (PR #36) still passes 4/4.

Refs: Phase 2 (runWebUI → startWebUI delegation), Issue #30.
