### PR TITLE
refactor(cli): extract brain ws-handlers into ws-handlers/brain.ts (PR 5b of #30)

### DIFF
--- a/docs/refactor-next.md
+++ b/docs/refactor-next.md
@@ -17,7 +17,8 @@ refactor). Update this before switching context, handing off, or resuming.
 | 5  | ws-handlers/ — **provider group** | ✅ merged | #58 |
 | 7  | lifecycle.ts | ✅ merged | #59 |
 | 8  | Final pass (module-map header + this doc) | ✅ merged | #61 |
-| 5b | ws-handlers/ — **remaining groups** | 🔴 deferred | — |
+| 5b | ws-handlers/ — **brain group** | ✅ merged | #62 |
+| 5c | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
 
 `webui-server.ts` is ~3000 lines (down from ~3250). The self-contained
 concerns now live under `packages/cli/src/webui-server/`:
@@ -31,28 +32,33 @@ webui-server/
   static-serve.ts       — dist discovery + HTTP bring-up    (PR 6)
   lifecycle.ts          — registry / ready+open / shutdown  (PR 7)
   ws-handlers/
-    index.ts            — WsHandlerContext + barrel         (PR 5)
+    index.ts            — WsCommon + per-group contexts + barrel (PR 5/5b)
     providers.ts        — provider/model/key handlers       (PR 5)
+    brain.ts            — brain.status/risk/ask handlers     (PR 5b)
 ```
+
+Per-group contexts now extend a small `WsCommon` base (`send`/`broadcast`/
+`log`) rather than one shared god-object growing a field per concern.
 
 A module-map doc comment at the top of `webui-server.ts` points to each.
 
 ---
 
-## PR 5b — remaining ws-handler groups (🔴 deferred, the real risk)
+## PR 5c — remaining ws-handler groups (🔴 in progress)
 
-PR 5 extracted the **provider** group (the largest cleanly-separable one:
-8 handlers + `WsHandlerContext`, fully unit-tested). The doc's original
-plan also listed sessions / mailbox / worktree / memory groups. Current
-reality:
+PR 5 extracted the **provider** group and PR 5b the **brain** group (each
+fully unit-tested, threaded via a per-group context extending `WsCommon`).
+The doc's original plan also listed sessions / mailbox / worktree / memory
+groups. Current reality:
 
 - **Already delegated** — `memory.*`, `files.*`, `mailbox.*`, `shell.open`
   cases already call the shared `@wrongstack/webui/server` handlers. No
   CLI-local extraction to do.
-- **Still inline, deferred** — the `handleMessage` switch cases for
-  `sessions` / `session.*`, `context.*`, `brain.*`, `tasks`/`task.*`,
+- **Still inline** — the `handleMessage` switch cases for
+  `sessions` / `session.*`, `context.*`, `tasks`/`task.*`,
   `projects.*`, `plan.*`, `skills`, `modes`/`mode.*`, `model.*`, `todos.*`,
   `diag`/`stats`, `autonomy.switch`, `prefs.*`, plus `handleUserMessage`.
+  (`brain.*` extracted in PR 5b — the small self-contained groups go first.)
 
 **Why deferred (not "forgotten"):** these cases are coupled to ~25 pieces
 of run-loop state (`abortController` + `abortControllers`, `clients`,

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -100,7 +100,11 @@ import {
 import { createProviderConfigStore } from './webui-server/provider-config.js';
 import { startStaticServe } from './webui-server/static-serve.js';
 import {
+  type BrainHandlerContext,
   type WsHandlerContext,
+  handleBrainAsk,
+  handleBrainRisk,
+  handleBrainStatus,
   handleKeyDelete,
   handleKeySetActive,
   handleKeyUpsert,
@@ -1238,6 +1242,21 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     log: (m) => console.log(m),
   };
 
+  const brainCtx: BrainHandlerContext = {
+    brainSettings: opts.brainSettings,
+    getBrainLog: opts.getBrainLog,
+    // Prefer the host-supplied arbiter; otherwise resolve the one bound
+    // in the agent container (if any). Mirrors the former inline lookup.
+    resolveArbiter: () =>
+      opts.brain ??
+      (opts.agent.container.has(TOKENS.BrainArbiter)
+        ? opts.agent.container.resolve(TOKENS.BrainArbiter)
+        : undefined),
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
   async function handleMessage(
     ws: WebSocket,
     client: ConnectedClient,
@@ -2328,66 +2347,19 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       // terminal and the WebUI never diverge. These used to be unknown
       // message types on the embedded server.
       case 'brain.status': {
-        send(ws, {
-          type: 'brain.status',
-          payload: {
-            maxAutoRisk: opts.brainSettings?.maxAutoRisk ?? 'medium',
-            log: opts.getBrainLog?.() ?? [],
-          },
-        });
+        handleBrainStatus(brainCtx, ws);
         break;
       }
 
       case 'brain.risk': {
         const level = (msg as { payload?: { level?: string } }).payload?.level ?? '';
-        const valid = ['off', 'low', 'medium', 'high', 'all'];
-        if (!valid.includes(level)) {
-          sendResult(ws, false, `Unknown risk level "${level}". Use: ${valid.join(', ')}.`);
-          break;
-        }
-        if (!opts.brainSettings) {
-          sendResult(ws, false, 'Brain settings are not wired into this server.');
-          break;
-        }
-        opts.brainSettings.maxAutoRisk = level as BrainAutoRisk;
-        send(ws, {
-          type: 'brain.status',
-          payload: { maxAutoRisk: opts.brainSettings.maxAutoRisk, log: opts.getBrainLog?.() ?? [] },
-        });
+        handleBrainRisk(brainCtx, ws, level);
         break;
       }
 
       case 'brain.ask': {
-        const question = (msg as { payload?: { question?: string } }).payload?.question?.trim();
-        if (!question) {
-          sendResult(ws, false, 'Usage: /brain ask <question>');
-          break;
-        }
-        const arbiter =
-          opts.brain ??
-          (opts.agent.container.has(TOKENS.BrainArbiter)
-            ? opts.agent.container.resolve(TOKENS.BrainArbiter)
-            : undefined);
-        if (!arbiter) {
-          sendResult(ws, false, 'No Brain is wired into this server.');
-          break;
-        }
-        try {
-          const decision = await arbiter.decide({
-            id: `brain-ask-${Date.now().toString(36)}`,
-            source: 'user',
-            question,
-            risk: 'medium',
-            fallback: 'ask_human',
-          });
-          send(ws, { type: 'brain.answer', payload: { question, decision } });
-        } catch (err) {
-          sendResult(
-            ws,
-            false,
-            `Brain consultation failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
+        const question = (msg as { payload?: { question?: string } }).payload?.question;
+        await handleBrainAsk(brainCtx, ws, question);
         break;
       }
 

--- a/packages/cli/src/webui-server/ws-handlers/brain.ts
+++ b/packages/cli/src/webui-server/ws-handlers/brain.ts
@@ -1,0 +1,96 @@
+import type { BrainArbiter, BrainAutoRisk } from '@wrongstack/core';
+import type { WebSocket } from 'ws';
+import type { WsCommon } from './index.js';
+
+/**
+ * PR 5b of Issue #30: Brain WebSocket handlers (`brain.status` /
+ * `brain.risk` / `brain.ask`).
+ *
+ * Extracted from the `runWebUI` switch. The former closure captures —
+ * `opts.brainSettings`, `opts.getBrainLog`, and the
+ * `opts.brain ?? container.resolve(TOKENS.BrainArbiter)` lookup — are now
+ * fields on `BrainHandlerContext`. The arbiter resolution is passed as a
+ * thunk so this module needn't know about the agent container or tokens.
+ */
+
+/** A single Brain decision-log entry (newest last). */
+export interface BrainLogEntry {
+  at: number;
+  kind: string;
+  question: string;
+  outcome: string;
+}
+
+export interface BrainHandlerContext extends WsCommon {
+  /** Shared autonomy ceiling — the SAME object `/brain` mutates. */
+  brainSettings: { maxAutoRisk: BrainAutoRisk } | undefined;
+  /** Read the host's rolling Brain decision log, or undefined when not wired. */
+  getBrainLog: (() => BrainLogEntry[]) | undefined;
+  /** Resolve the active Brain arbiter (host instance, else container-bound), or undefined. */
+  resolveArbiter: () => BrainArbiter | undefined;
+}
+
+function sendResult(ctx: WsCommon, ws: WebSocket, success: boolean, message: string): void {
+  ctx.send(ws, { type: 'key.operation_result', payload: { success, message } });
+}
+
+export function handleBrainStatus(ctx: BrainHandlerContext, ws: WebSocket): void {
+  ctx.send(ws, {
+    type: 'brain.status',
+    payload: {
+      maxAutoRisk: ctx.brainSettings?.maxAutoRisk ?? 'medium',
+      log: ctx.getBrainLog?.() ?? [],
+    },
+  });
+}
+
+export function handleBrainRisk(ctx: BrainHandlerContext, ws: WebSocket, level: string): void {
+  const valid = ['off', 'low', 'medium', 'high', 'all'];
+  if (!valid.includes(level)) {
+    sendResult(ctx, ws, false, `Unknown risk level "${level}". Use: ${valid.join(', ')}.`);
+    return;
+  }
+  if (!ctx.brainSettings) {
+    sendResult(ctx, ws, false, 'Brain settings are not wired into this server.');
+    return;
+  }
+  ctx.brainSettings.maxAutoRisk = level as BrainAutoRisk;
+  ctx.send(ws, {
+    type: 'brain.status',
+    payload: { maxAutoRisk: ctx.brainSettings.maxAutoRisk, log: ctx.getBrainLog?.() ?? [] },
+  });
+}
+
+export async function handleBrainAsk(
+  ctx: BrainHandlerContext,
+  ws: WebSocket,
+  question: string | undefined,
+): Promise<void> {
+  const q = question?.trim();
+  if (!q) {
+    sendResult(ctx, ws, false, 'Usage: /brain ask <question>');
+    return;
+  }
+  const arbiter = ctx.resolveArbiter();
+  if (!arbiter) {
+    sendResult(ctx, ws, false, 'No Brain is wired into this server.');
+    return;
+  }
+  try {
+    const decision = await arbiter.decide({
+      id: `brain-ask-${Date.now().toString(36)}`,
+      source: 'user',
+      question: q,
+      risk: 'medium',
+      fallback: 'ask_human',
+    });
+    ctx.send(ws, { type: 'brain.answer', payload: { question: q, decision } });
+  } catch (err) {
+    sendResult(
+      ctx,
+      ws,
+      false,
+      `Brain consultation failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -25,17 +25,12 @@ export interface WsServerMessage {
 }
 
 /**
- * Shared state threaded explicitly into every ws-handler group.
- *
- * Only the dependencies the extracted handlers actually use live
- * here. As more handler groups move out of webui-server.ts (sessions,
- * mailbox, …) this context grows the fields they need.
+ * The messaging surface every ws-handler group needs. Each group's
+ * context extends this with its own dependencies, so the per-group
+ * contexts stay focused instead of one shared god-object growing a
+ * field for every concern in the file.
  */
-export interface WsHandlerContext {
-  /** Provider-config store (load/save the saved-providers map), bound to the global config path. */
-  providerStore: ProviderConfigStore;
-  /** Models registry backing the provider/model catalog (optional). */
-  modelsRegistry: ModelsRegistry | undefined;
+export interface WsCommon {
   /** Send one message to a single socket (no-op if the socket isn't OPEN). */
   send: (ws: WebSocket, msg: WsServerMessage) => void;
   /** Broadcast a message to every connected socket. */
@@ -44,6 +39,22 @@ export interface WsHandlerContext {
   log: (msg: string) => void;
 }
 
+/**
+ * Context for the provider / model / API-key handlers.
+ */
+export interface WsHandlerContext extends WsCommon {
+  /** Provider-config store (load/save the saved-providers map), bound to the global config path. */
+  providerStore: ProviderConfigStore;
+  /** Models registry backing the provider/model catalog (optional). */
+  modelsRegistry: ModelsRegistry | undefined;
+}
+
+export {
+  type BrainHandlerContext,
+  handleBrainAsk,
+  handleBrainRisk,
+  handleBrainStatus,
+} from './brain.js';
 export {
   handleKeyDelete,
   handleKeySetActive,

--- a/packages/cli/tests/webui-server/ws-handlers-brain.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-brain.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import type {
+  BrainHandlerContext,
+  BrainLogEntry,
+} from '../../src/webui-server/ws-handlers/brain.js';
+import type { WsServerMessage } from '../../src/webui-server/ws-handlers/index.js';
+import {
+  handleBrainAsk,
+  handleBrainRisk,
+  handleBrainStatus,
+} from '../../src/webui-server/ws-handlers/index.js';
+
+/**
+ * PR 5b of Issue #30: Brain ws-handler unit tests.
+ *
+ * The handlers take a BrainHandlerContext; these drive them with a fake
+ * context (capturing send/broadcast) and a stub arbiter so no real Brain,
+ * container, or socket is involved.
+ */
+
+const FAKE_WS = {} as WebSocket;
+
+interface Captured {
+  sent: WsServerMessage[];
+}
+
+function makeCtx(over: Partial<BrainHandlerContext> = {}): {
+  ctx: BrainHandlerContext;
+  cap: Captured;
+} {
+  const cap: Captured = { sent: [] };
+  const ctx: BrainHandlerContext = {
+    brainSettings: { maxAutoRisk: 'medium' },
+    getBrainLog: () => [],
+    resolveArbiter: () => undefined,
+    send: (_ws, msg) => cap.sent.push(msg),
+    broadcast: () => {},
+    log: () => {},
+    ...over,
+  };
+  return { ctx, cap };
+}
+
+const lastResultMsg = (cap: Captured) =>
+  cap.sent.filter((m) => m.type === 'key.operation_result').at(-1)?.payload as
+    | { success: boolean; message: string }
+    | undefined;
+
+const lastOfType = (cap: Captured, type: string) => cap.sent.filter((m) => m.type === type).at(-1);
+
+describe('handleBrainStatus', () => {
+  it('emits the current ceiling and log', () => {
+    const log: BrainLogEntry[] = [{ at: 1, kind: 'auto', question: 'q', outcome: 'allow' }];
+    const { ctx, cap } = makeCtx({
+      brainSettings: { maxAutoRisk: 'high' },
+      getBrainLog: () => log,
+    });
+    handleBrainStatus(ctx, FAKE_WS);
+    const msg = lastOfType(cap, 'brain.status');
+    expect(msg?.payload).toEqual({ maxAutoRisk: 'high', log });
+  });
+
+  it('defaults the ceiling to medium and log to [] when unwired', () => {
+    const { ctx, cap } = makeCtx({ brainSettings: undefined, getBrainLog: undefined });
+    handleBrainStatus(ctx, FAKE_WS);
+    expect(lastOfType(cap, 'brain.status')?.payload).toEqual({ maxAutoRisk: 'medium', log: [] });
+  });
+});
+
+describe('handleBrainRisk', () => {
+  it('rejects an unknown level', () => {
+    const { ctx, cap } = makeCtx();
+    handleBrainRisk(ctx, FAKE_WS, 'bogus');
+    expect(lastResultMsg(cap)?.success).toBe(false);
+    expect(lastResultMsg(cap)?.message).toContain('Unknown risk level');
+  });
+
+  it('errors when brain settings are not wired', () => {
+    const { ctx, cap } = makeCtx({ brainSettings: undefined });
+    handleBrainRisk(ctx, FAKE_WS, 'high');
+    expect(lastResultMsg(cap)?.success).toBe(false);
+    expect(lastResultMsg(cap)?.message).toContain('not wired');
+  });
+
+  it('mutates the shared ceiling and echoes the new status', () => {
+    const settings = { maxAutoRisk: 'low' as const };
+    const { ctx, cap } = makeCtx({ brainSettings: settings });
+    handleBrainRisk(ctx, FAKE_WS, 'all');
+    // The SAME object is mutated (shared with /brain).
+    expect(settings.maxAutoRisk).toBe('all');
+    expect(lastOfType(cap, 'brain.status')?.payload).toMatchObject({ maxAutoRisk: 'all' });
+  });
+});
+
+describe('handleBrainAsk', () => {
+  it('rejects an empty question', async () => {
+    const { ctx, cap } = makeCtx();
+    await handleBrainAsk(ctx, FAKE_WS, '   ');
+    expect(lastResultMsg(cap)?.success).toBe(false);
+    expect(lastResultMsg(cap)?.message).toContain('Usage');
+  });
+
+  it('errors when no arbiter is wired', async () => {
+    const { ctx, cap } = makeCtx({ resolveArbiter: () => undefined });
+    await handleBrainAsk(ctx, FAKE_WS, 'should we deploy?');
+    expect(lastResultMsg(cap)?.success).toBe(false);
+    expect(lastResultMsg(cap)?.message).toContain('No Brain');
+  });
+
+  it('forwards the question to the arbiter and emits the answer', async () => {
+    const decision = { action: 'allow', reason: 'ok' };
+    const seen: Array<{ question: string; risk: string }> = [];
+    const { ctx, cap } = makeCtx({
+      resolveArbiter: () =>
+        ({
+          decide: async (req: { question: string; risk: string }) => {
+            seen.push({ question: req.question, risk: req.risk });
+            return decision as never;
+          },
+        }) as never,
+    });
+    await handleBrainAsk(ctx, FAKE_WS, '  ship it?  ');
+    // trims the question before forwarding
+    expect(seen).toEqual([{ question: 'ship it?', risk: 'medium' }]);
+    expect(lastOfType(cap, 'brain.answer')?.payload).toEqual({
+      question: 'ship it?',
+      decision,
+    });
+  });
+
+  it('reports a friendly error when the arbiter throws', async () => {
+    const { ctx, cap } = makeCtx({
+      resolveArbiter: () =>
+        ({
+          decide: async () => {
+            throw new Error('brain offline');
+          },
+        }) as never,
+    });
+    await handleBrainAsk(ctx, FAKE_WS, 'q?');
+    expect(lastResultMsg(cap)?.success).toBe(false);
+    expect(lastResultMsg(cap)?.message).toContain('Brain consultation failed');
+    expect(lastResultMsg(cap)?.message).toContain('brain offline');
+  });
+});


### PR DESCRIPTION
Continues the ws-handlers extraction (the deferred **PR 5b**) with the
next cleanly-separable group: the Brain handlers (`brain.status` /
`brain.risk` / `brain.ask`).

## What moves
- **`ws-handlers/brain.ts`** — `handleBrainStatus` / `handleBrainRisk` /
  `handleBrainAsk` on a `BrainHandlerContext`. Former closure captures
  (`opts.brainSettings`, `opts.getBrainLog`, and the
  `opts.brain ?? container.resolve(TOKENS.BrainArbiter)` lookup) are now
  context fields; arbiter resolution is a `resolveArbiter` thunk so the
  module needn't know about the agent container or tokens.
- **`ws-handlers/index.ts`** — introduces a small `WsCommon` base
  (`send`/`broadcast`/`log`). `WsHandlerContext` (providers) and the new
  `BrainHandlerContext` both extend it, so per-group contexts stay focused
  instead of one shared god-object growing a field per concern.
- **`webui-server.ts`** — builds `brainCtx` once; the 3 switch cases call
  the handlers. ~50 inline lines removed.

## Tests
New `tests/webui-server/ws-handlers-brain.test.ts` (9 cases): status
defaults, risk validation + shared-ceiling mutation, ask
empty/no-arbiter/forward+answer/error paths — driven by a stub arbiter,
no real Brain/container/socket.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- full webui-server suite (14 files) **74/74** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)