### PR TITLE
refactor(cli): extract read-only introspection ws-handlers (PR 5c of #30)

### DIFF
--- a/docs/refactor-next.md
+++ b/docs/refactor-next.md
@@ -18,7 +18,8 @@ refactor). Update this before switching context, handing off, or resuming.
 | 7  | lifecycle.ts | ✅ merged | #59 |
 | 8  | Final pass (module-map header + this doc) | ✅ merged | #61 |
 | 5b | ws-handlers/ — **brain group** | ✅ merged | #62 |
-| 5c | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
+| 5c | ws-handlers/ — **introspection group** | ✅ merged | #63 |
+| 5d | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
 
 `webui-server.ts` is ~3000 lines (down from ~3250). The self-contained
 concerns now live under `packages/cli/src/webui-server/`:
@@ -32,9 +33,10 @@ webui-server/
   static-serve.ts       — dist discovery + HTTP bring-up    (PR 6)
   lifecycle.ts          — registry / ready+open / shutdown  (PR 7)
   ws-handlers/
-    index.ts            — WsCommon + per-group contexts + barrel (PR 5/5b)
+    index.ts            — WsCommon + per-group contexts + barrel (PR 5/5b/5c)
     providers.ts        — provider/model/key handlers       (PR 5)
     brain.ts            — brain.status/risk/ask handlers     (PR 5b)
+    introspection.ts    — skills/tools/diag/stats snapshots  (PR 5c)
 ```
 
 Per-group contexts now extend a small `WsCommon` base (`send`/`broadcast`/
@@ -44,21 +46,25 @@ A module-map doc comment at the top of `webui-server.ts` points to each.
 
 ---
 
-## PR 5c — remaining ws-handler groups (🔴 in progress)
+## PR 5d — remaining ws-handler groups (🔴 in progress)
 
-PR 5 extracted the **provider** group and PR 5b the **brain** group (each
-fully unit-tested, threaded via a per-group context extending `WsCommon`).
-The doc's original plan also listed sessions / mailbox / worktree / memory
-groups. Current reality:
+PR 5 extracted **providers**, PR 5b **brain**, PR 5c **introspection**
+(skills/tools/diag/stats) — each fully unit-tested, threaded via a
+per-group context extending `WsCommon`. The doc's original plan also
+listed sessions / mailbox / worktree / memory groups. Current reality:
 
 - **Already delegated** — `memory.*`, `files.*`, `mailbox.*`, `shell.open`
   cases already call the shared `@wrongstack/webui/server` handlers. No
   CLI-local extraction to do.
 - **Still inline** — the `handleMessage` switch cases for
   `sessions` / `session.*`, `context.*`, `tasks`/`task.*`,
-  `projects.*`, `plan.*`, `skills`, `modes`/`mode.*`, `model.*`, `todos.*`,
-  `diag`/`stats`, `autonomy.switch`, `prefs.*`, plus `handleUserMessage`.
-  (`brain.*` extracted in PR 5b — the small self-contained groups go first.)
+  `projects.*`, `plan.*`, `modes`/`mode.*`, `model.*`, `todos.*`,
+  `autonomy.switch`, `prefs.*`, plus `handleUserMessage`. These are coupled
+  to run-loop state (the abort controllers, client map, custom-mode store,
+  session writer/store, the session.start payload builder, the
+  prefs-snapshot/persist closures) — extract test-first, one group at a
+  time, growing each group's context. The small self-contained groups
+  (provider/brain/introspection) went first.
 
 **Why deferred (not "forgotten"):** these cases are coupled to ~25 pieces
 of run-loop state (`abortController` + `abortControllers`, `clients`,

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -101,10 +101,12 @@ import { createProviderConfigStore } from './webui-server/provider-config.js';
 import { startStaticServe } from './webui-server/static-serve.js';
 import {
   type BrainHandlerContext,
+  type IntrospectionContext,
   type WsHandlerContext,
   handleBrainAsk,
   handleBrainRisk,
   handleBrainStatus,
+  handleDiagGet,
   handleKeyDelete,
   handleKeySetActive,
   handleKeyUpsert,
@@ -113,6 +115,9 @@ import {
   handleProviderRemove,
   handleProvidersList,
   handleProvidersSaved,
+  handleSkillsList,
+  handleStatsGet,
+  handleToolsList,
 } from './webui-server/ws-handlers/index.js';
 import { WebSocket, WebSocketServer } from 'ws';
 import { expectDefined } from './provider-config-utils.js';
@@ -131,7 +136,7 @@ type MessageLike = import('./webui-server/context-breakdown.js').MessageLike;
 
 // ── Cost computation helpers (inlined from @wrongstack/webui/server/usage-cost.ts) ──
 // PR 2 of Issue #30: extracted to `./webui-server/cost-helpers.js`.
-import { getCostRates, computeUsageCost } from './webui-server/cost-helpers.js';
+import { getCostRates } from './webui-server/cost-helpers.js';
 
 // Re-export types from webui for type checking
 // At runtime, the actual types are resolved via workspace resolution
@@ -1257,6 +1262,18 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     log: (m) => console.log(m),
   };
 
+  const introspectionCtx: IntrospectionContext = {
+    agent: opts.agent,
+    skillLoader: opts.skillLoader,
+    modelsRegistry: opts.modelsRegistry,
+    projectRoot: opts.projectRoot,
+    sessionId: opts.session.id,
+    sessionStartedAt,
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
   async function handleMessage(
     ws: WebSocket,
     client: ConnectedClient,
@@ -1600,67 +1617,12 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'diag.get': {
-        // Snapshot of key metrics — mirrors the standalone server's handler
-        // and the CLI /diag output. Uses the agent context for live state.
-        const ctx = opts.agent.ctx;
-        const tools = opts.agent.tools.list();
-        send(ws, {
-          type: 'diag.get',
-          payload: {
-            provider: (ctx.provider as { id: string }).id,
-            model: ctx.model,
-            cwd: opts.projectRoot ?? ctx.projectRoot,
-            sessionId: opts.session.id,
-            tools: {
-              count: tools.length,
-              names: tools.map((t) => t.name),
-            },
-            features: {},
-            mode: 'default',
-            usage: ctx.tokenCounter.total(),
-            messages: ctx.messages.length,
-            todos: ctx.todos.length,
-          },
-        });
+        handleDiagGet(introspectionCtx, ws);
         break;
       }
 
       case 'stats.get': {
-        // Detailed session usage stats, mirroring the CLI /stats.
-        const ctx = opts.agent.ctx;
-        const usage = ctx.tokenCounter.total();
-        const cacheStats = ctx.tokenCounter.cacheStats();
-        let cost: number | null = null;
-        try {
-          if (opts.modelsRegistry) {
-            const model = await opts.modelsRegistry.getModel(
-              (ctx.provider as { id: string }).id,
-              ctx.model,
-            );
-            const rates = getCostRates(model);
-            cost = computeUsageCost(
-              { input: usage.input, output: usage.output, cacheRead: cacheStats.readTokens },
-              rates,
-            );
-          }
-        } catch {
-          /* cost stays null */
-        }
-        send(ws, {
-          type: 'stats.get',
-          payload: {
-            sessionId: opts.session.id,
-            provider: (ctx.provider as { id: string }).id,
-            model: ctx.model,
-            usage,
-            cache: cacheStats,
-            cost,
-            messages: ctx.messages.length,
-            readFiles: ctx.readFiles.size,
-            tools: opts.agent.tools.list().length,
-            elapsedMs: Date.now() - sessionStartedAt,
-          },
-        });
+        await handleStatsGet(introspectionCtx, ws);
         break;
       }
 
@@ -1677,17 +1639,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'tools.list': {
-        const list = opts.agent.tools.list().map((t) => {
-          const schema =
-            (t as { inputSchema?: { properties?: Record<string, unknown> } }).inputSchema ?? {};
-          const params = schema.properties ? Object.keys(schema.properties) : [];
-          return {
-            name: t.name,
-            description: (t as { description?: string | undefined }).description ?? '',
-            params,
-          };
-        });
-        send(ws, { type: 'tools.list', payload: { tools: list } });
+        handleToolsList(introspectionCtx, ws);
         break;
       }
 
@@ -1924,39 +1876,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'skills.list': {
-        if (!opts.skillLoader) {
-          send(ws, { type: 'skills.list', payload: { skills: [], enabled: false } });
-          break;
-        }
-        try {
-          const manifests = await opts.skillLoader.list();
-          const entries = await opts.skillLoader.listEntries();
-          const byName = new Map(entries.map((e) => [e.name, e]));
-          send(ws, {
-            type: 'skills.list',
-            payload: {
-              enabled: true,
-              skills: manifests.map((m) => ({
-                name: m.name,
-                description: m.description,
-                version: m.version ?? '',
-                source: m.source,
-                path: m.path,
-                trigger: byName.get(m.name)?.trigger ?? '',
-                scope: byName.get(m.name)?.scope ?? [],
-              })),
-            },
-          });
-        } catch (err) {
-          send(ws, {
-            type: 'skills.list',
-            payload: {
-              skills: [],
-              enabled: true,
-              error: err instanceof Error ? err.message : String(err),
-            },
-          });
-        }
+        await handleSkillsList(introspectionCtx, ws);
         break;
       }
 

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -56,6 +56,13 @@ export {
   handleBrainStatus,
 } from './brain.js';
 export {
+  handleDiagGet,
+  handleSkillsList,
+  handleStatsGet,
+  handleToolsList,
+  type IntrospectionContext,
+} from './introspection.js';
+export {
   handleKeyDelete,
   handleKeySetActive,
   handleKeyUpsert,

--- a/packages/cli/src/webui-server/ws-handlers/introspection.ts
+++ b/packages/cli/src/webui-server/ws-handlers/introspection.ts
@@ -1,0 +1,142 @@
+import type { Agent, ModelsRegistry, SkillLoader } from '@wrongstack/core';
+import type { WebSocket } from 'ws';
+import { computeUsageCost, getCostRates } from '../cost-helpers.js';
+import type { WsCommon } from './index.js';
+
+/**
+ * PR 5c of Issue #30: read-only introspection WebSocket handlers
+ * (`skills.list`, `tools.list`, `diag.get`, `stats.get`).
+ *
+ * These four cases all snapshot live run state (the agent context, the
+ * tool registry, the skill loader, token usage) and send it to the
+ * browser — none mutate anything. Extracted from the runWebUI switch onto
+ * an `IntrospectionContext`: a read-only view of the run.
+ */
+
+export interface IntrospectionContext extends WsCommon {
+  /** The running agent — read for ctx (provider/model/usage/messages/…) and tools. */
+  agent: Agent;
+  /** Skill loader backing skills.list (optional — absent ⇒ feature disabled). */
+  skillLoader: SkillLoader | undefined;
+  /** Models registry, used by stats.get to price token usage (optional). */
+  modelsRegistry: ModelsRegistry | undefined;
+  /** Project root reported by diag.get (falls back to ctx.projectRoot). */
+  projectRoot: string | undefined;
+  /** Active session id. */
+  sessionId: string;
+  /** Epoch ms when the run started — stats.get reports elapsed time. */
+  sessionStartedAt: number;
+}
+
+export async function handleSkillsList(ctx: IntrospectionContext, ws: WebSocket): Promise<void> {
+  if (!ctx.skillLoader) {
+    ctx.send(ws, { type: 'skills.list', payload: { skills: [], enabled: false } });
+    return;
+  }
+  try {
+    const manifests = await ctx.skillLoader.list();
+    const entries = await ctx.skillLoader.listEntries();
+    const byName = new Map(entries.map((e) => [e.name, e]));
+    ctx.send(ws, {
+      type: 'skills.list',
+      payload: {
+        enabled: true,
+        skills: manifests.map((m) => ({
+          name: m.name,
+          description: m.description,
+          version: m.version ?? '',
+          source: m.source,
+          path: m.path,
+          trigger: byName.get(m.name)?.trigger ?? '',
+          scope: byName.get(m.name)?.scope ?? [],
+        })),
+      },
+    });
+  } catch (err) {
+    ctx.send(ws, {
+      type: 'skills.list',
+      payload: {
+        skills: [],
+        enabled: true,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
+  }
+}
+
+export function handleToolsList(ctx: IntrospectionContext, ws: WebSocket): void {
+  const list = ctx.agent.tools.list().map((t) => {
+    const schema =
+      (t as { inputSchema?: { properties?: Record<string, unknown> } }).inputSchema ?? {};
+    const params = schema.properties ? Object.keys(schema.properties) : [];
+    return {
+      name: t.name,
+      description: (t as { description?: string | undefined }).description ?? '',
+      params,
+    };
+  });
+  ctx.send(ws, { type: 'tools.list', payload: { tools: list } });
+}
+
+export function handleDiagGet(ctx: IntrospectionContext, ws: WebSocket): void {
+  // Snapshot of key metrics — mirrors the standalone server's handler
+  // and the CLI /diag output. Uses the agent context for live state.
+  const actx = ctx.agent.ctx;
+  const tools = ctx.agent.tools.list();
+  ctx.send(ws, {
+    type: 'diag.get',
+    payload: {
+      provider: (actx.provider as { id: string }).id,
+      model: actx.model,
+      cwd: ctx.projectRoot ?? actx.projectRoot,
+      sessionId: ctx.sessionId,
+      tools: {
+        count: tools.length,
+        names: tools.map((t) => t.name),
+      },
+      features: {},
+      mode: 'default',
+      usage: actx.tokenCounter.total(),
+      messages: actx.messages.length,
+      todos: actx.todos.length,
+    },
+  });
+}
+
+export async function handleStatsGet(ctx: IntrospectionContext, ws: WebSocket): Promise<void> {
+  // Detailed session usage stats, mirroring the CLI /stats.
+  const actx = ctx.agent.ctx;
+  const usage = actx.tokenCounter.total();
+  const cacheStats = actx.tokenCounter.cacheStats();
+  let cost: number | null = null;
+  try {
+    if (ctx.modelsRegistry) {
+      const model = await ctx.modelsRegistry.getModel(
+        (actx.provider as { id: string }).id,
+        actx.model,
+      );
+      const rates = getCostRates(model);
+      cost = computeUsageCost(
+        { input: usage.input, output: usage.output, cacheRead: cacheStats.readTokens },
+        rates,
+      );
+    }
+  } catch {
+    /* cost stays null */
+  }
+  ctx.send(ws, {
+    type: 'stats.get',
+    payload: {
+      sessionId: ctx.sessionId,
+      provider: (actx.provider as { id: string }).id,
+      model: actx.model,
+      usage,
+      cache: cacheStats,
+      cost,
+      messages: actx.messages.length,
+      readFiles: actx.readFiles.size,
+      tools: ctx.agent.tools.list().length,
+      elapsedMs: Date.now() - ctx.sessionStartedAt,
+    },
+  });
+}

--- a/packages/cli/tests/webui-server/ws-handlers-introspection.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-introspection.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import type { WsServerMessage } from '../../src/webui-server/ws-handlers/index.js';
+import {
+  handleDiagGet,
+  handleSkillsList,
+  handleStatsGet,
+  handleToolsList,
+} from '../../src/webui-server/ws-handlers/index.js';
+import type { IntrospectionContext } from '../../src/webui-server/ws-handlers/introspection.js';
+
+/**
+ * PR 5c of Issue #30: introspection ws-handler unit tests.
+ *
+ * skills.list / tools.list / diag.get / stats.get are read-only
+ * snapshots; these drive them with a fake IntrospectionContext (a stub
+ * agent/ctx + capturing send) so no real agent, registry, or socket is
+ * involved.
+ */
+
+const FAKE_WS = {} as WebSocket;
+
+function makeAgent(over: Record<string, unknown> = {}) {
+  const ctx = {
+    provider: { id: 'anthropic' },
+    model: 'claude-opus-4-8',
+    projectRoot: '/proj',
+    tokenCounter: {
+      total: () => ({ input: 100, output: 50 }),
+      cacheStats: () => ({ readTokens: 10, writeTokens: 5 }),
+    },
+    messages: [{ role: 'user' }, { role: 'assistant' }],
+    todos: [{ id: '1' }],
+    readFiles: new Set(['a.ts', 'b.ts']),
+    ...over,
+  };
+  return {
+    ctx,
+    tools: {
+      list: () => [
+        { name: 'read', description: 'Read a file', inputSchema: { properties: { path: {} } } },
+        { name: 'bash', description: 'Run a command' },
+      ],
+    },
+  };
+}
+
+function makeCtx(over: Partial<IntrospectionContext> = {}): {
+  ctx: IntrospectionContext;
+  sent: WsServerMessage[];
+} {
+  const sent: WsServerMessage[] = [];
+  const ctx: IntrospectionContext = {
+    agent: makeAgent() as never,
+    skillLoader: undefined,
+    modelsRegistry: undefined,
+    projectRoot: '/proj',
+    sessionId: 'sess-1',
+    sessionStartedAt: 0,
+    send: (_ws, msg) => sent.push(msg),
+    broadcast: () => {},
+    log: () => {},
+    ...over,
+  };
+  return { ctx, sent };
+}
+
+const payloadOf = (sent: WsServerMessage[], type: string) =>
+  sent.find((m) => m.type === type)?.payload as Record<string, unknown> | undefined;
+
+describe('handleToolsList', () => {
+  it('lists tool names, descriptions and param keys', () => {
+    const { ctx, sent } = makeCtx();
+    handleToolsList(ctx, FAKE_WS);
+    const tools = payloadOf(sent, 'tools.list')?.tools as Array<Record<string, unknown>>;
+    expect(tools).toEqual([
+      { name: 'read', description: 'Read a file', params: ['path'] },
+      { name: 'bash', description: 'Run a command', params: [] },
+    ]);
+  });
+});
+
+describe('handleDiagGet', () => {
+  it('snapshots provider/model/tools/usage from the agent ctx', () => {
+    const { ctx, sent } = makeCtx();
+    handleDiagGet(ctx, FAKE_WS);
+    const p = payloadOf(sent, 'diag.get');
+    expect(p).toMatchObject({
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      cwd: '/proj',
+      sessionId: 'sess-1',
+      tools: { count: 2, names: ['read', 'bash'] },
+      messages: 2,
+      todos: 1,
+    });
+  });
+});
+
+describe('handleSkillsList', () => {
+  it('reports disabled when no skill loader is wired', async () => {
+    const { ctx, sent } = makeCtx({ skillLoader: undefined });
+    await handleSkillsList(ctx, FAKE_WS);
+    expect(payloadOf(sent, 'skills.list')).toEqual({ skills: [], enabled: false });
+  });
+
+  it('maps manifests + entry triggers when a loader is present', async () => {
+    const loader = {
+      list: async () => [
+        { name: 's1', description: 'one', version: '1.0', source: 'user', path: '/s1' },
+      ],
+      listEntries: async () => [{ name: 's1', trigger: '/s1', scope: ['a'] }],
+    };
+    const { ctx, sent } = makeCtx({ skillLoader: loader as never });
+    await handleSkillsList(ctx, FAKE_WS);
+    const p = payloadOf(sent, 'skills.list');
+    expect(p?.enabled).toBe(true);
+    expect((p?.skills as Array<Record<string, unknown>>)[0]).toMatchObject({
+      name: 's1',
+      trigger: '/s1',
+      scope: ['a'],
+    });
+  });
+
+  it('reports an error payload when the loader throws', async () => {
+    const loader = {
+      list: async () => {
+        throw new Error('skills broke');
+      },
+      listEntries: async () => [],
+    };
+    const { ctx, sent } = makeCtx({ skillLoader: loader as never });
+    await handleSkillsList(ctx, FAKE_WS);
+    expect(payloadOf(sent, 'skills.list')).toMatchObject({ enabled: true, error: 'skills broke' });
+  });
+});
+
+describe('handleStatsGet', () => {
+  it('leaves cost null when no models registry is wired', async () => {
+    const { ctx, sent } = makeCtx({ modelsRegistry: undefined, sessionStartedAt: 0 });
+    await handleStatsGet(ctx, FAKE_WS);
+    const p = payloadOf(sent, 'stats.get');
+    expect(p).toMatchObject({
+      sessionId: 'sess-1',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      cost: null,
+      messages: 2,
+      readFiles: 2,
+      tools: 2,
+    });
+    expect(typeof p?.elapsedMs).toBe('number');
+  });
+
+  it('prices usage when a registry resolves the model', async () => {
+    const registry = {
+      getModel: async () => ({ cost: { input: 3, output: 15, cache_read: 0.3 } }),
+    };
+    const { ctx, sent } = makeCtx({ modelsRegistry: registry as never });
+    await handleStatsGet(ctx, FAKE_WS);
+    const p = payloadOf(sent, 'stats.get');
+    // cost computed (non-null number) — exact value depends on getCostRates/computeUsageCost.
+    expect(typeof p?.cost).toBe('number');
+  });
+});


### PR DESCRIPTION
Continues the ws-handlers extraction with the **introspection** group:
the four read-only snapshot handlers `skills.list` / `tools.list` /
`diag.get` / `stats.get`.

## What moves
- **`ws-handlers/introspection.ts`** — `handleSkillsList` /
  `handleToolsList` / `handleDiagGet` / `handleStatsGet` on an
  `IntrospectionContext extends WsCommon`: a read-only view of the run
  (agent, skillLoader, modelsRegistry, projectRoot, sessionId,
  sessionStartedAt). None mutate state; stats pricing pulls
  `getCostRates`/`computeUsageCost` from `cost-helpers` directly.
- **`webui-server.ts`** — builds `introspectionCtx` once; the 4 switch
  cases call the handlers. **~110 inline lines removed.** Dropped the now
  -unused `computeUsageCost` import.

## Tests
New `tests/webui-server/ws-handlers-introspection.test.ts` (7 cases):
tool listing, diag snapshot, skills disabled/mapped/error, stats with and
without a models registry — via a stub agent, no real run.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- full webui-server suite (15 files) **81/81** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)