### PR TITLE
refactor(cli): extract provider ws-handlers into webui-server/ws-handlers (PR 5 of #30)

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -24,7 +24,6 @@ import {
   GlobalMailbox,
   mutatePlan,
   mutateTasks,
-  type ProviderConfig,
   projectSlug,
   recentTextTurns,
   repairToolUseAdjacency,
@@ -59,19 +58,20 @@ import {
   registerInstance,
   unregisterInstance,
 } from '@wrongstack/webui/server';
-import {
-  loadSavedProviders,
-  saveProviders,
-} from './webui-server/provider-config.js';
 import { startStaticServe } from './webui-server/static-serve.js';
-import { WebSocket, WebSocketServer } from 'ws';
 import {
-  expectDefined,
-  maskedKey,
-  normalizeKeys,
-  nowIso,
-  writeKeysBack,
-} from './provider-config-utils.js';
+  type WsHandlerContext,
+  handleKeyDelete,
+  handleKeySetActive,
+  handleKeyUpsert,
+  handleProviderAdd,
+  handleProviderModels,
+  handleProviderRemove,
+  handleProvidersList,
+  handleProvidersSaved,
+} from './webui-server/ws-handlers/index.js';
+import { WebSocket, WebSocketServer } from 'ws';
+import { expectDefined } from './provider-config-utils.js';
 
 // ── Console logger adapter for AutoPhaseWebSocketHandler ──────────────────────
 // AutoPhaseWebSocketHandler requires a Logger. The CLI uses console.log/error
@@ -1203,6 +1203,17 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     process.on('SIGTERM', shutdown);
   });
 
+  // Shared state for the extracted ws-handler groups (PR 5 of #30).
+  // `send`/`broadcast` are hoisted function declarations, so capturing
+  // them here is safe even though they're defined further down.
+  const wsHandlerCtx: WsHandlerContext = {
+    globalConfigPath: opts.globalConfigPath,
+    modelsRegistry: opts.modelsRegistry,
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
   async function handleMessage(
     ws: WebSocket,
     client: ConnectedClient,
@@ -1251,36 +1262,37 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'providers.list':
-        await handleProvidersList(ws);
+        await handleProvidersList(wsHandlerCtx, ws);
         break;
 
       case 'provider.models':
         await handleProviderModels(
+          wsHandlerCtx,
           ws,
           (msg as { payload: { providerId: string } }).payload.providerId,
         );
         break;
 
       case 'providers.saved':
-        await handleProvidersSaved(ws);
+        await handleProvidersSaved(wsHandlerCtx, ws);
         break;
 
       case 'key.add':
       case 'key.update': {
         const m = msg as { payload: { providerId: string; label: string; apiKey: string } };
-        await handleKeyUpsert(ws, m.payload.providerId, m.payload.label, m.payload.apiKey);
+        await handleKeyUpsert(wsHandlerCtx, ws, m.payload.providerId, m.payload.label, m.payload.apiKey);
         break;
       }
 
       case 'key.delete': {
         const m = msg as { payload: { providerId: string; label: string } };
-        await handleKeyDelete(ws, m.payload.providerId, m.payload.label);
+        await handleKeyDelete(wsHandlerCtx, ws, m.payload.providerId, m.payload.label);
         break;
       }
 
       case 'key.set_active': {
         const m = msg as { payload: { providerId: string; label: string } };
-        await handleKeySetActive(ws, m.payload.providerId, m.payload.label);
+        await handleKeySetActive(wsHandlerCtx, ws, m.payload.providerId, m.payload.label);
         break;
       }
 
@@ -1293,13 +1305,13 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
             apiKey?: string | undefined;
           };
         };
-        await handleProviderAdd(ws, m.payload);
+        await handleProviderAdd(wsHandlerCtx, ws, m.payload);
         break;
       }
 
       case 'provider.remove': {
         const m = msg as { payload: { providerId: string } };
-        await handleProviderRemove(ws, m.payload.providerId);
+        await handleProviderRemove(wsHandlerCtx, ws, m.payload.providerId);
         break;
       }
 
@@ -3001,238 +3013,6 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
           // — let the 'close' handler remove it from the map naturally.
         }
       }
-    }
-  }
-
-  // ---- Provider/Model/Key management handlers ----
-
-  async function handleProvidersList(ws: WebSocket): Promise<void> {
-    if (!opts.modelsRegistry) {
-      sendResult(ws, false, 'Models registry not available');
-      return;
-    }
-    try {
-      const providers = await opts.modelsRegistry.listProviders();
-      const savedProviders = await loadSavedProviders(opts.globalConfigPath);
-      const savedIds = new Set(Object.keys(savedProviders));
-
-      send(ws, {
-        type: 'provider.catalog',
-        payload: {
-          providers: providers.map((p) => ({
-            id: p.id,
-            name: p.name,
-            family: p.family,
-            apiBase: p.apiBase,
-            envVars: p.envVars,
-            modelCount: p.models.length,
-            hasApiKey: savedIds.has(p.id) || p.envVars.some((v) => !!process.env[v]),
-          })),
-        },
-      });
-    } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
-    }
-  }
-
-  async function handleProviderModels(ws: WebSocket, providerId: string): Promise<void> {
-    if (!opts.modelsRegistry) {
-      sendResult(ws, false, 'Models registry not available');
-      return;
-    }
-    try {
-      const provider = await opts.modelsRegistry.getProvider(providerId);
-      if (!provider) {
-        sendResult(ws, false, `Provider "${providerId}" not found in catalog`);
-        return;
-      }
-      send(ws, {
-        type: 'provider.models',
-        payload: {
-          provider: providerId,
-          models: provider.models.map((m) => ({
-            id: m.id,
-            name: m.name,
-            releaseDate: m.release_date,
-            contextWindow: m.limit?.context,
-            inputCost: m.cost?.input,
-            outputCost: m.cost?.output,
-            capabilities: [
-              ...(m.tool_call ? ['tools'] : []),
-              ...(m.reasoning ? ['reasoning'] : []),
-              ...(m.modalities?.input?.includes('image') ? ['vision'] : []),
-              ...(m.open_weights ? ['open_weights'] : []),
-            ],
-          })),
-        },
-      });
-    } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
-    }
-  }
-
-  async function handleProvidersSaved(ws: WebSocket): Promise<void> {
-    try {
-      const providers = await loadSavedProviders(opts.globalConfigPath);
-      send(ws, {
-        type: 'providers.saved',
-        payload: {
-          providers: Object.entries(providers).map(([id, cfg]) => ({
-            id,
-            family: cfg.family,
-            baseUrl: cfg.baseUrl,
-            apiKeys: normalizeKeys(cfg).map((k) => ({
-              label: k.label,
-              maskedKey: maskedKey(k.apiKey),
-              isActive: k.label === cfg.activeKey,
-              createdAt: k.createdAt,
-            })),
-          })),
-        },
-      });
-    } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
-    }
-  }
-
-  async function handleKeyUpsert(
-    ws: WebSocket,
-    providerId: string,
-    label: string,
-    apiKey: string,
-  ): Promise<void> {
-    try {
-      const providers = await loadSavedProviders(opts.globalConfigPath);
-      const existing = providers[providerId] ?? { type: providerId };
-      const keys = normalizeKeys(existing);
-
-      // Check if label exists
-      const existingIdx = keys.findIndex((k) => k.label === label);
-      if (existingIdx >= 0) {
-        keys[existingIdx] = { ...expectDefined(keys[existingIdx]), apiKey, createdAt: nowIso() };
-      } else {
-        keys.push({ label, apiKey, createdAt: nowIso() });
-      }
-
-      writeKeysBack(existing, keys);
-      if (!existing.activeKey) existing.activeKey = label;
-      providers[providerId] = existing;
-
-      await saveProviders(opts.globalConfigPath, providers);
-      sendResult(ws, true, `Key "${label}" saved for ${providerId}`);
-    } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
-    }
-  }
-
-  async function handleKeyDelete(ws: WebSocket, providerId: string, label: string): Promise<void> {
-    try {
-      const providers = await loadSavedProviders(opts.globalConfigPath);
-      const existing = providers[providerId];
-      if (!existing) {
-        sendResult(ws, false, `Provider "${providerId}" not found`);
-        return;
-      }
-      const keys = normalizeKeys(existing).filter((k) => k.label !== label);
-      if (keys.length === 0) {
-        delete providers[providerId];
-      } else {
-        writeKeysBack(existing, keys);
-        if (existing.activeKey === label) {
-          existing.activeKey = keys[0]?.label;
-        }
-        providers[providerId] = existing;
-      }
-      await saveProviders(opts.globalConfigPath, providers);
-      sendResult(ws, true, `Key "${label}" deleted from ${providerId}`);
-    } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
-    }
-  }
-
-  async function handleKeySetActive(
-    ws: WebSocket,
-    providerId: string,
-    label: string,
-  ): Promise<void> {
-    try {
-      const providers = await loadSavedProviders(opts.globalConfigPath);
-      const existing = providers[providerId];
-      if (!existing) {
-        sendResult(ws, false, `Provider "${providerId}" not found`);
-        return;
-      }
-      existing.activeKey = label;
-      writeKeysBack(existing, normalizeKeys(existing));
-      providers[providerId] = existing;
-      await saveProviders(opts.globalConfigPath, providers);
-      sendResult(ws, true, `Active key for ${providerId} set to "${label}"`);
-    } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
-    }
-  }
-
-  async function handleProviderAdd(
-    ws: WebSocket,
-    payload: {
-      id: string;
-      family: string;
-      baseUrl?: string | undefined;
-      apiKey?: string | undefined;
-    },
-  ): Promise<void> {
-    try {
-      const providers = await loadSavedProviders(opts.globalConfigPath);
-      if (providers[payload.id]) {
-        sendResult(ws, false, `Provider "${payload.id}" already exists. Use key.add to add a key.`);
-        return;
-      }
-      const newProv: ProviderConfig = {
-        type: payload.id,
-        family: payload.family as ProviderConfig['family'],
-        baseUrl: payload.baseUrl,
-      };
-      if (payload.apiKey) {
-        newProv.apiKeys = [{ label: 'default', apiKey: payload.apiKey, createdAt: nowIso() }];
-        newProv.activeKey = 'default';
-      }
-      providers[payload.id] = newProv;
-      await saveProviders(opts.globalConfigPath, providers);
-      sendResult(ws, true, `Provider "${payload.id}" added`);
-      console.log(`[WebUI] Provider "${payload.id}" added via provider.add`);
-      broadcast({
-        type: 'providers.saved',
-        payload: {
-          providers: Object.entries(providers).map(([id, cfg]) => ({
-            id,
-            family: cfg.family,
-            baseUrl: cfg.baseUrl,
-            apiKeys: normalizeKeys(cfg).map((k) => ({
-              label: k.label,
-              maskedKey: maskedKey(k.apiKey),
-              isActive: k.label === cfg.activeKey,
-              createdAt: k.createdAt,
-            })),
-          })),
-        },
-      });
-    } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
-    }
-  }
-
-  async function handleProviderRemove(ws: WebSocket, providerId: string): Promise<void> {
-    try {
-      const providers = await loadSavedProviders(opts.globalConfigPath);
-      if (!providers[providerId]) {
-        sendResult(ws, false, `Provider "${providerId}" not found`);
-        return;
-      }
-      delete providers[providerId];
-      await saveProviders(opts.globalConfigPath, providers);
-      sendResult(ws, true, `Provider "${providerId}" removed`);
-    } catch (err) {
-      sendResult(ws, false, err instanceof Error ? err.message : String(err));
     }
   }
 

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -1,0 +1,55 @@
+import type { ModelsRegistry } from '@wrongstack/core';
+import type { WebSocket } from 'ws';
+
+/**
+ * PR 5 of Issue #30 (webui-server 8-PR refactor): ws-handlers/.
+ *
+ * The WebSocket message handlers used to live as closures inside
+ * `runWebUI`, capturing `opts`, `send`, `broadcast`, etc. directly.
+ * To move them into their own topic files we replace every closure
+ * capture with a field on `WsHandlerContext`, built once in
+ * `runWebUI` and threaded explicitly into each handler — no hidden
+ * captures.
+ */
+
+/**
+ * Server→client message shape. Mirrors `WSServerMessage` in
+ * webui-server.ts; duplicated here (rather than imported) so the
+ * ws-handlers modules never import back from webui-server.ts and
+ * create a cycle.
+ */
+export interface WsServerMessage {
+  type: string;
+  payload: unknown;
+}
+
+/**
+ * Shared state threaded explicitly into every ws-handler group.
+ *
+ * Only the dependencies the extracted handlers actually use live
+ * here. As more handler groups move out of webui-server.ts (sessions,
+ * mailbox, …) this context grows the fields they need.
+ */
+export interface WsHandlerContext {
+  /** Path to the global config (~/.wrongstack/config.json) — provider keys live here. */
+  globalConfigPath: string | undefined;
+  /** Models registry backing the provider/model catalog (optional). */
+  modelsRegistry: ModelsRegistry | undefined;
+  /** Send one message to a single socket (no-op if the socket isn't OPEN). */
+  send: (ws: WebSocket, msg: WsServerMessage) => void;
+  /** Broadcast a message to every connected socket. */
+  broadcast: (msg: WsServerMessage) => void;
+  /** console.log adapter, so handlers don't reach for the global directly. */
+  log: (msg: string) => void;
+}
+
+export {
+  handleKeyDelete,
+  handleKeySetActive,
+  handleKeyUpsert,
+  handleProviderAdd,
+  handleProviderModels,
+  handleProviderRemove,
+  handleProvidersList,
+  handleProvidersSaved,
+} from './providers.js';

--- a/packages/cli/src/webui-server/ws-handlers/providers.ts
+++ b/packages/cli/src/webui-server/ws-handlers/providers.ts
@@ -1,0 +1,280 @@
+import type { ProviderConfig } from '@wrongstack/core';
+import type { WebSocket } from 'ws';
+import {
+  expectDefined,
+  maskedKey,
+  normalizeKeys,
+  nowIso,
+  writeKeysBack,
+} from '../../provider-config-utils.js';
+import { loadSavedProviders, saveProviders } from '../provider-config.js';
+import type { WsHandlerContext } from './index.js';
+
+/**
+ * PR 5 of Issue #30: provider / model / API-key WebSocket handlers.
+ *
+ * Extracted verbatim from the `runWebUI` closure in webui-server.ts.
+ * Every former closure capture (`opts.modelsRegistry`,
+ * `opts.globalConfigPath`, `send`, `broadcast`, `console.log`) is now a
+ * field on `ctx: WsHandlerContext` — no hidden state.
+ */
+
+/**
+ * Module-private result helper. webui-server.ts keeps its own
+ * `sendResult` (used by ~80 other switch cases); this is the
+ * provider-group copy so these handlers don't depend on it.
+ */
+function sendResult(ctx: WsHandlerContext, ws: WebSocket, success: boolean, message: string): void {
+  ctx.send(ws, { type: 'key.operation_result', payload: { success, message } });
+}
+
+export async function handleProvidersList(ctx: WsHandlerContext, ws: WebSocket): Promise<void> {
+  if (!ctx.modelsRegistry) {
+    sendResult(ctx, ws, false, 'Models registry not available');
+    return;
+  }
+  try {
+    const providers = await ctx.modelsRegistry.listProviders();
+    const savedProviders = await loadSavedProviders(ctx.globalConfigPath);
+    const savedIds = new Set(Object.keys(savedProviders));
+
+    ctx.send(ws, {
+      type: 'provider.catalog',
+      payload: {
+        providers: providers.map((p) => ({
+          id: p.id,
+          name: p.name,
+          family: p.family,
+          apiBase: p.apiBase,
+          envVars: p.envVars,
+          modelCount: p.models.length,
+          hasApiKey: savedIds.has(p.id) || p.envVars.some((v) => !!process.env[v]),
+        })),
+      },
+    });
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleProviderModels(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  providerId: string,
+): Promise<void> {
+  if (!ctx.modelsRegistry) {
+    sendResult(ctx, ws, false, 'Models registry not available');
+    return;
+  }
+  try {
+    const provider = await ctx.modelsRegistry.getProvider(providerId);
+    if (!provider) {
+      sendResult(ctx, ws, false, `Provider "${providerId}" not found in catalog`);
+      return;
+    }
+    ctx.send(ws, {
+      type: 'provider.models',
+      payload: {
+        provider: providerId,
+        models: provider.models.map((m) => ({
+          id: m.id,
+          name: m.name,
+          releaseDate: m.release_date,
+          contextWindow: m.limit?.context,
+          inputCost: m.cost?.input,
+          outputCost: m.cost?.output,
+          capabilities: [
+            ...(m.tool_call ? ['tools'] : []),
+            ...(m.reasoning ? ['reasoning'] : []),
+            ...(m.modalities?.input?.includes('image') ? ['vision'] : []),
+            ...(m.open_weights ? ['open_weights'] : []),
+          ],
+        })),
+      },
+    });
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleProvidersSaved(ctx: WsHandlerContext, ws: WebSocket): Promise<void> {
+  try {
+    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    ctx.send(ws, {
+      type: 'providers.saved',
+      payload: {
+        providers: Object.entries(providers).map(([id, cfg]) => ({
+          id,
+          family: cfg.family,
+          baseUrl: cfg.baseUrl,
+          apiKeys: normalizeKeys(cfg).map((k) => ({
+            label: k.label,
+            maskedKey: maskedKey(k.apiKey),
+            isActive: k.label === cfg.activeKey,
+            createdAt: k.createdAt,
+          })),
+        })),
+      },
+    });
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleKeyUpsert(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  providerId: string,
+  label: string,
+  apiKey: string,
+): Promise<void> {
+  try {
+    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    const existing = providers[providerId] ?? { type: providerId };
+    const keys = normalizeKeys(existing);
+
+    // Check if label exists
+    const existingIdx = keys.findIndex((k) => k.label === label);
+    if (existingIdx >= 0) {
+      keys[existingIdx] = { ...expectDefined(keys[existingIdx]), apiKey, createdAt: nowIso() };
+    } else {
+      keys.push({ label, apiKey, createdAt: nowIso() });
+    }
+
+    writeKeysBack(existing, keys);
+    if (!existing.activeKey) existing.activeKey = label;
+    providers[providerId] = existing;
+
+    await saveProviders(ctx.globalConfigPath, providers);
+    sendResult(ctx, ws, true, `Key "${label}" saved for ${providerId}`);
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleKeyDelete(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  providerId: string,
+  label: string,
+): Promise<void> {
+  try {
+    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    const existing = providers[providerId];
+    if (!existing) {
+      sendResult(ctx, ws, false, `Provider "${providerId}" not found`);
+      return;
+    }
+    const keys = normalizeKeys(existing).filter((k) => k.label !== label);
+    if (keys.length === 0) {
+      delete providers[providerId];
+    } else {
+      writeKeysBack(existing, keys);
+      if (existing.activeKey === label) {
+        existing.activeKey = keys[0]?.label;
+      }
+      providers[providerId] = existing;
+    }
+    await saveProviders(ctx.globalConfigPath, providers);
+    sendResult(ctx, ws, true, `Key "${label}" deleted from ${providerId}`);
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleKeySetActive(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  providerId: string,
+  label: string,
+): Promise<void> {
+  try {
+    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    const existing = providers[providerId];
+    if (!existing) {
+      sendResult(ctx, ws, false, `Provider "${providerId}" not found`);
+      return;
+    }
+    existing.activeKey = label;
+    writeKeysBack(existing, normalizeKeys(existing));
+    providers[providerId] = existing;
+    await saveProviders(ctx.globalConfigPath, providers);
+    sendResult(ctx, ws, true, `Active key for ${providerId} set to "${label}"`);
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleProviderAdd(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  payload: {
+    id: string;
+    family: string;
+    baseUrl?: string | undefined;
+    apiKey?: string | undefined;
+  },
+): Promise<void> {
+  try {
+    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    if (providers[payload.id]) {
+      sendResult(
+        ctx,
+        ws,
+        false,
+        `Provider "${payload.id}" already exists. Use key.add to add a key.`,
+      );
+      return;
+    }
+    const newProv: ProviderConfig = {
+      type: payload.id,
+      family: payload.family as ProviderConfig['family'],
+      baseUrl: payload.baseUrl,
+    };
+    if (payload.apiKey) {
+      newProv.apiKeys = [{ label: 'default', apiKey: payload.apiKey, createdAt: nowIso() }];
+      newProv.activeKey = 'default';
+    }
+    providers[payload.id] = newProv;
+    await saveProviders(ctx.globalConfigPath, providers);
+    sendResult(ctx, ws, true, `Provider "${payload.id}" added`);
+    ctx.log(`[WebUI] Provider "${payload.id}" added via provider.add`);
+    ctx.broadcast({
+      type: 'providers.saved',
+      payload: {
+        providers: Object.entries(providers).map(([id, cfg]) => ({
+          id,
+          family: cfg.family,
+          baseUrl: cfg.baseUrl,
+          apiKeys: normalizeKeys(cfg).map((k) => ({
+            label: k.label,
+            maskedKey: maskedKey(k.apiKey),
+            isActive: k.label === cfg.activeKey,
+            createdAt: k.createdAt,
+          })),
+        })),
+      },
+    });
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleProviderRemove(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  providerId: string,
+): Promise<void> {
+  try {
+    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    if (!providers[providerId]) {
+      sendResult(ctx, ws, false, `Provider "${providerId}" not found`);
+      return;
+    }
+    delete providers[providerId];
+    await saveProviders(ctx.globalConfigPath, providers);
+    sendResult(ctx, ws, true, `Provider "${providerId}" removed`);
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}

--- a/packages/cli/tests/webui-server/ws-handlers-providers.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-providers.test.ts
@@ -1,0 +1,179 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import { loadSavedProviders } from '../../src/webui-server/provider-config.js';
+import type {
+  WsHandlerContext,
+  WsServerMessage,
+} from '../../src/webui-server/ws-handlers/index.js';
+import {
+  handleKeyDelete,
+  handleKeySetActive,
+  handleKeyUpsert,
+  handleProviderAdd,
+  handleProviderRemove,
+  handleProvidersList,
+  handleProvidersSaved,
+} from '../../src/webui-server/ws-handlers/index.js';
+
+/**
+ * PR 5 of Issue #30 (webui-server 8-PR refactor):
+ * provider ws-handler unit tests.
+ *
+ * The handlers used to be closures inside runWebUI; now they take an
+ * explicit `WsHandlerContext`. These tests drive them with a fake
+ * context (capturing send/broadcast) over a temp config dir, so they
+ * exercise the real provider-config IO + cipher stack without a live
+ * WebSocket or models registry.
+ */
+
+const FAKE_WS = {} as WebSocket;
+
+interface Captured {
+  sent: WsServerMessage[];
+  broadcasts: WsServerMessage[];
+  logs: string[];
+}
+
+function makeCtx(
+  globalConfigPath: string | undefined,
+  modelsRegistry?: WsHandlerContext['modelsRegistry'],
+): { ctx: WsHandlerContext; cap: Captured } {
+  const cap: Captured = { sent: [], broadcasts: [], logs: [] };
+  const ctx: WsHandlerContext = {
+    globalConfigPath,
+    modelsRegistry,
+    send: (_ws, msg) => cap.sent.push(msg),
+    broadcast: (msg) => cap.broadcasts.push(msg),
+    log: (m) => cap.logs.push(m),
+  };
+  return { ctx, cap };
+}
+
+const lastResult = (cap: Captured): { success: boolean; message: string } =>
+  cap.sent
+    .filter((m) => m.type === 'key.operation_result')
+    .map((m) => m.payload as { success: boolean; message: string })
+    .at(-1) as { success: boolean; message: string };
+
+let tmpDir = '';
+let configPath = '';
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wstack-pr5-'));
+  configPath = path.join(tmpDir, 'config.json');
+});
+
+afterEach(async () => {
+  if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+  tmpDir = '';
+  configPath = '';
+});
+
+describe('ws-handlers/providers (PR 5 of #30)', () => {
+  it('handleProvidersList: errors when no models registry', async () => {
+    const { ctx, cap } = makeCtx(configPath, undefined);
+    await handleProvidersList(ctx, FAKE_WS);
+    expect(lastResult(cap)).toEqual({ success: false, message: 'Models registry not available' });
+  });
+
+  it('handleProviderModels: errors when no models registry', async () => {
+    const { ctx, cap } = makeCtx(configPath, undefined);
+    await handleProvidersList(ctx, FAKE_WS);
+    expect(lastResult(cap).success).toBe(false);
+  });
+
+  it('handleProvidersSaved: empty config → empty providers list', async () => {
+    const { ctx, cap } = makeCtx(configPath);
+    await handleProvidersSaved(ctx, FAKE_WS);
+    const msg = cap.sent.find((m) => m.type === 'providers.saved');
+    expect(msg).toBeDefined();
+    expect((msg?.payload as { providers: unknown[] }).providers).toEqual([]);
+  });
+
+  it('handleProviderAdd: persists provider, broadcasts providers.saved, reports success', async () => {
+    const { ctx, cap } = makeCtx(configPath);
+    await handleProviderAdd(ctx, FAKE_WS, {
+      id: 'custom',
+      family: 'openai-compatible',
+      baseUrl: 'https://example.com/v1',
+      apiKey: 'sk-secret',
+    });
+
+    expect(lastResult(cap).success).toBe(true);
+    // Broadcast went out so other tabs refresh.
+    expect(cap.broadcasts.some((m) => m.type === 'providers.saved')).toBe(true);
+    // Logged the add.
+    expect(cap.logs.join('\n')).toContain('provider.add');
+
+    // Persisted to disk (encrypted) and reloadable.
+    const saved = await loadSavedProviders(configPath);
+    expect(saved.custom).toBeDefined();
+    expect(saved.custom?.activeKey).toBe('default');
+  });
+
+  it('handleProviderAdd: refuses duplicate id', async () => {
+    const { ctx } = makeCtx(configPath);
+    await handleProviderAdd(ctx, FAKE_WS, { id: 'dup', family: 'openai-compatible' });
+    const { ctx: ctx2, cap: cap2 } = makeCtx(configPath);
+    await handleProviderAdd(ctx2, FAKE_WS, { id: 'dup', family: 'openai-compatible' });
+    expect(lastResult(cap2).success).toBe(false);
+    expect(lastResult(cap2).message).toContain('already exists');
+  });
+
+  it('key lifecycle: upsert → set_active → masked in saved → delete', async () => {
+    // Seed a provider record.
+    const seed = makeCtx(configPath);
+    await handleProviderAdd(seed.ctx, FAKE_WS, { id: 'acme', family: 'openai-compatible' });
+
+    // Add a second key.
+    const add = makeCtx(configPath);
+    await handleKeyUpsert(add.ctx, FAKE_WS, 'acme', 'work', 'sk-work-key');
+    expect(lastResult(add.cap).success).toBe(true);
+
+    // Make it active.
+    const active = makeCtx(configPath);
+    await handleKeySetActive(active.ctx, FAKE_WS, 'acme', 'work');
+    expect(lastResult(active.cap).success).toBe(true);
+
+    // providers.saved masks the key (never returns the plaintext).
+    const saved = makeCtx(configPath);
+    await handleProvidersSaved(saved.ctx, FAKE_WS);
+    const payload = saved.cap.sent.find((m) => m.type === 'providers.saved')?.payload as {
+      providers: Array<{
+        id: string;
+        apiKeys: Array<{ label: string; maskedKey: string; isActive: boolean }>;
+      }>;
+    };
+    const acme = payload.providers.find((p) => p.id === 'acme');
+    const work = acme?.apiKeys.find((k) => k.label === 'work');
+    expect(work?.isActive).toBe(true);
+    expect(work?.maskedKey).not.toContain('sk-work-key');
+
+    // Delete the key.
+    const del = makeCtx(configPath);
+    await handleKeyDelete(del.ctx, FAKE_WS, 'acme', 'work');
+    expect(lastResult(del.cap).success).toBe(true);
+  });
+
+  it('handleProviderRemove: deletes the provider', async () => {
+    const seed = makeCtx(configPath);
+    await handleProviderAdd(seed.ctx, FAKE_WS, { id: 'gone', family: 'openai-compatible' });
+
+    const rm = makeCtx(configPath);
+    await handleProviderRemove(rm.ctx, FAKE_WS, 'gone');
+    expect(lastResult(rm.cap).success).toBe(true);
+
+    const saved = await loadSavedProviders(configPath);
+    expect(saved.gone).toBeUndefined();
+  });
+
+  it('handleProviderRemove: errors on unknown provider', async () => {
+    const { ctx, cap } = makeCtx(configPath);
+    await handleProviderRemove(ctx, FAKE_WS, 'nope');
+    expect(lastResult(cap).success).toBe(false);
+    expect(lastResult(cap).message).toContain('not found');
+  });
+});


### PR DESCRIPTION
PR 5 of the webui-server 8-PR refactor (Issue #30) — the start of the
ws-handlers extraction. Moves the largest cleanly-separable WebSocket
handler group (provider / model / API-key) out of the ~3200-line
`runWebUI` closure and establishes the `WsHandlerContext` seam the rest
of the extraction builds on.

## What moves
- **`webui-server/ws-handlers/index.ts`** — `WsHandlerContext`, the
  explicit shared-state interface that replaces closure captures
  (`globalConfigPath`, `modelsRegistry`, `send`, `broadcast`, `log`).
- **`webui-server/ws-handlers/providers.ts`** — the 8 handlers
  (`handleProvidersList`/`ProviderModels`/`ProvidersSaved`/`KeyUpsert`/
  `KeyDelete`/`KeySetActive`/`ProviderAdd`/`ProviderRemove`), moved
  verbatim with closure captures swapped for `ctx` fields.
- **`webui-server.ts`** — builds `wsHandlerCtx` once; the 8 switch cases
  call the imported handlers; the 232-line block is deleted; now-unused
  imports dropped. **Net −220 lines.**

## Tests
New `tests/webui-server/ws-handlers-providers.test.ts` (8 cases): drives
the handlers with a fake context over a temp config dir — exercises the
real provider-config IO + cipher stack with no live socket/registry:
no-registry errors, add→broadcast→persist, duplicate refusal, full key
lifecycle (upsert→set_active→masked-in-saved→delete), and remove paths.

## Scope note (deferred groups)
The other doc-listed groups are intentionally **not** in this PR:
`memory`/`files`/`mailbox`/`shell` cases already delegate to the shared
`@wrongstack/webui/server` handlers, and the remaining inline cases
(`sessions`/`context`/`brain`/…) are coupled to ~25 closure variables
with no unit coverage. Extracting those safely needs its own test-first
PR rather than being rushed into this one. Tracked in the refactor notes.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- webui-server suite (8 files) **47/47** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)