### PR TITLE
refactor(cli): cli: extract tool-registry registration into boot/tool-registry.ts (PR 6 of #29)

### DIFF
--- a/packages/cli/src/boot/tool-registry.ts
+++ b/packages/cli/src/boot/tool-registry.ts
@@ -1,0 +1,110 @@
+// PR 6 of Issue #29: extract the inline tool-registry
+// construction (the 18-line block that runs immediately
+// after the SystemPromptBuilder binding) into a single
+// helper.
+//
+// Why this split:
+//
+//   - The tool registry bring-up is the *single largest*
+//     contiguous import-and-wire block in main() that
+//     does not depend on anything other than the container
+//     and the runtime config. Extracting it makes the
+//     boot sequence scannable: each line of main() becomes
+//     a single "phase done, next phase" call.
+//
+//   - The memory / mailbox / mail_send / mail_inbox
+//     registrations are the *only* consumers of
+//     `config.features.memory` and the runtime events
+//     bus. Lifting them into a helper means a future
+//     "always register mailbox" config flag is a single
+//     touchpoint, not a 4-place edit through main().
+//
+//   - The helper takes the tool registry, the feature
+//     flags, the memory store, the events bus, and the
+//     project directory as inputs. The tool-registry
+//     concrete class is passed in (not created) so the
+//     helper is a *registration* helper, not a
+//     *factory* helper \u2014 a future refactor that wants
+//     to inject a different ToolRegistry implementation
+//     (e.g. for tests) doesn't need to touch the helper.
+//
+// What is *not* in this helper:
+//
+//   - The `compactor` registration. The compactor is
+//     resolved from the container at registration time,
+//     and lifting the resolve into the helper would force
+//     the helper to know about the container's specific
+//     tokens. Instead, the caller passes the compactor as
+//     `compactorInstance`.
+//
+//   - The metrics wiring. That is a separate concern
+//     (extracted to `wiring/metrics.ts` already) and is
+//     not a tool-registry concern.
+
+import type { EventBus, MemoryStore, ToolRegistry, WstackPaths } from '@wrongstack/core';
+import { createContextManagerTool, makeMailboxTool, makeMailInboxTool, makeMailSendTool } from '@wrongstack/core';
+import { builtinToolsPack, forgetTool, relatedMemoryTool, rememberTool, searchMemoryTool } from '@wrongstack/tools';
+
+export interface RegisterBuiltinToolsDeps {
+  toolRegistry: ToolRegistry;
+  compactor: unknown;
+  config: { features: { memory: boolean } };
+  memoryStore: MemoryStore | null | undefined;
+  events: EventBus;
+  wpaths: Pick<WstackPaths, 'projectDir'>;
+}
+
+/**
+ * Register the inline tool set: context manager + memory
+ * tools (if features.memory) + mailbox tools. The mailbox
+ * tools are always registered \u2014 they are needed for
+ * inter-agent coordination regardless of the per-session
+ * memory feature flag.
+ */
+export function registerBuiltinTools(deps: RegisterBuiltinToolsDeps): void {
+  // Bulk register the builtin tool pack. The
+  // `registerAllOrThrow` call is intentional: a malformed
+  // pack is a boot-time failure, not a runtime one.
+  deps.toolRegistry.registerAllOrThrow(
+    [...(builtinToolsPack.tools ?? [])],
+    builtinToolsPack.name,
+  );
+
+  // Context manager tool: the model uses this to
+  // prune/compact its own context window when full. The
+  // compactor is resolved from the container at
+  // registration time, so a swap to a different
+  // compaction strategy at runtime doesn't require
+  // re-registering the tool.
+  deps.toolRegistry.registerDefault(
+    createContextManagerTool({ compactor: deps.compactor as never }),
+  );
+
+  if (deps.config.features.memory && deps.memoryStore) {
+    deps.toolRegistry.register(rememberTool(deps.memoryStore));
+    deps.toolRegistry.register(forgetTool(deps.memoryStore));
+    deps.toolRegistry.register(searchMemoryTool(deps.memoryStore));
+    deps.toolRegistry.register(relatedMemoryTool(deps.memoryStore));
+  }
+
+  // Mailbox tools. The inter-agent mailbox is a
+  // project-level concern (GlobalMailbox), so registration
+  // is unconditional. The events bus is passed so the
+  // mailbox tool can emit `agent_registered` /
+  // `heartbeat` events that the TUI/WebUI subscribe to
+  // for the status-bar online-agent count.
+  deps.toolRegistry.register(
+    makeMailboxTool({ projectDir: deps.wpaths.projectDir, events: deps.events }),
+  );
+  // High-affordance thin wrappers (mail_send / mail_inbox).
+  // The explicit verbs are what makes agents use the
+  // mailbox autonomously mid-task; without them, agents
+  // only see the mailbox through the `mailbox` core
+  // tool, which has a less discoverable API.
+  deps.toolRegistry.register(
+    makeMailSendTool({ projectDir: deps.wpaths.projectDir, events: deps.events }),
+  );
+  deps.toolRegistry.register(
+    makeMailInboxTool({ projectDir: deps.wpaths.projectDir, events: deps.events }),
+  );
+}

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -11,7 +11,6 @@ import {
   type Config,
   color,
   createAutonomyBrain,
-  createContextManagerTool,
   createDelegateTool,
   createMcpControlTool,
   createSessionEventBridge,
@@ -29,9 +28,6 @@ import {
   isStdinTTY,
   loadDirectorState,
   mailboxSessionTag,
-  makeMailboxTool,
-  makeMailInboxTool,
-  makeMailSendTool,
   ObservableBrainArbiter,
   type PackageAuthorTrackerOptions,
   ParallelEternalEngine,
@@ -50,15 +46,9 @@ import {
 } from '@wrongstack/core';
 import { MCPRegistry } from '@wrongstack/mcp';
 import { makeProviderFromConfig } from '@wrongstack/providers';
-import {
-  builtinToolsPack,
-  forgetTool,
-  relatedMemoryTool,
-  rememberTool,
-  searchMemoryTool,
-} from '@wrongstack/tools';
 import { createAutoPhaseHost } from './autophase-host.js';
 import { boot } from './boot.js';
+import { registerBuiltinTools } from './boot/tool-registry.js';
 import { parseArgs } from './arg-parser.js';
 import { launchEternalFromFlag } from './cli-eternal-flag.js';
 import { promptRecovery } from './cli-recovery-prompt.js';
@@ -278,26 +268,21 @@ export async function main(argv: string[]): Promise<number> {
     systemPromptBuilderToken: TOKENS.SystemPromptBuilder,
   });
 
-  // Tool registry
+  // Tool registry — PR 6 of Issue #29. The 18-line
+  // registration block (context manager + memory tools +
+  // mailbox tools) is now a single helper call. The helper
+  // takes the pre-constructed ToolRegistry, the feature
+  // flags, the memory store, the events bus, and the
+  // project dir; it does not touch the container.
   const toolRegistry = new ToolRegistry();
-  toolRegistry.registerAllOrThrow([...(builtinToolsPack.tools ?? [])], builtinToolsPack.name);
-  toolRegistry.registerDefault(
-    createContextManagerTool({ compactor: container.resolve(TOKENS.Compactor) }),
-  );
-  if (config.features.memory) {
-    toolRegistry.register(rememberTool(memoryStore));
-    toolRegistry.register(forgetTool(memoryStore));
-    toolRegistry.register(searchMemoryTool(memoryStore));
-    toolRegistry.register(relatedMemoryTool(memoryStore));
-  }
-  // Register the inter-agent mailbox tool — resolves to project-level GlobalMailbox at runtime.
-  // events are passed so mailbox.agent_registered/heartbeat events are emitted for TUI/WebUI
-  // to update the online agent count in the status bar.
-  toolRegistry.register(makeMailboxTool({ projectDir: wpaths.projectDir, events }));
-  // High-affordance thin wrappers (mail_send/mail_inbox) — the explicit
-  // verbs are what makes agents use the mailbox autonomously mid-task.
-  toolRegistry.register(makeMailSendTool({ projectDir: wpaths.projectDir, events }));
-  toolRegistry.register(makeMailInboxTool({ projectDir: wpaths.projectDir, events }));
+  registerBuiltinTools({
+    toolRegistry,
+    compactor: container.resolve(TOKENS.Compactor),
+    config,
+    memoryStore,
+    events,
+    wpaths,
+  });
 
   // Metrics wiring — extracted to wiring/metrics.ts
   const { metricsSink, healthRegistry } = (() => {

--- a/packages/cli/tests/boot/tool-registry.test.ts
+++ b/packages/cli/tests/boot/tool-registry.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * PR 6 of Issue #29: extract the inline tool-registry
+ * registration into a helper. This test pins the contract
+ * the helper preserves:
+ *
+ *   1. The builtin tool pack is always registered (memory
+ *      feature flag does not gate it).
+ *   2. The context manager tool is always registered as a
+ *      "default" tool, with the compactor passed through.
+ *   3. The four memory tools (remember / forget / search /
+ *      related) are only registered when both
+ *      `config.features.memory === true` AND
+ *      `memoryStore` is truthy. If memoryStore is null
+ *      (the runtime null-case when the store is not yet
+ *      bound), the memory tools are skipped silently.
+ *   4. The three mailbox tools (mailbox / mail_send /
+ *      mail_inbox) are always registered, regardless of
+ *      the memory feature flag, with the events bus passed
+ *      through.
+ *
+ * The test uses a fake `ToolRegistry` that just counts
+ * calls \u2014 we don't need a real registry implementation
+ * to assert the registration order or argument shape.
+ */
+
+const { registerBuiltinTools } = await import('../../src/boot/tool-registry.js');
+
+function makeFakeToolRegistry() {
+  const calls: { kind: string; toolName: string; isDefault: boolean }[] = [];
+  let nextDefault = false;
+  return {
+    registry: {
+      registerAllOrThrow: vi.fn((_tools: unknown, packName: string) => {
+        calls.push({ kind: 'bulk', toolName: packName, isDefault: false });
+      }),
+      registerDefault: vi.fn((_tool: unknown) => {
+        calls.push({ kind: 'default', toolName: '<default>', isDefault: true });
+      }),
+      register: vi.fn((tool: unknown) => {
+        // Each tool factory is a function; we capture the
+        // shape by storing the function reference. The
+        // helper calls register(tool) with a tool instance.
+        calls.push({ kind: 'single', toolName: '<tool>', isDefault: false });
+      }),
+    },
+    calls,
+  };
+}
+
+function makeEvents() {
+  return { _kind: 'fakeEvents' };
+}
+
+function makeWpaths() {
+  return { projectDir: '/tmp/project' };
+}
+
+describe('registerBuiltinTools (PR 6 of #29)', () => {
+  it('always registers the builtin tool pack and the context manager default', () => {
+    const { registry, calls } = makeFakeToolRegistry();
+    registerBuiltinTools({
+      toolRegistry: registry as never,
+      compactor: { _kind: 'fakeCompactor' },
+      config: { features: { memory: false } },
+      memoryStore: null,
+      events: makeEvents() as never,
+      wpaths: makeWpaths() as never,
+    });
+    expect(calls.some(c => c.kind === 'bulk')).toBe(true);
+    expect(calls.some(c => c.kind === 'default')).toBe(true);
+  });
+
+  it('skips memory tools when config.features.memory is false', () => {
+    const { registry, calls } = makeFakeToolRegistry();
+    registerBuiltinTools({
+      toolRegistry: registry as never,
+      compactor: {},
+      config: { features: { memory: false } },
+      memoryStore: { _kind: 'fakeStore' } as never,
+      events: makeEvents() as never,
+      wpaths: makeWpaths() as never,
+    });
+    // Exactly three single-tool registrations: mailbox,
+    // mail_send, mail_inbox. No memory tools.
+    const singles = calls.filter(c => c.kind === 'single');
+    expect(singles).toHaveLength(3);
+  });
+
+  it('skips memory tools when memoryStore is null even if features.memory is true', () => {
+    const { registry, calls } = makeFakeToolRegistry();
+    registerBuiltinTools({
+      toolRegistry: registry as never,
+      compactor: {},
+      config: { features: { memory: true } },
+      memoryStore: null,
+      events: makeEvents() as never,
+      wpaths: makeWpaths() as never,
+    });
+    // Memory flag is on but the store is null \u2014 the helper
+    // silently skips the memory tools. This matches the
+    // pre-refactor inline behavior: `if
+    // (config.features.memory)` would have crashed with
+    // a TypeError on `rememberTool(memoryStore)` when
+    // memoryStore is null. The refactor tightens this:
+    // features.memory && memoryStore \u2014 the null case
+    // is now a no-op.
+    const singles = calls.filter(c => c.kind === 'single');
+    expect(singles).toHaveLength(3);
+  });
+
+  it('registers all four memory tools when features.memory is true AND memoryStore is provided', () => {
+    const { registry, calls } = makeFakeToolRegistry();
+    registerBuiltinTools({
+      toolRegistry: registry as never,
+      compactor: {},
+      config: { features: { memory: true } },
+      memoryStore: { _kind: 'fakeStore' } as never,
+      events: makeEvents() as never,
+      wpaths: makeWpaths() as never,
+    });
+    // 3 mailbox tools + 4 memory tools = 7 single
+    // registrations.
+    const singles = calls.filter(c => c.kind === 'single');
+    expect(singles).toHaveLength(7);
+  });
+});


### PR DESCRIPTION
Extracted the 18-line inline tool-registry block (bulk builtin pack + context manager default + memory tools + mailbox tools) into a single `registerBuiltinTools(deps)` helper.

The helper:
  - takes a pre-constructed `ToolRegistry` (so it is a *registration* helper, not a *factory* helper — a future refactor that wants to inject a different registry implementation doesn't need to touch this file).
  - takes the runtime `config`, `memoryStore`, `events`, and a `Pick<WstackPaths, 'projectDir'>` so the helper doesn't depend on the full `WstackPaths` shape.
  - tightens the memory-tool guard: pre-refactor inline was `if (config.features.memory)` — a null `memoryStore` would have crashed with a TypeError on `rememberTool(memoryStore)`. Post-refactor is `features.memory && memoryStore` — the null case is now a silent skip, matching the intent.
  - keeps the compactor resolution in main() (not in the helper) so the helper doesn't need to know about `TOKENS.Compactor`.

4 new unit tests in `packages/cli/tests/boot/tool-registry.test.ts`:
  - always registers the builtin tool pack and the context manager default
  - skips memory tools when config.features.memory is false
  - skips memory tools when memoryStore is null even if features.memory is true
  - registers all four memory tools when features.memory is true AND memoryStore is provided

cli 95/95 (1307 tests) green with no regressions.

Refs: Issue #29, PR 0 (#36), PR 1 (#39), PR 2 (#43), PR 3 (#44), PR 4 (#46), PR 5 (#47).