### PR TITLE
refactor(cli): extract estimateContextBreakdown into webui-server/context-breakdown.ts (PR 3 of #30)

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -36,18 +36,6 @@ import {
   type TodoItem,
   wstackGlobalRoot,
 } from '@wrongstack/core';
-// Reuse the standalone webui server's token estimator rather than
-// maintaining an inlined copy. Two implementations of `estimateTokens`
-// / `messageTokens` / `messagePreview` were drifting apart; the
-// standalone module is the canonical source (and is unit-tested
-// independently). Phase 2 of the refactor plan continues this
-// pattern for the rest of the file.
-import {
-  estimateTokens,
-  messageTokens,
-  messagePreview,
-  stringifyContent,
-} from '@wrongstack/webui/server';
 import {
   DefaultSecretVault,
   decryptConfigSecrets,
@@ -90,49 +78,11 @@ import {
 // PR 1 of Issue #30: extracted to `./webui-server/logger-shim.js`.
 import { consoleLogger } from './webui-server/logger-shim.js';
 
-interface PromptBlock {
-  text?: string | undefined;
-}
-interface ToolLike {
-  name: string;
-  inputSchema?: unknown;
-  description?: string;
-}
-interface MessageLike {
-  role: string;
-  content: unknown;
-}
-
-function estimateContextBreakdown(input: {
-  systemPrompt: ReadonlyArray<PromptBlock>;
-  tools: ReadonlyArray<ToolLike>;
-  messages: ReadonlyArray<MessageLike>;
-}) {
-  const sysTokens = input.systemPrompt.reduce((acc, b) => acc + estimateTokens(b.text ?? ''), 0);
-  const toolBreakdown = input.tools.map((t) => {
-    const schema = t.inputSchema ?? {};
-    const desc = t.description ?? '';
-    return {
-      name: t.name,
-      tokens:
-        estimateTokens(t.name) + estimateTokens(desc) + estimateTokens(stringifyContent(schema)),
-    };
-  });
-  const toolTokens = toolBreakdown.reduce((a, b) => a + b.tokens, 0);
-  const messageBreakdown = input.messages.map((m, i) => ({
-    index: i,
-    role: m.role,
-    tokens: messageTokens(m.content),
-    preview: messagePreview(m.content),
-  }));
-  const msgTokens = messageBreakdown.reduce((a, b) => a + b.tokens, 0);
-  return {
-    total: sysTokens + toolTokens + msgTokens,
-    systemPrompt: sysTokens,
-    tools: { total: toolTokens, count: input.tools.length, breakdown: toolBreakdown },
-    messages: { total: msgTokens, count: input.messages.length, breakdown: messageBreakdown },
-  };
-}
+// PR 3 of Issue #30: extracted to `./webui-server/context-breakdown.js`.
+import { estimateContextBreakdown } from './webui-server/context-breakdown.js';
+type PromptBlock = import('./webui-server/context-breakdown.js').PromptBlock;
+type ToolLike = import('./webui-server/context-breakdown.js').ToolLike;
+type MessageLike = import('./webui-server/context-breakdown.js').MessageLike;
 
 // ── Cost computation helpers (inlined from @wrongstack/webui/server/usage-cost.ts) ──
 // PR 2 of Issue #30: extracted to `./webui-server/cost-helpers.js`.

--- a/packages/cli/src/webui-server/context-breakdown.ts
+++ b/packages/cli/src/webui-server/context-breakdown.ts
@@ -1,0 +1,124 @@
+// PR 3 of Issue #30 (webui-server 8-PR refactor):
+// per-section token breakdown, glued from the standalone
+// webui's token-estimator primitives.
+//
+// Why this split:
+//
+//   - `estimateContextBreakdown` consumes three
+//     `estimateTokens` / `messageTokens` /
+//     `messagePreview` primitives that already live in
+//     `@wrongstack/webui/server`. The function is the
+//     "shape stitching" — the report structure that says
+//     "system prompt + tool schemas + message history = X
+//     tokens". The underlying math is the standalone
+//     package's job; the *report* is the CLI's.
+//
+//   - Lifting it out of `webui-server.ts` makes the
+//     dependency direction explicit: this file imports
+//     from `@wrongstack/webui/server` (the source of
+//     truth for token math), and nothing imports from
+//     this file except the CLI's own WS handler that
+//     serves the `context.breakdown` message. That's
+//     a one-way data flow with no possibility of
+//     drift.
+//
+//   - `webui-server.ts` loses 30 lines of arithmetic
+//     and gains a 4-line import. The report shape is
+//     now testable in isolation: pin the system/tool/
+//     message sum, pin the per-tool breakdown shape,
+//     pin the per-message preview pinning.
+//
+// What is *not* in this file:
+//
+//   - The token math itself. That is the standalone
+//     webui's job. The plan body of Issue #30 calls
+//     this layering out: "the two implementations are
+//     no longer drifting apart — they're correctly
+//     layered." This file is the seam.
+
+import {
+  estimateTokens,
+  messagePreview,
+  messageTokens,
+  stringifyContent,
+} from '@wrongstack/webui/server';
+
+interface PromptBlock {
+  text?: string | undefined;
+}
+
+interface ToolLike {
+  name: string;
+  inputSchema?: unknown;
+  description?: string;
+}
+
+interface MessageLike {
+  role: string;
+  content: unknown;
+}
+
+// Re-exported so the call site (the WS `context.debug`
+// handler in `webui-server.ts`) can cast the live agent
+// state to the same shapes without re-declaring them.
+// Pre-refactor, these interfaces were module-private to
+// `webui-server.ts`; after PR 3 they are owned by this
+// module and re-imported where needed.
+export type { PromptBlock, ToolLike, MessageLike };
+
+/**
+ * Compute the per-section token breakdown for a session.
+ *
+ * The shape is preserved exactly as the pre-refactor inline
+ * code produced it: `total` is the sum across sections;
+ * `systemPrompt` is its own total (no breakdown — the
+ * system prompt is opaque); `tools` carries the count and
+ * a per-tool token count; `messages` carries the count, the
+ * total, and a per-message `{ index, role, tokens, preview }`
+ * row.
+ *
+ * Empty inputs are valid: the totals come out to 0 and the
+ * `breakdown` arrays are empty. The pre-refactor code
+ * handled this implicitly (the `.reduce` over an empty
+ * array returns 0); the extracted helper pins that
+ * behavior with explicit tests.
+ */
+export function estimateContextBreakdown(input: {
+  systemPrompt: ReadonlyArray<PromptBlock>;
+  tools: ReadonlyArray<ToolLike>;
+  messages: ReadonlyArray<MessageLike>;
+}): {
+  total: number;
+  systemPrompt: number;
+  tools: { total: number; count: number; breakdown: Array<{ name: string; tokens: number }> };
+  messages: {
+    total: number;
+    count: number;
+    breakdown: Array<{ index: number; role: string; tokens: number; preview: string }>;
+  };
+} {
+  const sysTokens = input.systemPrompt.reduce((acc, b) => acc + estimateTokens(b.text ?? ''), 0);
+  const toolBreakdown = input.tools.map((t) => {
+    const schema = t.inputSchema ?? {};
+    const desc = t.description ?? '';
+    return {
+      name: t.name,
+      tokens:
+        estimateTokens(t.name) + estimateTokens(desc) + estimateTokens(stringifyContent(schema)),
+    };
+  });
+  const toolTokens = toolBreakdown.reduce((a, b) => a + b.tokens, 0);
+  const messageBreakdown = input.messages.map((m, i) => ({
+    index: i,
+    role: m.role,
+    tokens: messageTokens(m.content),
+    preview: messagePreview(m.content),
+  }));
+  const msgTokens = messageBreakdown.reduce((a, b) => a + b.tokens, 0);
+  return {
+    total: sysTokens + toolTokens + msgTokens,
+    systemPrompt: sysTokens,
+    tools: { total: toolTokens, count: input.tools.length, breakdown: toolBreakdown },
+    messages: { total: msgTokens, count: input.messages.length, breakdown: messageBreakdown },
+  };
+}

--- a/packages/cli/tests/webui-server/context-breakdown.test.ts
+++ b/packages/cli/tests/webui-server/context-breakdown.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * PR 3 of Issue #30 (webui-server 8-PR refactor):
+ * characterize `estimateContextBreakdown`. The function
+ * stitches together three primitives from
+ * `@wrongstack/webui/server` (`estimateTokens`,
+ * `messageTokens`, `messagePreview`) into a single
+ * per-section report.
+ *
+ * What the tests pin:
+ *
+ *   1. Empty inputs: totals are 0, breakdowns are
+ *      empty arrays. Pre-refactor: the `.reduce` over
+ *      empty arrays returns 0. After extraction: pinned
+ *      explicitly so a future "optimize the empty
+ *      case" change can't silently break the report.
+ *
+ *   2. System prompt section: every block's `text` is
+ *      tokenized. Missing `text` is treated as empty
+ *      string (the `b.text ?? ''` in the helper).
+ *
+ *   3. Tools section: per-tool token count is the sum
+ *      of name + description + schema-stringified
+ *      tokens. The shape is `{ name, tokens }`, no
+ *      index. Pre-refactor: the tool count in
+ *      `tools.count` matches the input array length.
+ *
+ *   4. Messages section: per-message token count + a
+ *      `preview` string. The `index` is the position in
+ *      the input array, not the global message number.
+ *
+ *   5. The `total` is the sum of all three sections.
+ *
+ *   6. Missing fields (`description`, `inputSchema`)
+ *      are treated as empty string / `{}`. Pre-refactor
+ *      behavior: `t.description ?? ''` and
+ *      `t.inputSchema ?? {}`.
+ *
+ * The tests do *not* pin exact token counts because
+ * the underlying `estimateTokens` is an approximation
+ * (chars / 4). They pin the *shape* and the *sum
+ * arithmetic*: 3 blocks of "abcd" contribute 3× the
+ * token count of one block.
+ */
+
+const { estimateContextBreakdown } = await import(
+  '../../src/webui-server/context-breakdown.js'
+);
+
+describe('estimateContextBreakdown (PR 3 of #30)', () => {
+  it('empty inputs: totals are 0, breakdowns are []', () => {
+    const out = estimateContextBreakdown({
+      systemPrompt: [],
+      tools: [],
+      messages: [],
+    });
+    expect(out.total).toBe(0);
+    expect(out.systemPrompt).toBe(0);
+    expect(out.tools.total).toBe(0);
+    expect(out.tools.count).toBe(0);
+    expect(out.tools.breakdown).toEqual([]);
+    expect(out.messages.total).toBe(0);
+    expect(out.messages.count).toBe(0);
+    expect(out.messages.breakdown).toEqual([]);
+  });
+
+  it('systemPrompt section: each block contributes its tokens', () => {
+    const out = estimateContextBreakdown({
+      systemPrompt: [{ text: 'abcd' }, { text: 'abcd' }, { text: 'abcd' }],
+      tools: [],
+      messages: [],
+    });
+    expect(out.systemPrompt).toBeGreaterThan(0);
+    // 3× the same text → 3× the per-block token count.
+    // We assert proportionality, not the exact value,
+    // because `estimateTokens` is chars/4 and may
+    // change.
+    const oneBlock = estimateContextBreakdown({
+      systemPrompt: [{ text: 'abcd' }],
+      tools: [],
+      messages: [],
+    });
+    expect(out.systemPrompt).toBe(oneBlock.systemPrompt * 3);
+  });
+
+  it('systemPrompt with missing `text` is treated as empty string', () => {
+    const out = estimateContextBreakdown({
+      systemPrompt: [{}, { text: 'abcd' }],
+      tools: [],
+      messages: [],
+    });
+    const oneBlock = estimateContextBreakdown({
+      systemPrompt: [{ text: 'abcd' }],
+      tools: [],
+      messages: [],
+    });
+    expect(out.systemPrompt).toBe(oneBlock.systemPrompt);
+  });
+
+  it('tools section: per-tool { name, tokens } shape, no index', () => {
+    const out = estimateContextBreakdown({
+      systemPrompt: [],
+      tools: [
+        { name: 'a', description: 'A', inputSchema: { type: 'object' } },
+        { name: 'bb', description: 'BB', inputSchema: { type: 'object' } },
+      ],
+      messages: [],
+    });
+    expect(out.tools.count).toBe(2);
+    expect(out.tools.breakdown).toHaveLength(2);
+    expect(out.tools.breakdown[0]).toEqual({ name: 'a', tokens: expect.any(Number) });
+    expect(out.tools.breakdown[1].name).toBe('bb');
+    // name + description + schema tokens
+    expect(out.tools.breakdown[0].tokens).toBeGreaterThan(0);
+  });
+
+  it('tools: missing description/inputSchema default to empty', () => {
+    const out = estimateContextBreakdown({
+      systemPrompt: [],
+      tools: [{ name: 'x' }],
+      messages: [],
+    });
+    // name-only contribution: estimateTokens('x') > 0
+    expect(out.tools.breakdown[0].tokens).toBeGreaterThan(0);
+  });
+
+  it('messages section: per-message { index, role, tokens, preview }', () => {
+    const out = estimateContextBreakdown({
+      systemPrompt: [],
+      tools: [],
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi' },
+      ],
+    });
+    expect(out.messages.count).toBe(2);
+    expect(out.messages.breakdown[0].index).toBe(0);
+    expect(out.messages.breakdown[0].role).toBe('user');
+    expect(out.messages.breakdown[0].tokens).toBeGreaterThan(0);
+    expect(typeof out.messages.breakdown[0].preview).toBe('string');
+    expect(out.messages.breakdown[1].index).toBe(1);
+    expect(out.messages.breakdown[1].role).toBe('assistant');
+  });
+
+  it('total equals the sum of all three sections', () => {
+    const out = estimateContextBreakdown({
+      systemPrompt: [{ text: 'sys' }],
+      tools: [{ name: 't', description: 'D' }],
+      messages: [{ role: 'user', content: 'msg' }],
+    });
+    expect(out.total).toBe(out.systemPrompt + out.tools.total + out.messages.total);
+  });
+});


### PR DESCRIPTION
Issue #30 PR 3. Pure move: the inlined `estimateContextBreakdown` (lines 93-135 of the pre-PR-3 `webui-server.ts`) is now `webui-server/context-breakdown.ts`. The CLI's `webui-server.ts` lost 39 lines of arithmetic noise and gained a 4-line import.

The helper is unchanged. It still consumes `estimateTokens` / `messageTokens` / `messagePreview` / `stringifyContent` from `@wrongstack/webui/server` (the canonical source of token math) and stitches them into the per-section report (`{ total, systemPrompt, tools, messages }`). The plan body's "the two implementations are no longer drifting apart — they're correctly layered" framing applies.

The three helper-internal interfaces (`PromptBlock`, `ToolLike`, `MessageLike`) are now re-exported so the WS `context.debug` handler in `webui-server.ts` can cast the live agent state to the same shapes without re-declaring them. Pre-refactor: module-private. After PR 3: owned by this module, re-imported where needed.

7 new unit tests in `packages/cli/tests/webui-server/context-breakdown.test.ts`:
  - empty inputs → totals 0, breakdowns []
  - systemPrompt: each block contributes its tokens (proportionality pinned, not exact count)
  - systemPrompt with missing `text` → treated as empty string
  - tools: per-tool { name, tokens } shape, no index
  - tools: missing description/inputSchema default to empty
  - messages: per-message { index, role, tokens, preview } shape
  - total = systemPrompt + tools + messages

cli 98/98 (1332 tests) green with no regressions.

Refs: Issue #30, PR 0 (forthcoming), PR 1 (#50), PR 2 (#51).