### PR TITLE
refactor(cli): extract static-serve to webui-server/static-serve (PR 6 of #30)

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -1,6 +1,5 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
-import { createRequire } from 'node:module';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type {
@@ -47,7 +46,6 @@ import {
   type CustomModeStore,
   createCustomModeStore,
   createEternalSubscription,
-  createHttpServer,
   findFreePort,
   handleFilesList,
   handleFilesRead,
@@ -65,6 +63,7 @@ import {
   loadSavedProviders,
   saveProviders,
 } from './webui-server/provider-config.js';
+import { startStaticServe } from './webui-server/static-serve.js';
 import { WebSocket, WebSocketServer } from 'ws';
 import {
   expectDefined,
@@ -575,33 +574,31 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
   console.log(`[WebUI] WebSocket server starting on ws://${host}:${port}`);
 
   // Serve the React frontend over HTTP so `wrongstack --webui` is a one-command
-  // launch (open the printed URL) instead of only a WS bridge. The static
-  // serve + WS-port injection live in @wrongstack/webui; we resolve its built
-  // dist via the package entry. If the webui package isn't built, we degrade
+  // launch (open the printed URL) instead of only a WS bridge. The dist
+  // discovery + HTTP server bring-up live in
+  // `webui-server/static-serve.ts`; we just hand it the options and
+  // wire the open-browser callback on top. If the webui package
+  // isn't built, `startStaticServe` returns null and we degrade
   // gracefully to WS-only (the original behavior).
-  let httpServer: import('node:http').Server | null = null;
-  try {
-    const requireFromHere = createRequire(import.meta.url);
-    const serverEntry = requireFromHere.resolve('@wrongstack/webui/server');
-    const distDir = path.resolve(path.dirname(serverEntry), '..'); // .../dist
-    httpServer = createHttpServer({
-      host,
-      distDir,
-      wsPort,
-      globalRoot: path.dirname(opts.globalConfigPath ?? ''),
-    });
+  const httpServer = startStaticServe({
+    host,
+    httpPort,
+    wsPort,
+    globalRoot: path.dirname(opts.globalConfigPath ?? ''),
+  });
+  if (httpServer) {
     const openUrl = `http://${host}:${httpPort}`;
-    httpServer?.listen(httpPort, host, () => {
+    httpServer.server.on('listening', () => {
       console.log(
         `\n  ▸ WebUI ready — open \x1b[1m${openUrl}\x1b[0m in your browser` +
           `\n    (same agent as this terminal · ws:${wsPort})\n`,
       );
       if (opts.open) openBrowser(openUrl);
     });
-  } catch (err) {
+  } else {
     console.warn(
-      `[WebUI] Frontend not served (run \`pnpm --filter @wrongstack/webui build\`): ` +
-        `${err instanceof Error ? err.message : String(err)}. WS bridge still active on ws://${host}:${wsPort}.`,
+      `[WebUI] Frontend not served (run \`pnpm --filter @wrongstack/webui build\`). ` +
+        `WS bridge still active on ws://${host}:${wsPort}.`,
     );
   }
 
@@ -1193,7 +1190,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       const unregistered = unregisterInstance(process.pid, registryBaseDir).catch((err: unknown) =>
         console.debug(`[webui-server] unregister failed: ${err}`),
       );
-      httpServer?.close();
+      httpServer?.server.close();
       wss.close(() => {
         void unregistered.then(() => {
           console.log('[WebUI] Server stopped');
@@ -2989,7 +2986,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
   function shutdown(): void {
     console.log('[WebUI] Shutting down...');
     unregisterWebuiClient();
-    httpServer?.close();
+    httpServer?.server.close();
     opts.onExit?.();
   }
 

--- a/packages/cli/src/webui-server/static-serve.ts
+++ b/packages/cli/src/webui-server/static-serve.ts
@@ -1,0 +1,69 @@
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import type { Server } from 'node:http';
+import { createHttpServer } from '@wrongstack/webui/server';
+
+/**
+ * PR 6 of Issue #30 (webui-server 8-PR refactor):
+ * dist discovery + HTTP server bring-up.
+ *
+ * Before this PR, the `runWebUI` body inlined five lines
+ * that resolved the webui package's `dist` directory via
+ * `createRequire(import.meta.url)` and handed the path to
+ * `createHttpServer`. If the webui package wasn't built,
+ * the inline try/catch silently degraded to WS-only.
+ *
+ * After this PR, the dist-resolution lives in
+ * `webui-server/static-serve.ts` and the only thing
+ * `runWebUI` does is call `startStaticServe({ host,
+ * httpPort, wsPort, globalRoot })`. The function returns
+ * the listening `Server` and its real `port` (the OS
+ * may reassign if the requested port was in use), or
+ * `null` when the webui package is unbuilt.
+ *
+ * The try/catch around the require resolution stays
+ * inside this module so the runWebUI body does not have
+ * to think about webui's build state at all.
+ */
+
+export interface StaticServeHandle {
+  server: Server;
+  port: number;
+}
+
+export interface StaticServeOptions {
+  host: string;
+  httpPort: number;
+  wsPort: number;
+  globalRoot: string;
+}
+
+export function startStaticServe(opts: StaticServeOptions): StaticServeHandle | null {
+  let distDir: string;
+  try {
+    const requireFromHere = createRequire(import.meta.url);
+    const serverEntry = requireFromHere.resolve('@wrongstack/webui/server');
+    distDir = path.resolve(path.dirname(serverEntry), '..'); // .../dist
+  } catch {
+    return null;
+  }
+
+  const server = createHttpServer({
+    host: opts.host,
+    distDir,
+    wsPort: opts.wsPort,
+    globalRoot: opts.globalRoot,
+  });
+
+  server.listen(opts.httpPort, opts.host);
+  // `createHttpServer` returns the bound port via
+  // `server.address()` after `listen` resolves. We return
+  // the requested port instead because the existing
+  // call sites pass the requested port straight into
+  // the open-browser URL — the runWebUI body has no
+  // use for the bound-port value today. If a future
+  // caller needs the actual bound port, this function
+  // is the place to expose it (e.g. via a `listening`
+  // event).
+  return { server, port: opts.httpPort };
+}

--- a/packages/cli/src/webui-server/static-serve.ts
+++ b/packages/cli/src/webui-server/static-serve.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import type { Server } from 'node:http';
-import { createHttpServer } from '@wrongstack/webui/server';
+import { type CreateHttpServerOptions, createHttpServer } from '@wrongstack/webui/server';
 
 /**
  * PR 6 of Issue #30 (webui-server 8-PR refactor):
@@ -38,17 +38,48 @@ export interface StaticServeOptions {
   globalRoot: string;
 }
 
-export function startStaticServe(opts: StaticServeOptions): StaticServeHandle | null {
-  let distDir: string;
+/**
+ * Resolve the webui package's built `dist` directory.
+ *
+ * Returns the absolute path, or `null` if the package's
+ * server entry can't be resolved (webui not built). This
+ * is the one piece of `startStaticServe` that touches the
+ * module tree, so it lives behind its own function: tests
+ * can exercise the resolution (and stub it) without
+ * binding a socket.
+ */
+export function resolveDistDir(): string | null {
   try {
     const requireFromHere = createRequire(import.meta.url);
     const serverEntry = requireFromHere.resolve('@wrongstack/webui/server');
-    distDir = path.resolve(path.dirname(serverEntry), '..'); // .../dist
+    return path.resolve(path.dirname(serverEntry), '..'); // .../dist
   } catch {
     return null;
   }
+}
 
-  const server = createHttpServer({
+/**
+ * Injectable seams for `startStaticServe`. Both default to
+ * the real implementations; tests override them to assert
+ * the wiring without resolving the webui package or binding
+ * a real port.
+ */
+export interface StaticServeDeps {
+  resolveDist?: () => string | null;
+  createServer?: (opts: CreateHttpServerOptions) => Server;
+}
+
+export function startStaticServe(
+  opts: StaticServeOptions,
+  deps: StaticServeDeps = {},
+): StaticServeHandle | null {
+  const resolveDist = deps.resolveDist ?? resolveDistDir;
+  const create = deps.createServer ?? createHttpServer;
+
+  const distDir = resolveDist();
+  if (distDir === null) return null;
+
+  const server = create({
     host: opts.host,
     distDir,
     wsPort: opts.wsPort,

--- a/packages/cli/tests/webui-server/static-serve.test.ts
+++ b/packages/cli/tests/webui-server/static-serve.test.ts
@@ -1,0 +1,105 @@
+import type { Server } from 'node:http';
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type StaticServeHandle,
+  resolveDistDir,
+  startStaticServe,
+} from '../../src/webui-server/static-serve.js';
+
+/**
+ * PR 6 of Issue #30 (webui-server 8-PR refactor):
+ * static-serve unit tests.
+ *
+ * `startStaticServe` resolves the webui `dist` dir and
+ * brings up the HTTP server, or returns null when the
+ * webui package isn't built. The two seams it touches —
+ * module resolution (`resolveDist`) and server creation
+ * (`createServer`) — are injectable, so these tests assert
+ * the wiring and the degrade-to-null path without resolving
+ * the real package or binding a real socket.
+ */
+
+/** Minimal fake http.Server: records listen() args, supports close(). */
+class FakeServer extends EventEmitter {
+  listenCalls: Array<[number, string]> = [];
+  closed = false;
+  listen(port: number, host: string): this {
+    this.listenCalls.push([port, host]);
+    return this;
+  }
+  close(): this {
+    this.closed = true;
+    return this;
+  }
+}
+
+describe('resolveDistDir', () => {
+  it('resolves the webui dist directory in the monorepo', () => {
+    const dir = resolveDistDir();
+    // The webui package is a workspace dep of the cli, so the
+    // server entry resolves and the parent dir is `.../dist`.
+    expect(dir).not.toBeNull();
+    expect(dir?.replace(/\\/g, '/')).toMatch(/\/dist$/);
+  });
+});
+
+describe('startStaticServe', () => {
+  const baseOpts = {
+    host: '127.0.0.1',
+    httpPort: 3456,
+    wsPort: 3457,
+    globalRoot: '/tmp/.wrongstack',
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when dist cannot be resolved (webui unbuilt)', () => {
+    const createServer = vi.fn();
+    const handle = startStaticServe(baseOpts, {
+      resolveDist: () => null,
+      createServer,
+    });
+    expect(handle).toBeNull();
+    // It must short-circuit before ever creating a server.
+    expect(createServer).not.toHaveBeenCalled();
+  });
+
+  it('threads options into createHttpServer and listens on httpPort/host', () => {
+    const fake = new FakeServer();
+    const createServer = vi.fn(() => fake as unknown as Server);
+
+    const handle = startStaticServe(baseOpts, {
+      resolveDist: () => '/resolved/dist',
+      createServer,
+    }) as StaticServeHandle;
+
+    expect(handle).not.toBeNull();
+    expect(createServer).toHaveBeenCalledTimes(1);
+    expect(createServer).toHaveBeenCalledWith({
+      host: '127.0.0.1',
+      distDir: '/resolved/dist',
+      wsPort: 3457,
+      globalRoot: '/tmp/.wrongstack',
+    });
+    // Binds the *http* port, not the ws port.
+    expect(fake.listenCalls).toEqual([[3456, '127.0.0.1']]);
+    // Returns the requested http port (see function doc).
+    expect(handle.port).toBe(3456);
+    expect(handle.server).toBe(fake);
+  });
+
+  it('does not swallow a real createServer failure', () => {
+    const boom = new Error('createHttpServer exploded');
+    expect(() =>
+      startStaticServe(baseOpts, {
+        resolveDist: () => '/resolved/dist',
+        createServer: () => {
+          throw boom;
+        },
+      }),
+    ).toThrow(boom);
+  });
+});

--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -97,6 +97,7 @@ export type { WSServerMessage, WSClientMessage, ConnectedClient } from './types.
 // WS port, pick free ports, and register in the shared instance registry —
 // without duplicating any of that logic.
 export { createHttpServer, buildCspHeader, injectWsPort } from './http-server.js';
+export type { CreateHttpServerOptions } from './http-server.js';
 export { findFreePort, isPortFree } from './port-utils.js';
 export { openBrowser, browserOpenCommand } from './open-browser.js';
 // Token estimator primitives — exposed for the CLI's embedded webui


### PR DESCRIPTION
PR 6 of the webui-server 8-PR refactor (Issue #30). Extracts the dist
discovery + HTTP server bring-up out of the ~3200-line `webui-server.ts`
`runWebUI` body into `webui-server/static-serve.ts`.

## What moves
- `createRequire` + `distDir` resolution + `createHttpServer` call →
  `startStaticServe()` in `webui-server/static-serve.ts`.
- `runWebUI` now calls `startStaticServe({ host, httpPort, wsPort,
  globalRoot })` and wires the open-browser callback on top; null return
  ⇒ degrade gracefully to WS-only.
- Removed unused `createRequire` / `createHttpServer` imports from
  `webui-server.ts`; two `httpServer.close()` → `httpServer.server.close()`
  call sites updated (type changed `Server | null` → `StaticServeHandle | null`).

## Follow-up included (was the open checkbox in refactor-next.md)
- Extracted `resolveDistDir(): string | null` — the only piece that
  touches the module tree — so the resolution can be tested/stubbed
  without binding a socket.
- Added injectable `StaticServeDeps` (resolveDist / createServer) seams,
  both defaulting to the real implementations (runWebUI behaviour
  unchanged).
- Re-exported `CreateHttpServerOptions` from `@wrongstack/webui/server`
  to type the injected seam.
- New `tests/webui-server/static-serve.test.ts` (4 cases): real dist
  resolution, degrade-to-null when unbuilt, option threading +
  httpPort/host listen, and that a real createServer failure is not
  swallowed.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- `pnpm --filter @wrongstack/webui typecheck` ✅
- `static-serve.test.ts` 4/4 ✅, `webui-server-baseline.test.ts` 3/3 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)