### PR TITLE
refactor(cli): extract process lifecycle into webui-server/lifecycle.ts (PR 7 of #30)

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -54,10 +54,13 @@ import {
   handleMemoryList,
   handleMemoryRemember,
   handleShellOpen,
-  openBrowser,
-  registerInstance,
-  unregisterInstance,
 } from '@wrongstack/webui/server';
+import {
+  announceWebuiReady,
+  createWebuiShutdown,
+  registerWebuiInstance,
+  registerWebuiSignalHandlers,
+} from './webui-server/lifecycle.js';
 import { startStaticServe } from './webui-server/static-serve.js';
 import {
   type WsHandlerContext,
@@ -587,13 +590,12 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     globalRoot: path.dirname(opts.globalConfigPath ?? ''),
   });
   if (httpServer) {
-    const openUrl = `http://${host}:${httpPort}`;
-    httpServer.server.on('listening', () => {
-      console.log(
-        `\n  ▸ WebUI ready — open \x1b[1m${openUrl}\x1b[0m in your browser` +
-          `\n    (same agent as this terminal · ws:${wsPort})\n`,
-      );
-      if (opts.open) openBrowser(openUrl);
+    announceWebuiReady({
+      server: httpServer.server,
+      host,
+      httpPort,
+      wsPort,
+      open: !!opts.open,
     });
   } else {
     console.warn(
@@ -606,19 +608,15 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
   // ~/.wrongstack/webui-instances.json alongside standalone instances.
   const registryBaseDir = opts.globalConfigPath ? path.dirname(opts.globalConfigPath) : undefined;
   if (opts.projectRoot) {
-    void registerInstance(
-      {
-        pid: process.pid,
-        httpPort,
-        wsPort,
-        host,
-        projectRoot: opts.projectRoot,
-        projectName: path.basename(opts.projectRoot) || opts.projectRoot,
-        startedAt: new Date().toISOString(),
-        url: `http://${host}:${httpPort}`,
-      },
+    registerWebuiInstance({
+      pid: process.pid,
+      host,
+      httpPort,
+      wsPort,
+      projectRoot: opts.projectRoot,
+      startedAt: new Date().toISOString(),
       registryBaseDir,
-    ).catch(() => {});
+    });
   }
   // Auth token is sent to clients via the session.start payload — do NOT log it.
 
@@ -1154,53 +1152,42 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       );
     });
 
-    // Graceful shutdown. Idempotent: every runWebUI call registers its own
-    // SIGINT/SIGTERM handlers, so a signal after this server already stopped
-    // (multiple servers per process — tests, /webui restarts) must not
-    // re-run teardown or fire a second unregister against a gone registry.
-    let shutdownStarted = false;
-    function shutdown() {
-      if (shutdownStarted) return;
-      shutdownStarted = true;
-      process.off('SIGINT', shutdown);
-      process.off('SIGTERM', shutdown);
-      console.log('[WebUI] Shutting down...');
-      // Abort every in-flight run before closing clients. Without this, a run
-      // mid-iteration at SIGINT/SIGTERM continues to completion on a now-dead
-      // webui (wasted provider spend; the eventual `run.result` is sent to
-      // nobody because clients are about to close). Both the legacy single
-      // slot (project-switch path) and every per-socket controller must be
-      // aborted — they are independent.
-      if (abortController) {
-        abortController.abort();
-        abortController = null;
-      }
-      for (const c of abortControllers.values()) {
-        c.abort();
-      }
-      abortControllers.clear();
-      for (const unsub of eventUnsubscribers) unsub();
-      for (const [ws] of clients) {
-        ws.close();
-      }
-      clients.clear();
-      // Drop ourselves from the running-instance registry; the run promise
-      // resolves only after the write settles so callers can safely remove
-      // the registry directory once runWebUI's promise resolves.
-      const unregistered = unregisterInstance(process.pid, registryBaseDir).catch((err: unknown) =>
-        console.debug(`[webui-server] unregister failed: ${err}`),
-      );
-      httpServer?.server.close();
-      wss.close(() => {
-        void unregistered.then(() => {
-          console.log('[WebUI] Server stopped');
-          resolve();
-        });
-      });
-    }
+    // Graceful shutdown (extracted to webui-server/lifecycle.ts, PR 7 of
+    // #30). Idempotent: every runWebUI call registers its own SIGINT/SIGTERM
+    // handlers, so a signal after this server already stopped (multiple
+    // servers per process — tests, /webui restarts) must not re-run teardown
+    // or fire a second unregister against a gone registry. The teardown
+    // sequence (abort in-flight runs → unsubscribe events → close clients →
+    // unregister → close HTTP/WS → resolve) lives in lifecycle.ts; the
+    // run-loop state stays here and is threaded in as callbacks.
+    const signalShutdown = createWebuiShutdown({
+      abortInFlight: () => {
+        // Both the legacy single slot (project-switch path) and every
+        // per-socket controller must be aborted — they are independent.
+        if (abortController) {
+          abortController.abort();
+          abortController = null;
+        }
+        for (const c of abortControllers.values()) c.abort();
+        abortControllers.clear();
+      },
+      unsubscribeEvents: () => {
+        for (const unsub of eventUnsubscribers) unsub();
+      },
+      closeClients: () => {
+        for (const [ws] of clients) ws.close();
+        clients.clear();
+      },
+      closeHttpServer: () => {
+        httpServer?.server.close();
+      },
+      wss,
+      pid: process.pid,
+      registryBaseDir,
+      onStopped: resolve,
+    });
 
-    process.on('SIGINT', shutdown);
-    process.on('SIGTERM', shutdown);
+    registerWebuiSignalHandlers(signalShutdown);
   });
 
   // Shared state for the extracted ws-handler groups (PR 5 of #30).

--- a/packages/cli/src/webui-server/lifecycle.ts
+++ b/packages/cli/src/webui-server/lifecycle.ts
@@ -1,0 +1,186 @@
+import * as path from 'node:path';
+import {
+  openBrowser,
+  registerInstance,
+  unregisterInstance,
+  type WebUIInstanceRecord,
+} from '@wrongstack/webui/server';
+
+/**
+ * PR 7 of Issue #30 (webui-server 8-PR refactor): process lifecycle.
+ *
+ * Three concerns pulled out of the ~3000-line `runWebUI` body:
+ *
+ *   - `registerWebuiInstance` — record this embedded WebUI in the shared
+ *     running-instance registry (so `webui --list` sees it).
+ *   - `announceWebuiReady` — log the ready banner and pop the browser
+ *     once the HTTP server is listening.
+ *   - `createWebuiShutdown` + `registerWebuiSignalHandlers` — the
+ *     SIGINT/SIGTERM teardown sequence.
+ *
+ * Each external dependency (registry IO, browser launch) is an
+ * injectable seam so the orchestration can be unit-tested without
+ * touching disk or spawning a browser. Run-loop state (abort
+ * controllers, client map, the run promise's `resolve`) stays in
+ * `webui-server.ts` and is threaded in as callbacks — the module never
+ * captures it.
+ */
+
+// ── Instance registry ────────────────────────────────────────────────
+
+export interface RegisterWebuiInstanceParams {
+  pid: number;
+  host: string;
+  httpPort: number;
+  wsPort: number;
+  projectRoot: string;
+  /** ISO timestamp when the instance registered. */
+  startedAt: string;
+  /** Registry base dir (dirname of globalConfigPath); undefined ⇒ registry default. */
+  registryBaseDir: string | undefined;
+}
+
+export interface RegisterWebuiInstanceDeps {
+  registerFn?: (record: WebUIInstanceRecord, baseDir?: string) => Promise<void>;
+}
+
+/**
+ * Fire-and-forget registration of this WebUI in the running-instance
+ * registry. Best-effort: a registry write error never blocks startup and
+ * is swallowed (the registry is a convenience index, not a source of
+ * truth). Caller guards on `projectRoot` being known.
+ */
+export function registerWebuiInstance(
+  p: RegisterWebuiInstanceParams,
+  deps: RegisterWebuiInstanceDeps = {},
+): void {
+  const register = deps.registerFn ?? registerInstance;
+  void register(
+    {
+      pid: p.pid,
+      httpPort: p.httpPort,
+      wsPort: p.wsPort,
+      host: p.host,
+      projectRoot: p.projectRoot,
+      projectName: path.basename(p.projectRoot) || p.projectRoot,
+      startedAt: p.startedAt,
+      url: `http://${p.host}:${p.httpPort}`,
+    },
+    p.registryBaseDir,
+  ).catch(() => {});
+}
+
+// ── Ready banner + open browser ──────────────────────────────────────
+
+export interface AnnounceWebuiReadyParams {
+  /** The HTTP server (StaticServeHandle.server). */
+  server: { on: (event: 'listening', cb: () => void) => void };
+  host: string;
+  httpPort: number;
+  wsPort: number;
+  open: boolean;
+  log?: (msg: string) => void;
+  openBrowserFn?: (url: string) => void;
+}
+
+/**
+ * Once the HTTP server is listening, print the ready banner and (if
+ * `open`) launch the browser at the served URL.
+ */
+export function announceWebuiReady(p: AnnounceWebuiReadyParams): void {
+  const log = p.log ?? ((m: string) => console.log(m));
+  const launch = p.openBrowserFn ?? openBrowser;
+  const openUrl = `http://${p.host}:${p.httpPort}`;
+  p.server.on('listening', () => {
+    log(
+      `\n  ▸ WebUI ready — open \x1b[1m${openUrl}\x1b[0m in your browser` +
+        `\n    (same agent as this terminal · ws:${p.wsPort})\n`,
+    );
+    if (p.open) launch(openUrl);
+  });
+}
+
+// ── Graceful shutdown (SIGINT/SIGTERM) ───────────────────────────────
+
+export interface WebuiShutdownResources {
+  /** Abort every in-flight run (legacy single slot + per-socket controllers) and clear them. */
+  abortInFlight: () => void;
+  /** Run and drop every event-bus unsubscriber. */
+  unsubscribeEvents: () => void;
+  /** Close every connected socket and clear the client map. */
+  closeClients: () => void;
+  /** Close the static HTTP server (no-op when WS-only). */
+  closeHttpServer: () => void;
+  /** The WebSocket server to stop (its close callback resolves the run promise). */
+  wss: { close: (cb?: () => void) => void };
+  /** This process's pid — the registry liveness key. */
+  pid: number;
+  /** Registry base dir (undefined ⇒ registry default). */
+  registryBaseDir: string | undefined;
+  /** Called once teardown settles — wired to the run promise's `resolve`. */
+  onStopped: () => void;
+  log?: (msg: string) => void;
+  debug?: (msg: string) => void;
+  /** Injectable for tests; defaults to the real registry unregister. */
+  unregisterFn?: (pid: number, baseDir?: string) => Promise<void>;
+}
+
+/**
+ * Build the SIGINT/SIGTERM teardown handler. The returned function is
+ * idempotent: the first call runs the teardown, later calls (e.g. a
+ * second Ctrl+C, or a signal after another server in the same process
+ * already stopped) return immediately.
+ *
+ * Order matches the original inline handler: abort runs → unsubscribe
+ * events → close clients → unregister from the instance registry (async,
+ * awaited inside the wss.close callback) → close HTTP → close WS → on
+ * close, once the unregister settles, `onStopped()`.
+ */
+export function createWebuiShutdown(res: WebuiShutdownResources): () => void {
+  const log = res.log ?? ((m: string) => console.log(m));
+  const debug = res.debug ?? ((m: string) => console.debug(m));
+  const unregister = res.unregisterFn ?? unregisterInstance;
+  let started = false;
+
+  return () => {
+    if (started) return;
+    started = true;
+    log('[WebUI] Shutting down...');
+    res.abortInFlight();
+    res.unsubscribeEvents();
+    res.closeClients();
+    // Drop ourselves from the running-instance registry; the run promise
+    // resolves only after the write settles so callers can safely remove
+    // the registry directory once runWebUI's promise resolves.
+    const unregistered = unregister(res.pid, res.registryBaseDir).catch((err: unknown) =>
+      debug(`[webui-server] unregister failed: ${err}`),
+    );
+    res.closeHttpServer();
+    res.wss.close(() => {
+      void unregistered.then(() => {
+        log('[WebUI] Server stopped');
+        res.onStopped();
+      });
+    });
+  };
+}
+
+/**
+ * Register `shutdown` on SIGINT and SIGTERM. The wrapper self-detaches
+ * both listeners on first fire (so a server that has already shut down
+ * can't re-trigger teardown). Returns an unregister function for tests
+ * and clean restarts.
+ */
+export function registerWebuiSignalHandlers(shutdown: () => void): () => void {
+  const handler = (): void => {
+    process.off('SIGINT', handler);
+    process.off('SIGTERM', handler);
+    shutdown();
+  };
+  process.on('SIGINT', handler);
+  process.on('SIGTERM', handler);
+  return () => {
+    process.off('SIGINT', handler);
+    process.off('SIGTERM', handler);
+  };
+}

--- a/packages/cli/tests/webui-server/lifecycle.test.ts
+++ b/packages/cli/tests/webui-server/lifecycle.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  announceWebuiReady,
+  createWebuiShutdown,
+  registerWebuiInstance,
+  registerWebuiSignalHandlers,
+  type WebUIInstanceRecord,
+} from '../../src/webui-server/lifecycle.js';
+
+/**
+ * PR 7 of Issue #30 (webui-server 8-PR refactor): lifecycle unit tests.
+ *
+ * The three lifecycle concerns pulled out of runWebUI — instance
+ * registration, the ready/open-browser banner, and SIGINT/SIGTERM
+ * teardown — are driven here through their injectable seams, with no
+ * disk IO, no browser launch, and no real process signal.
+ */
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('registerWebuiInstance', () => {
+  it('builds the registry record (basename projectName + url) and passes baseDir', async () => {
+    const calls: Array<{ record: WebUIInstanceRecord; baseDir?: string }> = [];
+    registerWebuiInstance(
+      {
+        pid: 1234,
+        host: '127.0.0.1',
+        httpPort: 3456,
+        wsPort: 3457,
+        projectRoot: '/home/me/projects/acme',
+        startedAt: '2026-06-13T00:00:00.000Z',
+        registryBaseDir: '/cfg',
+      },
+      { registerFn: async (record, baseDir) => void calls.push({ record, baseDir }) },
+    );
+    // fire-and-forget — let the microtask run
+    await Promise.resolve();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.baseDir).toBe('/cfg');
+    expect(calls[0]?.record).toMatchObject({
+      pid: 1234,
+      httpPort: 3456,
+      wsPort: 3457,
+      host: '127.0.0.1',
+      projectRoot: '/home/me/projects/acme',
+      projectName: 'acme',
+      startedAt: '2026-06-13T00:00:00.000Z',
+      url: 'http://127.0.0.1:3456',
+    });
+  });
+
+  it('swallows registry write failures (best-effort)', async () => {
+    expect(() =>
+      registerWebuiInstance(
+        {
+          pid: 1,
+          host: '127.0.0.1',
+          httpPort: 1,
+          wsPort: 2,
+          projectRoot: '/x',
+          startedAt: 't',
+          registryBaseDir: undefined,
+        },
+        { registerFn: async () => Promise.reject(new Error('disk full')) },
+      ),
+    ).not.toThrow();
+    await Promise.resolve();
+  });
+});
+
+describe('announceWebuiReady', () => {
+  function fakeServer() {
+    let listener: (() => void) | undefined;
+    return {
+      on: (_event: 'listening', cb: () => void) => {
+        listener = cb;
+      },
+      fire: () => listener?.(),
+    };
+  }
+
+  it('logs the banner and opens the browser when open=true', () => {
+    const server = fakeServer();
+    const logs: string[] = [];
+    const opened: string[] = [];
+    announceWebuiReady({
+      server,
+      host: '127.0.0.1',
+      httpPort: 3456,
+      wsPort: 3457,
+      open: true,
+      log: (m) => logs.push(m),
+      openBrowserFn: (u) => opened.push(u),
+    });
+    // nothing happens until the server is listening
+    expect(logs).toHaveLength(0);
+    server.fire();
+    expect(logs.join('\n')).toContain('WebUI ready');
+    expect(opened).toEqual(['http://127.0.0.1:3456']);
+  });
+
+  it('does not open the browser when open=false', () => {
+    const server = fakeServer();
+    const opened: string[] = [];
+    announceWebuiReady({
+      server,
+      host: '127.0.0.1',
+      httpPort: 3456,
+      wsPort: 3457,
+      open: false,
+      log: () => {},
+      openBrowserFn: (u) => opened.push(u),
+    });
+    server.fire();
+    expect(opened).toEqual([]);
+  });
+});
+
+describe('createWebuiShutdown', () => {
+  function makeRes(overrides: Partial<Parameters<typeof createWebuiShutdown>[0]> = {}) {
+    const order: string[] = [];
+    let wssCloseCb: (() => void) | undefined;
+    const res = {
+      abortInFlight: () => order.push('abort'),
+      unsubscribeEvents: () => order.push('unsub'),
+      closeClients: () => order.push('closeClients'),
+      closeHttpServer: () => order.push('closeHttp'),
+      wss: {
+        close: (cb?: () => void) => {
+          order.push('wssClose');
+          wssCloseCb = cb;
+        },
+      },
+      pid: 99,
+      registryBaseDir: '/cfg',
+      onStopped: () => order.push('stopped'),
+      log: () => {},
+      debug: () => {},
+      unregisterFn: async (_pid: number, _baseDir?: string) => {
+        order.push('unregister');
+      },
+      ...overrides,
+    };
+    return { res, order, fireWssClose: () => wssCloseCb?.() };
+  }
+
+  it('runs teardown in order and resolves only after unregister settles', async () => {
+    const { res, order, fireWssClose } = makeRes();
+    const shutdown = createWebuiShutdown(res);
+    shutdown();
+    // synchronous portion: abort → unsub → closeClients → (unregister kicks off) → closeHttp → wssClose
+    expect(order).toEqual([
+      'abort',
+      'unsub',
+      'closeClients',
+      'unregister',
+      'closeHttp',
+      'wssClose',
+    ]);
+    // onStopped only after wss close callback + the unregister promise settles
+    fireWssClose();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(order.at(-1)).toBe('stopped');
+  });
+
+  it('is idempotent: a second call is a no-op', () => {
+    const { res, order } = makeRes();
+    const shutdown = createWebuiShutdown(res);
+    shutdown();
+    const afterFirst = order.length;
+    shutdown();
+    expect(order.length).toBe(afterFirst);
+  });
+
+  it('still resolves when unregister rejects', async () => {
+    const { res, fireWssClose, order } = makeRes({
+      unregisterFn: async () => Promise.reject(new Error('registry gone')),
+    });
+    const shutdown = createWebuiShutdown(res);
+    shutdown();
+    fireWssClose();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(order).toContain('stopped');
+  });
+});
+
+describe('registerWebuiSignalHandlers', () => {
+  it('registers on SIGINT/SIGTERM, fires shutdown once, and self-detaches', () => {
+    const registered = new Map<string, () => void>();
+    const onSpy = vi.spyOn(process, 'on').mockImplementation(((ev: string, cb: () => void) => {
+      registered.set(ev, cb);
+      return process;
+    }) as typeof process.on);
+    const offSpy = vi.spyOn(process, 'off').mockImplementation(((ev: string) => {
+      registered.delete(ev);
+      return process;
+    }) as typeof process.off);
+
+    let calls = 0;
+    const unregister = registerWebuiSignalHandlers(() => {
+      calls++;
+    });
+
+    expect(onSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+    expect(onSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+
+    const handler = registered.get('SIGINT');
+    expect(handler).toBeDefined();
+    handler?.();
+    expect(calls).toBe(1);
+    // self-detached both listeners
+    expect(offSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+    expect(offSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+
+    // returned unregister is safe to call again
+    expect(() => unregister()).not.toThrow();
+  });
+});


### PR DESCRIPTION
PR 7 of the webui-server 8-PR refactor (Issue #30). Pulls the three
process-lifecycle concerns out of the ~3000-line `runWebUI` body into
`webui-server/lifecycle.ts`, each behind an injectable seam so the
orchestration is unit-testable without disk IO, a browser launch, or a
real process signal.

## What moves
- **`registerWebuiInstance`** — builds the running-instance registry
  record (`basename` projectName + url) and fires the best-effort
  `registerInstance` write. Replaces the inline ~15-line block.
- **`announceWebuiReady`** — the "WebUI ready" banner + `openBrowser`
  -on-`listening` wiring (`openBrowserFn` / `log` injectable).
- **`createWebuiShutdown` + `registerWebuiSignalHandlers`** — the
  SIGINT/SIGTERM teardown. Run-loop state (legacy abort slot, per-socket
  abort controllers, eventUnsubscribers, client map, httpServer, wss, the
  run promise's `resolve`) **stays in webui-server.ts** and is threaded in
  as callbacks; the module captures none of it. The idempotent guard and
  listener self-detach are preserved verbatim; `unregisterInstance` is
  injectable.

`webui-server.ts` imports these four helpers and drops the
`openBrowser` / `registerInstance` / `unregisterInstance` barrel imports.

## Tests
New `tests/webui-server/lifecycle.test.ts` (8 cases): record shape +
best-effort swallow, banner/open gating on the `open` flag, shutdown
ordering + resolve-after-unregister + idempotency + resolve-on-reject,
and signal registration / one-shot fire / self-detach.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- full webui-server suite (13 files) **62/62** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)