### PR TITLE
refactor(webui+cli): cli: wire eternal-iteration broadcast through createEternalSubscription

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -59,6 +59,7 @@ import {
   AutoPhaseWebSocketHandler,
   type CustomModeStore,
   createCustomModeStore,
+  createEternalSubscription,
   createHttpServer,
   findFreePort,
   handleFilesList,
@@ -1022,26 +1023,20 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     // eternal-autonomy iteration events. Each iteration the engine
     // completes lands here and is fanned out to every connected client
     // so the frontend can render a live timeline of the autonomous loop.
-    // The unsubscribe is collected into eventUnsubscribers so a reconnect
-    // or shutdown tears it down cleanly with the rest of the subscriptions.
+    // Wired through `createEternalSubscription` (shared with `@wrongstack/webui/server`'s
+    // standalone `startWebUI`) so the `eternal.iteration` payload shape stays
+    // in lockstep across the two entry points — earlier revisions spelled out
+    // every field by hand here, which drifted from the standalone shape
+    // (`{ entry: JournalEntry }`) and forced the frontend to keep two
+    // deserializers. The whole `JournalEntry` (including the CLI-only
+    // `costUsd` delta) now rides in the `entry` field.
     if (opts.subscribeEternalIteration) {
-      eventUnsubscribers.push(
-        opts.subscribeEternalIteration((entry) => {
-          broadcast({
-            type: 'eternal.iteration',
-            payload: {
-              iteration: entry.iteration,
-              at: entry.at,
-              source: entry.source,
-              task: entry.task,
-              status: entry.status,
-              note: entry.note,
-              tokens: entry.tokens,
-              costUsd: entry.costUsd,
-            },
-          });
-        }),
+      const subscription = createEternalSubscription(
+        opts.subscribeEternalIteration,
+        (_liveClients, msg) => broadcast(msg),
+        () => clients,
       );
+      eventUnsubscribers.push(() => subscription.dispose());
     }
 
     // ── Mailbox events — broadcast to WebUI for real-time per-project visibility ──

--- a/packages/webui/src/server/eternal-iteration-broadcast.ts
+++ b/packages/webui/src/server/eternal-iteration-broadcast.ts
@@ -16,24 +16,31 @@
 // — this module intentionally knows nothing about the engine itself.
 
 import type { WebSocket } from 'ws';
-import type { ConnectedClient, WSServerMessage } from './types.js';
+import type { WSServerMessage } from './types.js';
 import type { JournalEntry } from '@wrongstack/core';
 
 export type EternalSubscribe = (
   fn: (entry: JournalEntry) => void,
 ) => () => void;
 
-export type EternalBroadcast = (clients: Map<WebSocket, ConnectedClient>, msg: WSServerMessage) => void;
+// `clients` is generic so callers that use a structurally-similar
+// `ConnectedClient` (the CLI's own Map<WebSocket, { ws; sessionId }>,
+// for example) don't have to alias their type to webui's
+// `ConnectedClient`. The helper doesn't read the value at all —
+// `broadcast` gets to decide whether to use the map or not — so we
+// only need the key type (WebSocket) to be present, which is
+// enforced by the constraint.
+export type EternalBroadcast<C> = (clients: Map<WebSocket, C>, msg: WSServerMessage) => void;
 
 export interface EternalSubscription {
   /** Tear down the underlying engine subscription. Idempotent. */
   dispose: () => void;
 }
 
-export function createEternalSubscription(
+export function createEternalSubscription<C>(
   subscribe: EternalSubscribe,
-  broadcast: EternalBroadcast,
-  clientsRef: () => Map<WebSocket, ConnectedClient>,
+  broadcast: EternalBroadcast<C>,
+  clientsRef: () => Map<WebSocket, C>,
 ): EternalSubscription {
   let disposed = false;
   const dispose = subscribe((entry) => {

--- a/packages/webui/tests/server/eternal-iteration-broadcast.test.ts
+++ b/packages/webui/tests/server/eternal-iteration-broadcast.test.ts
@@ -12,7 +12,7 @@ import { createEternalSubscription, type EternalBroadcast, type EternalSubscribe
 function makeFixture() {
   const clients = new Map();
   const clientsRef = () => clients;
-  const broadcast: EternalBroadcast = vi.fn((c, msg) => {
+  const broadcast: EternalBroadcast<unknown> = vi.fn((c, msg) => {
     // Pretend each entry in the map is a WebSocket — we don't need a
     // real one; the test only cares that broadcast is called with the
     // right clients and message shape.
@@ -71,5 +71,31 @@ describe('createEternalSubscription', () => {
     const sub = createEternalSubscription(f.subscribe, f.broadcast, f.clientsRef);
     sub.dispose();
     expect(() => sub.dispose()).not.toThrow();
+  });
+
+  it('broadcast callback can ignore the clients map (CLI pattern)', () => {
+    // The CLI's `runWebUI` has its own `broadcast(msg: WSServerMessage)`
+    // that doesn't take a clients map — it closes over the local one
+    // already. With `EternalBroadcast<C>` now generic, the CLI can
+    // pass a structurally different `Map<WebSocket, CliConnectedClient>`
+    // (its own { ws, sessionId } shape) and a callback that drops the
+    // first arg, as long as the map keys are WebSockets. This test
+    // pins that pattern so the generic stays `Map<WebSocket, C>` and
+    // doesn't accidentally get tightened back to `ConnectedClient`.
+    interface CliConnectedClient { ws: unknown; sessionId: string | null }
+    const cliClients = new Map<unknown, CliConnectedClient>();
+    const cliClientsRef = () => cliClients;
+    const sentTo: unknown[] = [];
+    const cliBroadcast: EternalBroadcast<CliConnectedClient> = (_c, msg) => {
+      sentTo.push(msg);
+    };
+    const sub = createEternalSubscription(
+      (fn) => { fn({ kind: 'cli' }); return () => {}; },
+      cliBroadcast,
+      cliClientsRef,
+    );
+    expect(sentTo).toHaveLength(1);
+    expect(sentTo[0]).toEqual({ type: 'eternal.iteration', payload: { entry: { kind: 'cli' } } });
+    sub.dispose();
   });
 });


### PR DESCRIPTION
The CLI's `runWebUI` used to spell out every `JournalEntry` field by
hand when projecting an `eternal.iteration` WS message (L1027-1045
in the old file), which drifted from the standalone
`createEternalSubscription` helper's payload shape
(`{ entry: JournalEntry }`) and forced the frontend to keep two
deserializers — one for `entry.{iteration,at,source,task,status,note,tokens,costUsd}`
when the message came from the CLI, and one for `entry.*` when it
came from the standalone webui. That drift is exactly the kind of
issue the Phase-2 PR 4 `createEternalSubscription` extraction was
meant to prevent, and PR 4's README in the helper explicitly says
"Both the disposer and the JournalEntry are projected by the caller"
— the CLI just hadn't taken the wiring upgrade yet.

This PR:
  1. Imports `createEternalSubscription` from `@wrongstack/webui/server`.
  2. Replaces the 19-line hand-rolled subscribe+broadcast wiring in
     `runWebUI` with a 6-line `createEternalSubscription` call. The
     whole `JournalEntry` (including the CLI-only `costUsd` delta)
     now rides in the `entry` field of the WS payload, so the
     frontend can drop one deserializer.
  3. Loosens `EternalBroadcast` in the helper from
     `EternalBroadcast = (clients, msg) => void` (locked to webui's
     `ConnectedClient`) to `EternalBroadcast<C> = (clients, msg) => void`
     so the CLI's structurally-similar `Map<WebSocket, CliConnectedClient>`
     (just `{ ws, sessionId }` — no `connectedAt`) type-checks
     without an alias. A new test pins that pattern so the generic
     doesn't get accidentally tightened back to `ConnectedClient`.

Back-compat:
  - standalone `startWebUI` keeps the inferred
    `EternalBroadcast<webui.ConnectedClient>` (it passes its own
    `broadcast` and `clients` — same as before).
  - `eternal-iteration-broadcast.test.ts`'s existing 4 tests still
    pass; the new one exercises the CLI generic.
  - WS wire shape changes from a flat object to `{ entry: JournalEntry }`
    on the CLI side. The frontend (`packages/webui/src/lib/ws-client.ts`)
    is unaffected because it already handles `{ entry: ... }` from the
    standalone server. The only client affected would be a direct CLI
    consumer that hard-coded the 8-field shape, but I checked: the
    WebSocket client is the only consumer and it already
    deserializes `entry`-shaped payloads.

Diff: +36 / -19 across 3 files. webui 5/5 + cli baseline 4/4 pass.
PR 5a (PR #35) and PR 4 (PR #34) on this series stay green.

Refs: Phase 2 (runWebUI → startWebUI delegation), Issue #30.

This is the first slice of the headline 3,000-line `runWebUI` shim
deletion that was promised in Phase 2 PR 5b. The remaining slices
(`shell.open` deduplication, `projects.select` wiring, autonomy
state forwarding, etc.) each have their own PR.