### PR TITLE
refactor(cli): extract provider-config IO (PR 4 of #30)

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -61,12 +61,14 @@ import {
   registerInstance,
   unregisterInstance,
 } from '@wrongstack/webui/server';
+import {
+  loadSavedProviders,
+  saveProviders,
+} from './webui-server/provider-config.js';
 import { WebSocket, WebSocketServer } from 'ws';
 import {
   expectDefined,
-  loadConfigProviders,
   maskedKey,
-  mutateConfigProviders,
   normalizeKeys,
   nowIso,
   writeKeysBack,
@@ -1978,10 +1980,8 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
 
           // Create a new provider instance from the saved config
           const { makeProviderFromConfig } = await import('@wrongstack/providers');
-          const { loadConfigProviders } = await import('./provider-config-utils.js');
-          const saved = opts.globalConfigPath
-            ? await loadConfigProviders(opts.globalConfigPath, getVault())
-            : {};
+          const { loadSavedProviders } = await import('./webui-server/provider-config.js');
+          const saved = await loadSavedProviders(opts.globalConfigPath);
           const providerCfg = saved[newProvider] ?? { type: newProvider };
           const newProv = makeProviderFromConfig(newProvider, providerCfg);
           ctx.provider = newProv;
@@ -3016,7 +3016,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     }
     try {
       const providers = await opts.modelsRegistry.listProviders();
-      const savedProviders = await loadSavedProviders();
+      const savedProviders = await loadSavedProviders(opts.globalConfigPath);
       const savedIds = new Set(Object.keys(savedProviders));
 
       send(ws, {
@@ -3076,7 +3076,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
 
   async function handleProvidersSaved(ws: WebSocket): Promise<void> {
     try {
-      const providers = await loadSavedProviders();
+      const providers = await loadSavedProviders(opts.globalConfigPath);
       send(ws, {
         type: 'providers.saved',
         payload: {
@@ -3105,7 +3105,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     apiKey: string,
   ): Promise<void> {
     try {
-      const providers = await loadSavedProviders();
+      const providers = await loadSavedProviders(opts.globalConfigPath);
       const existing = providers[providerId] ?? { type: providerId };
       const keys = normalizeKeys(existing);
 
@@ -3121,7 +3121,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       if (!existing.activeKey) existing.activeKey = label;
       providers[providerId] = existing;
 
-      await saveProviders(providers);
+      await saveProviders(opts.globalConfigPath, providers);
       sendResult(ws, true, `Key "${label}" saved for ${providerId}`);
     } catch (err) {
       sendResult(ws, false, err instanceof Error ? err.message : String(err));
@@ -3130,7 +3130,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
 
   async function handleKeyDelete(ws: WebSocket, providerId: string, label: string): Promise<void> {
     try {
-      const providers = await loadSavedProviders();
+      const providers = await loadSavedProviders(opts.globalConfigPath);
       const existing = providers[providerId];
       if (!existing) {
         sendResult(ws, false, `Provider "${providerId}" not found`);
@@ -3146,7 +3146,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         }
         providers[providerId] = existing;
       }
-      await saveProviders(providers);
+      await saveProviders(opts.globalConfigPath, providers);
       sendResult(ws, true, `Key "${label}" deleted from ${providerId}`);
     } catch (err) {
       sendResult(ws, false, err instanceof Error ? err.message : String(err));
@@ -3159,7 +3159,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     label: string,
   ): Promise<void> {
     try {
-      const providers = await loadSavedProviders();
+      const providers = await loadSavedProviders(opts.globalConfigPath);
       const existing = providers[providerId];
       if (!existing) {
         sendResult(ws, false, `Provider "${providerId}" not found`);
@@ -3168,7 +3168,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       existing.activeKey = label;
       writeKeysBack(existing, normalizeKeys(existing));
       providers[providerId] = existing;
-      await saveProviders(providers);
+      await saveProviders(opts.globalConfigPath, providers);
       sendResult(ws, true, `Active key for ${providerId} set to "${label}"`);
     } catch (err) {
       sendResult(ws, false, err instanceof Error ? err.message : String(err));
@@ -3185,7 +3185,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     },
   ): Promise<void> {
     try {
-      const providers = await loadSavedProviders();
+      const providers = await loadSavedProviders(opts.globalConfigPath);
       if (providers[payload.id]) {
         sendResult(ws, false, `Provider "${payload.id}" already exists. Use key.add to add a key.`);
         return;
@@ -3200,7 +3200,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         newProv.activeKey = 'default';
       }
       providers[payload.id] = newProv;
-      await saveProviders(providers);
+      await saveProviders(opts.globalConfigPath, providers);
       sendResult(ws, true, `Provider "${payload.id}" added`);
       console.log(`[WebUI] Provider "${payload.id}" added via provider.add`);
       broadcast({
@@ -3226,39 +3226,20 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
 
   async function handleProviderRemove(ws: WebSocket, providerId: string): Promise<void> {
     try {
-      const providers = await loadSavedProviders();
+      const providers = await loadSavedProviders(opts.globalConfigPath);
       if (!providers[providerId]) {
         sendResult(ws, false, `Provider "${providerId}" not found`);
         return;
       }
       delete providers[providerId];
-      await saveProviders(providers);
+      await saveProviders(opts.globalConfigPath, providers);
       sendResult(ws, true, `Provider "${providerId}" removed`);
     } catch (err) {
       sendResult(ws, false, err instanceof Error ? err.message : String(err));
     }
   }
 
-  // ---- Config I/O helpers (delegated to shared provider-config-utils) ----
-
-  function getVault(): DefaultSecretVault {
-    const keyFile = path.join(path.dirname(opts.globalConfigPath ?? ''), '.key');
-    return new DefaultSecretVault({ keyFile });
-  }
-
-  async function loadSavedProviders(): Promise<Record<string, ProviderConfig>> {
-    if (!opts.globalConfigPath) return {};
-    return loadConfigProviders(opts.globalConfigPath, getVault());
-  }
-
-  async function saveProviders(providers: Record<string, ProviderConfig>): Promise<void> {
-    if (!opts.globalConfigPath) return;
-    await mutateConfigProviders(opts.globalConfigPath, getVault(), (existing) => {
-      // Replace the entire providers map.
-      for (const key of Object.keys(existing)) delete existing[key];
-      Object.assign(existing, providers);
-    });
-  }
+  // ---- Config I/O helpers (delegated to webui-server/provider-config) ----
 
   function sendResult(ws: WebSocket, success: boolean, message: string): void {
     send(ws, { type: 'key.operation_result', payload: { success, message } });

--- a/packages/cli/src/webui-server/provider-config.ts
+++ b/packages/cli/src/webui-server/provider-config.ts
@@ -1,0 +1,55 @@
+import * as path from 'node:path';
+import { DefaultSecretVault } from '@wrongstack/core/security';
+import type { ProviderConfig } from '@wrongstack/core/types';
+import { loadConfigProviders, mutateConfigProviders } from '../provider-config-utils.js';
+
+/**
+ * PR 4 of Issue #30 (webui-server 8-PR refactor):
+ * provider-config IO.
+ *
+ * Before this PR, the two helpers below were inlined
+ * at the bottom of `webui-server.ts` as closure-captured
+ * helpers that read `opts.globalConfigPath` from the
+ * surrounding `runWebUI` scope. The helpers themselves
+ * are pure: given a config path and a vault, they
+ * load or save the providers map. The `globalConfigPath`
+ * closure capture is what made them untestable in
+ * isolation.
+ *
+ * After this PR, the helpers live in their own module
+ * with explicit parameters. `runWebUI` is the only
+ * caller; it now constructs the helpers at the call
+ * site or threads `globalConfigPath` through a thin
+ * adapter.
+ *
+ * Note: `writeKeysBack` and `normalizeKeys` (used by
+ * the per-handler key ops) are *already* imported from
+ * `@wrongstack/webui/server`. This PR does not move
+ * them — they were never inlined in `webui-server.ts`.
+ * Per the plan body's update after PR #51, they are
+ * not part of this extraction.
+ */
+
+export function getVault(globalConfigPath: string | undefined): DefaultSecretVault {
+  const keyFile = path.join(path.dirname(globalConfigPath ?? ''), '.key');
+  return new DefaultSecretVault({ keyFile });
+}
+
+export async function loadSavedProviders(
+  globalConfigPath: string | undefined,
+): Promise<Record<string, ProviderConfig>> {
+  if (!globalConfigPath) return {};
+  return loadConfigProviders(globalConfigPath, getVault(globalConfigPath));
+}
+
+export async function saveProviders(
+  globalConfigPath: string | undefined,
+  providers: Record<string, ProviderConfig>,
+): Promise<void> {
+  if (!globalConfigPath) return;
+  await mutateConfigProviders(globalConfigPath, getVault(globalConfigPath), (existing: Record<string, ProviderConfig>) => {
+    // Replace the entire providers map.
+    for (const key of Object.keys(existing)) delete existing[key];
+    Object.assign(existing, providers);
+  });
+}

--- a/packages/cli/tests/webui-server/provider-config.test.ts
+++ b/packages/cli/tests/webui-server/provider-config.test.ts
@@ -1,0 +1,95 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getVault,
+  loadSavedProviders,
+  saveProviders,
+} from '../../src/webui-server/provider-config.js';
+
+/**
+ * PR 4 of Issue #30 (webui-server 8-PR refactor):
+ * provider-config IO unit tests.
+ *
+ * These cover the three helpers extracted from
+ * webui-server.ts:
+ *
+ *   - getVault: builds a DefaultSecretVault rooted at
+ *     <dirname(globalConfigPath)>/.key
+ *   - loadSavedProviders: returns {} when no
+ *     globalConfigPath, otherwise the on-disk map
+ *     (decrypted via the vault)
+ *   - saveProviders: no-op when no globalConfigPath,
+ *     otherwise replaces the entire providers map
+ *
+ * Tests use real on-disk temp files in
+ * os.tmpdir() — no mocking of the vault or
+ * loadConfigProviders. The point of this PR is to
+ * decouple the helpers from the `runWebUI` closure;
+ * the helpers themselves are still integration-tested
+ * with the underlying fs/cipher stack.
+ */
+
+let tmpDir = '';
+let configPath = '';
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wstack-pr4-'));
+  configPath = path.join(tmpDir, 'config.json');
+});
+
+afterEach(async () => {
+  if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+  tmpDir = '';
+  configPath = '';
+});
+
+describe('webui-server/provider-config (PR 4 of #30)', () => {
+  it('getVault: returns a DefaultSecretVault rooted at dirname(configPath)/.key', () => {
+    const v = getVault(configPath);
+    expect(v).toBeDefined();
+    // DefaultSecretVault is the only thing exported
+    // from @wrongstack/core/security that has a
+    // keyFile; we don't introspect further, just
+    // assert it's truthy.
+  });
+
+  it('getVault: tolerates undefined configPath', () => {
+    const v = getVault(undefined);
+    expect(v).toBeDefined();
+  });
+
+  it('loadSavedProviders: returns {} when no globalConfigPath', async () => {
+    const out = await loadSavedProviders(undefined);
+    expect(out).toEqual({});
+  });
+
+  it('loadSavedProviders: returns {} when config file is absent', async () => {
+    // configPath exists as a path but no file at
+    // it yet. loadConfigProviders treats that as
+    // an empty config.
+    const out = await loadSavedProviders(configPath);
+    expect(out).toEqual({});
+  });
+
+  it('saveProviders + loadSavedProviders round-trip', async () => {
+    // The vault encrypts the keys, so save+load
+    // should return the same map. We don't
+    // introspect the on-disk format — the
+    // round-trip is the contract.
+    const input = {
+      anthropic: { type: 'anthropic', apiKeys: [{ label: 'k1', key: 'sk-test-1' }] },
+      openai: { type: 'openai', apiKeys: [{ label: 'k2', key: 'sk-test-2' }] },
+    } as never;
+    await saveProviders(configPath, input);
+    const out = await loadSavedProviders(configPath);
+    expect(out).toEqual(input);
+  });
+
+  it('saveProviders: no-op when no globalConfigPath', async () => {
+    // The function must not throw, must not create
+    // any files, and must not write to anything.
+    await expect(saveProviders(undefined, {})).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
PR 4 of Issue #30 (webui-server 8-PR refactor): extract `loadSavedProviders`, `saveProviders`, `getVault` from `webui-server.ts` into `webui-server/provider-config.ts`.

Helpers now take `globalConfigPath` as an explicit parameter instead of closing over `runWebUI`'s `opts`. One stale closure-captured `loadConfigProviders` call site at L1985 is migrated to the new module.

`writeKeysBack` and `normalizeKeys` were already imported from `./provider-config-utils.js` — they were never inlined in `webui-server.ts`, so this PR does not move them (per the plan-body update from PR #51).

6 unit tests cover the three helpers (round-trip, no-config-path no-op, vault construction).
