### PR TITLE
refactor(cli): ProviderConfigStore facade for webui provider handlers (PR 4 follow-up of #30)

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -61,6 +61,7 @@ import {
   registerWebuiInstance,
   registerWebuiSignalHandlers,
 } from './webui-server/lifecycle.js';
+import { createProviderConfigStore } from './webui-server/provider-config.js';
 import { startStaticServe } from './webui-server/static-serve.js';
 import {
   type WsHandlerContext,
@@ -1194,7 +1195,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
   // `send`/`broadcast` are hoisted function declarations, so capturing
   // them here is safe even though they're defined further down.
   const wsHandlerCtx: WsHandlerContext = {
-    globalConfigPath: opts.globalConfigPath,
+    providerStore: createProviderConfigStore(opts.globalConfigPath),
     modelsRegistry: opts.modelsRegistry,
     send,
     broadcast,

--- a/packages/cli/src/webui-server/provider-config.ts
+++ b/packages/cli/src/webui-server/provider-config.ts
@@ -3,6 +3,21 @@ import { DefaultSecretVault } from '@wrongstack/core/security';
 import type { ProviderConfig } from '@wrongstack/core/types';
 import { loadConfigProviders, mutateConfigProviders } from '../provider-config-utils.js';
 
+// Re-export the provider-record transforms the webui handlers need, so
+// callers (ws-handlers/providers.ts) have a single import surface for
+// "webui provider config" instead of juggling this module *and*
+// ../provider-config-utils.js. The transforms themselves stay in the
+// broadly-shared provider-config-utils.js (auth-menu, slash-commands,
+// subcommands all use it); this is a facade re-export, not a move.
+// PR 4 follow-up of Issue #30.
+export {
+  expectDefined,
+  maskedKey,
+  normalizeKeys,
+  nowIso,
+  writeKeysBack,
+} from '../provider-config-utils.js';
+
 /**
  * PR 4 of Issue #30 (webui-server 8-PR refactor):
  * provider-config IO.
@@ -47,9 +62,42 @@ export async function saveProviders(
   providers: Record<string, ProviderConfig>,
 ): Promise<void> {
   if (!globalConfigPath) return;
-  await mutateConfigProviders(globalConfigPath, getVault(globalConfigPath), (existing: Record<string, ProviderConfig>) => {
-    // Replace the entire providers map.
-    for (const key of Object.keys(existing)) delete existing[key];
-    Object.assign(existing, providers);
-  });
+  await mutateConfigProviders(
+    globalConfigPath,
+    getVault(globalConfigPath),
+    (existing: Record<string, ProviderConfig>) => {
+      // Replace the entire providers map.
+      for (const key of Object.keys(existing)) delete existing[key];
+      Object.assign(existing, providers);
+    },
+  );
+}
+
+/**
+ * A provider-config store bound to one `globalConfigPath`.
+ *
+ * PR 4 follow-up of Issue #30: the provider ws-handlers used to take a
+ * raw `globalConfigPath` and call `loadSavedProviders`/`saveProviders`
+ * with it on every operation. Binding the path once into a small
+ * `load`/`save` object (mirrors the standalone server's
+ * `createProviderConfigIO`) removes the repeated path threading and
+ * gives callers a single dependency to mock.
+ */
+export interface ProviderConfigStore {
+  load(): Promise<Record<string, ProviderConfig>>;
+  save(providers: Record<string, ProviderConfig>): Promise<void>;
+}
+
+/**
+ * Build a {@link ProviderConfigStore} for `globalConfigPath`. When the
+ * path is undefined the store is a no-op (load ⇒ `{}`, save ⇒ nothing),
+ * matching the underlying helpers' behaviour.
+ */
+export function createProviderConfigStore(
+  globalConfigPath: string | undefined,
+): ProviderConfigStore {
+  return {
+    load: () => loadSavedProviders(globalConfigPath),
+    save: (providers) => saveProviders(globalConfigPath, providers),
+  };
 }

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -1,5 +1,6 @@
 import type { ModelsRegistry } from '@wrongstack/core';
 import type { WebSocket } from 'ws';
+import type { ProviderConfigStore } from '../provider-config.js';
 
 /**
  * PR 5 of Issue #30 (webui-server 8-PR refactor): ws-handlers/.
@@ -31,8 +32,8 @@ export interface WsServerMessage {
  * mailbox, …) this context grows the fields they need.
  */
 export interface WsHandlerContext {
-  /** Path to the global config (~/.wrongstack/config.json) — provider keys live here. */
-  globalConfigPath: string | undefined;
+  /** Provider-config store (load/save the saved-providers map), bound to the global config path. */
+  providerStore: ProviderConfigStore;
   /** Models registry backing the provider/model catalog (optional). */
   modelsRegistry: ModelsRegistry | undefined;
   /** Send one message to a single socket (no-op if the socket isn't OPEN). */

--- a/packages/cli/src/webui-server/ws-handlers/providers.ts
+++ b/packages/cli/src/webui-server/ws-handlers/providers.ts
@@ -6,17 +6,17 @@ import {
   normalizeKeys,
   nowIso,
   writeKeysBack,
-} from '../../provider-config-utils.js';
-import { loadSavedProviders, saveProviders } from '../provider-config.js';
+} from '../provider-config.js';
 import type { WsHandlerContext } from './index.js';
 
 /**
  * PR 5 of Issue #30: provider / model / API-key WebSocket handlers.
  *
- * Extracted verbatim from the `runWebUI` closure in webui-server.ts.
- * Every former closure capture (`opts.modelsRegistry`,
- * `opts.globalConfigPath`, `send`, `broadcast`, `console.log`) is now a
- * field on `ctx: WsHandlerContext` — no hidden state.
+ * Extracted from the `runWebUI` closure in webui-server.ts. Every former
+ * closure capture is now a field on `ctx: WsHandlerContext` — no hidden
+ * state: `opts.modelsRegistry` → `ctx.modelsRegistry`, the
+ * globalConfigPath-bound provider IO → `ctx.providerStore`, and
+ * `send`/`broadcast`/`console.log` → `ctx.send`/`broadcast`/`log`.
  */
 
 /**
@@ -35,7 +35,7 @@ export async function handleProvidersList(ctx: WsHandlerContext, ws: WebSocket):
   }
   try {
     const providers = await ctx.modelsRegistry.listProviders();
-    const savedProviders = await loadSavedProviders(ctx.globalConfigPath);
+    const savedProviders = await ctx.providerStore.load();
     const savedIds = new Set(Object.keys(savedProviders));
 
     ctx.send(ws, {
@@ -99,7 +99,7 @@ export async function handleProviderModels(
 
 export async function handleProvidersSaved(ctx: WsHandlerContext, ws: WebSocket): Promise<void> {
   try {
-    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    const providers = await ctx.providerStore.load();
     ctx.send(ws, {
       type: 'providers.saved',
       payload: {
@@ -129,7 +129,7 @@ export async function handleKeyUpsert(
   apiKey: string,
 ): Promise<void> {
   try {
-    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    const providers = await ctx.providerStore.load();
     const existing = providers[providerId] ?? { type: providerId };
     const keys = normalizeKeys(existing);
 
@@ -145,7 +145,7 @@ export async function handleKeyUpsert(
     if (!existing.activeKey) existing.activeKey = label;
     providers[providerId] = existing;
 
-    await saveProviders(ctx.globalConfigPath, providers);
+    await ctx.providerStore.save(providers);
     sendResult(ctx, ws, true, `Key "${label}" saved for ${providerId}`);
   } catch (err) {
     sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
@@ -159,7 +159,7 @@ export async function handleKeyDelete(
   label: string,
 ): Promise<void> {
   try {
-    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    const providers = await ctx.providerStore.load();
     const existing = providers[providerId];
     if (!existing) {
       sendResult(ctx, ws, false, `Provider "${providerId}" not found`);
@@ -175,7 +175,7 @@ export async function handleKeyDelete(
       }
       providers[providerId] = existing;
     }
-    await saveProviders(ctx.globalConfigPath, providers);
+    await ctx.providerStore.save(providers);
     sendResult(ctx, ws, true, `Key "${label}" deleted from ${providerId}`);
   } catch (err) {
     sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
@@ -189,7 +189,7 @@ export async function handleKeySetActive(
   label: string,
 ): Promise<void> {
   try {
-    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    const providers = await ctx.providerStore.load();
     const existing = providers[providerId];
     if (!existing) {
       sendResult(ctx, ws, false, `Provider "${providerId}" not found`);
@@ -198,7 +198,7 @@ export async function handleKeySetActive(
     existing.activeKey = label;
     writeKeysBack(existing, normalizeKeys(existing));
     providers[providerId] = existing;
-    await saveProviders(ctx.globalConfigPath, providers);
+    await ctx.providerStore.save(providers);
     sendResult(ctx, ws, true, `Active key for ${providerId} set to "${label}"`);
   } catch (err) {
     sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
@@ -216,7 +216,7 @@ export async function handleProviderAdd(
   },
 ): Promise<void> {
   try {
-    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    const providers = await ctx.providerStore.load();
     if (providers[payload.id]) {
       sendResult(
         ctx,
@@ -236,7 +236,7 @@ export async function handleProviderAdd(
       newProv.activeKey = 'default';
     }
     providers[payload.id] = newProv;
-    await saveProviders(ctx.globalConfigPath, providers);
+    await ctx.providerStore.save(providers);
     sendResult(ctx, ws, true, `Provider "${payload.id}" added`);
     ctx.log(`[WebUI] Provider "${payload.id}" added via provider.add`);
     ctx.broadcast({
@@ -266,13 +266,13 @@ export async function handleProviderRemove(
   providerId: string,
 ): Promise<void> {
   try {
-    const providers = await loadSavedProviders(ctx.globalConfigPath);
+    const providers = await ctx.providerStore.load();
     if (!providers[providerId]) {
       sendResult(ctx, ws, false, `Provider "${providerId}" not found`);
       return;
     }
     delete providers[providerId];
-    await saveProviders(ctx.globalConfigPath, providers);
+    await ctx.providerStore.save(providers);
     sendResult(ctx, ws, true, `Provider "${providerId}" removed`);
   } catch (err) {
     sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));

--- a/packages/cli/tests/webui-server/provider-config.test.ts
+++ b/packages/cli/tests/webui-server/provider-config.test.ts
@@ -1,10 +1,13 @@
+import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import * as fs from 'node:fs/promises';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  createProviderConfigStore,
   getVault,
   loadSavedProviders,
+  maskedKey,
+  normalizeKeys,
   saveProviders,
 } from '../../src/webui-server/provider-config.js';
 
@@ -91,5 +94,31 @@ describe('webui-server/provider-config (PR 4 of #30)', () => {
     // The function must not throw, must not create
     // any files, and must not write to anything.
     await expect(saveProviders(undefined, {})).resolves.toBeUndefined();
+  });
+});
+
+describe('webui-server/provider-config facade (PR 4 follow-up of #30)', () => {
+  it('re-exports the provider-record transforms (single import surface)', () => {
+    expect(typeof normalizeKeys).toBe('function');
+    expect(typeof maskedKey).toBe('function');
+    // maskedKey never returns the plaintext.
+    expect(maskedKey('sk-supersecret-value')).not.toContain('supersecret');
+  });
+
+  it('createProviderConfigStore: load/save round-trip bound to one path', async () => {
+    const store = createProviderConfigStore(configPath);
+    const input = {
+      anthropic: { type: 'anthropic', apiKeys: [{ label: 'k1', key: 'sk-test-1' }] },
+    } as never;
+    await store.save(input);
+    expect(await store.load()).toEqual(input);
+    // The store is just a binding over the same IO.
+    expect(await loadSavedProviders(configPath)).toEqual(input);
+  });
+
+  it('createProviderConfigStore: no-op store when path is undefined', async () => {
+    const store = createProviderConfigStore(undefined);
+    expect(await store.load()).toEqual({});
+    await expect(store.save({})).resolves.toBeUndefined();
   });
 });

--- a/packages/cli/tests/webui-server/ws-handlers-providers.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-providers.test.ts
@@ -3,7 +3,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { WebSocket } from 'ws';
-import { loadSavedProviders } from '../../src/webui-server/provider-config.js';
+import {
+  createProviderConfigStore,
+  loadSavedProviders,
+} from '../../src/webui-server/provider-config.js';
 import type {
   WsHandlerContext,
   WsServerMessage,
@@ -43,7 +46,7 @@ function makeCtx(
 ): { ctx: WsHandlerContext; cap: Captured } {
   const cap: Captured = { sent: [], broadcasts: [], logs: [] };
   const ctx: WsHandlerContext = {
-    globalConfigPath,
+    providerStore: createProviderConfigStore(globalConfigPath),
     modelsRegistry,
     send: (_ws, msg) => cap.sent.push(msg),
     broadcast: (msg) => cap.broadcasts.push(msg),


### PR DESCRIPTION
Closes the **PR 4 follow-up** from `docs/refactor-next.md`. The provider
ws-handlers juggled two import paths — `../provider-config-utils.js` for
the record transforms and `../provider-config.js` for the IO — and
threaded a raw `globalConfigPath` into every call.

## What changes
- **`webui-server/provider-config.ts`** gains a `ProviderConfigStore`
  interface + `createProviderConfigStore(globalConfigPath)` factory
  (mirrors the standalone server's `createProviderConfigIO`): binds the
  path once into a small `load`/`save` object, so callers stop repeating
  it and get one dependency to mock.
- It also **re-exports** the transforms the handlers need
  (`normalizeKeys`/`maskedKey`/`writeKeysBack`/`nowIso`/`expectDefined`),
  giving the handlers a single import surface. The transforms still
  **live** in the broadly-shared `provider-config-utils.js` (auth-menu,
  slash-commands, subcommands all use it) — facade re-export, not a move.
- **`WsHandlerContext`** swaps `globalConfigPath` for
  `providerStore: ProviderConfigStore`; `providers.ts` now calls
  `ctx.providerStore.load()` / `.save(providers)` (12 call sites).
- **`webui-server.ts`** builds the store via
  `createProviderConfigStore(opts.globalConfigPath)`.

## Tests
- `provider-config.test.ts`: transform re-exports, store round-trip,
  undefined-path no-op store.
- `ws-handlers-providers.test.ts`: builds its fake ctx via
  `createProviderConfigStore`; the 8 handler tests pass unchanged.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- full webui-server suite (13 files) **65/65** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)