### PR TITLE
docs(issue): update PR 4 of #30 plan body to reflect actual scope (PR #55)

### DIFF
--- a/docs/issues/2026-06-13-webui-server-refactor.md
+++ b/docs/issues/2026-06-13-webui-server-refactor.md
@@ -207,6 +207,17 @@ CLI-specific extras (`writeKeysBack`'s `addKey` semantics,
 > `ProviderConfigStore` interface), it should land as a
 > follow-up to PR 4.
 
+> **Update 2026-06-13 (after PR #55):** the plan body listed
+> `writeKeysBack` and `normalizeKeys` in this PR. These two
+> functions are *already* imported from
+> `packages/cli/src/provider-config-utils.js` (not inlined in
+> `webui-server.ts`), so PR #55 extracted only the inlined
+> helpers (`loadSavedProviders`, `saveProviders`, `getVault`)
+> and did not move them. If a future PR needs to dedupe the
+> import path (e.g. wrap them behind a single
+> `ProviderConfigStore` interface), it should land as a
+> follow-up to PR 4.
+
 ### PR 5 — `webui-server/ws-handlers/` directory (medium risk) 🔥
 
 This is the **core extraction**. The 25+ inline `handleXxx` WebSocket

--- a/docs/issues/2026-06-13-webui-server-refactor.md
+++ b/docs/issues/2026-06-13-webui-server-refactor.md
@@ -196,6 +196,17 @@ implementation where they overlap and *only* contain genuinely
 CLI-specific extras (`writeKeysBack`'s `addKey` semantics,
 `normalizeKeys`'s migration logic).
 
+> **Update 2026-06-13 (after PR #55):** the plan body listed
+> `writeKeysBack` and `normalizeKeys` in this PR. These two
+> functions are *already* imported from
+> `packages/cli/src/provider-config-utils.js` (not inlined in
+> `webui-server.ts`), so PR #55 extracted only the inlined
+> helpers (`loadSavedProviders`, `saveProviders`, `getVault`)
+> and did not move them. If a future PR needs to dedupe the
+> import path (e.g. wrap them behind a single
+> `ProviderConfigStore` interface), it should land as a
+> follow-up to PR 4.
+
 ### PR 5 — `webui-server/ws-handlers/` directory (medium risk) 🔥
 
 This is the **core extraction**. The 25+ inline `handleXxx` WebSocket


### PR DESCRIPTION
Docs-only follow-up to PR #55.

PR 4 of Issue #30 (#30) planned to extract `loadSavedProviders`, `saveProviders`, `writeKeysBack`, and `normalizeKeys`. After PR #55 shipped, the actual scope was narrower: only the three inlined helpers (`loadSavedProviders`, `saveProviders`, `getVault`) moved to `webui-server/provider-config.ts`. The other two were already imported from `packages/cli/src/provider-config-utils.js` and were never inlined in `webui-server.ts`, so there was nothing to move.

This PR adds a status block under the PR 4 section in the plan body to make that distinction visible to future readers, and to flag the open follow-up (a `ProviderConfigStore` interface that would dedupe the two import paths) so it does not get lost.

No code changes. Docs only.
