### PR TITLE
refactor(cli): extract agent-config (modes/model) ws-handlers (PR 5e of #30)

### DIFF
--- a/docs/refactor-next.md
+++ b/docs/refactor-next.md
@@ -20,7 +20,8 @@ refactor). Update this before switching context, handing off, or resuming.
 | 5b | ws-handlers/ — **brain group** | ✅ merged | #62 |
 | 5c | ws-handlers/ — **introspection group** | ✅ merged | #63 |
 | 5d | ws-handlers/ — **worklist group** (todos/tasks/plan) | ✅ merged | #64 |
-| 5e | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
+| 5e | ws-handlers/ — **agent-config** (modes/model) | ✅ merged | #65 |
+| 5f | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
 
 `webui-server.ts` is ~3000 lines (down from ~3250). The self-contained
 concerns now live under `packages/cli/src/webui-server/`:
@@ -39,6 +40,7 @@ webui-server/
     brain.ts            — brain.status/risk/ask handlers     (PR 5b)
     introspection.ts    — skills/tools/diag/stats snapshots  (PR 5c)
     worklist.ts         — todos/tasks/plan handlers          (PR 5d)
+    agent-config.ts     — modes/mode.switch/model.*          (PR 5e)
 ```
 
 Per-group contexts now extend a small `WsCommon` base (`send`/`broadcast`/
@@ -48,18 +50,19 @@ A module-map doc comment at the top of `webui-server.ts` points to each.
 
 ---
 
-## PR 5e — remaining ws-handler groups (🔴 in progress)
+## PR 5f — remaining ws-handler groups (🔴 in progress)
 
-Extracted so far: **providers** (PR 5), **brain** (5b), **introspection**
-(5c), **worklist** todos/tasks/plan (5d) — each fully unit-tested,
-threaded via a per-group context extending `WsCommon`. Current reality:
+Extracted so far: **providers** (5), **brain** (5b), **introspection**
+(5c), **worklist** todos/tasks/plan (5d), **agent-config** modes/model
+(5e) — each fully unit-tested, threaded via a per-group context extending
+`WsCommon`. Current reality:
 
 - **Already delegated** — `memory.*`, `files.*`, `mailbox.*`, `shell.open`
   cases already call the shared `@wrongstack/webui/server` handlers. No
   CLI-local extraction to do.
 - **Still inline** — the `handleMessage` switch cases for
-  `sessions` / `session.*`, `context.*`, `projects.*`, `modes`/`mode.*`,
-  `model.*`, `autonomy.switch`, `prefs.*`, plus `handleUserMessage`. These
+  `sessions` / `session.*`, `context.*`, `projects.*`,
+  `autonomy.switch`, `prefs.*`, plus `handleUserMessage`. These
   are coupled to run-loop state (the abort controllers, client map,
   custom-mode store, session writer/store, the session.start payload
   builder, the prefs-snapshot/persist closures) — extract test-first, one

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -56,10 +56,8 @@ import {
   DEFAULT_CONTEXT_WINDOW_MODE_ID,
   DefaultSecretScrubber,
   DefaultSystemPromptBuilder,
-  enhanceUserPrompt,
   GlobalMailbox,
   projectSlug,
-  recentTextTurns,
   repairToolUseAdjacency,
   resolveContextWindowPolicy,
   resolveProjectDir,
@@ -97,6 +95,7 @@ import {
 import { createProviderConfigStore } from './webui-server/provider-config.js';
 import { startStaticServe } from './webui-server/static-serve.js';
 import {
+  type AgentConfigContext,
   type BrainHandlerContext,
   type IntrospectionContext,
   type WorklistContext,
@@ -108,6 +107,10 @@ import {
   handleKeyDelete,
   handleKeySetActive,
   handleKeyUpsert,
+  handleModeSwitch,
+  handleModelRefine,
+  handleModelSwitch,
+  handleModesList,
   handlePlanGet,
   handlePlanItemUpdate,
   handlePlanTemplateUse,
@@ -1288,6 +1291,16 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     log: (m) => console.log(m),
   };
 
+  const agentConfigCtx: AgentConfigContext = {
+    agent: opts.agent,
+    modeStore: opts.modeStore,
+    globalConfigPath: opts.globalConfigPath,
+    buildSessionStart: (overrides) => buildSessionStartPayload(overrides),
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
   async function handleMessage(
     ws: WebSocket,
     client: ConnectedClient,
@@ -1774,98 +1787,21 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'modes.list': {
-        if (!opts.modeStore) {
-          send(ws, {
-            type: 'modes.list',
-            payload: { modes: [], activeId: 'default', error: 'Mode store not available' },
-          });
-          break;
-        }
-        try {
-          const modes = await opts.modeStore.listModes();
-          const active = await opts.modeStore.getActiveMode();
-          send(ws, {
-            type: 'modes.list',
-            payload: {
-              modes: modes.map((m) => ({
-                id: m.id,
-                name: m.name,
-                description: m.description,
-                isActive: m.id === (active?.id ?? 'default'),
-              })),
-              activeId: active?.id ?? 'default',
-            },
-          });
-        } catch (err) {
-          send(ws, {
-            type: 'modes.list',
-            payload: {
-              modes: [],
-              activeId: 'default',
-              error: err instanceof Error ? err.message : String(err),
-            },
-          });
-        }
+        await handleModesList(agentConfigCtx, ws);
         break;
       }
 
       case 'mode.switch': {
-        if (!opts.modeStore) {
-          sendResult(ws, false, 'Mode store not available');
-          break;
-        }
-        const { id } = (msg as { payload: { id: string } }).payload;
-        try {
-          if (id === 'default') {
-            await opts.modeStore.setActiveMode(null);
-          } else {
-            const found = await opts.modeStore.getMode(id);
-            if (!found) throw new Error(`Unknown mode "${id}"`);
-            await opts.modeStore.setActiveMode(id);
-          }
-          // Store the mode in context.meta so the agent sees it on the next turn.
-          opts.agent.ctx.meta['mode'] = id;
-          sendResult(ws, true, `Switched to mode "${id}"`);
-          const modeSwP = await buildSessionStartPayload({ mode: id });
-          broadcast({ type: 'session.start', payload: modeSwP });
-        } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
-        }
+        await handleModeSwitch(agentConfigCtx, ws, (msg as { payload: { id: string } }).payload.id);
         break;
       }
 
       case 'model.switch': {
-        const { provider: newProvider, model: newModel } = (
-          msg as { payload: { provider: string; model: string } }
-        ).payload;
-        try {
-          // Update context
-          const ctx = opts.agent.ctx;
-          ctx.model = newModel;
-
-          // Create a new provider instance from the saved config
-          const { makeProviderFromConfig } = await import('@wrongstack/providers');
-          const { loadSavedProviders } = await import('./webui-server/provider-config.js');
-          const saved = await loadSavedProviders(opts.globalConfigPath);
-          const providerCfg = saved[newProvider] ?? { type: newProvider };
-          const newProv = makeProviderFromConfig(newProvider, providerCfg);
-          ctx.provider = newProv;
-
-          send(ws, {
-            type: 'key.operation_result',
-            payload: { success: true, message: `Switched to ${newProvider} / ${newModel}` },
-          });
-          const modelSwP = await buildSessionStartPayload();
-          broadcast({ type: 'session.start', payload: modelSwP });
-        } catch (err) {
-          send(ws, {
-            type: 'key.operation_result',
-            payload: {
-              success: false,
-              message: `Switch failed: ${err instanceof Error ? err.message : String(err)}`,
-            },
-          });
-        }
+        await handleModelSwitch(
+          agentConfigCtx,
+          ws,
+          (msg as { payload: { provider: string; model: string } }).payload,
+        );
         break;
       }
 
@@ -2500,55 +2436,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'model.refine': {
-        const { text } = (msg as { payload: { text: string } }).payload;
-        if (!text?.trim()) {
-          send(ws, {
-            type: 'model.refine_result',
-            payload: { refined: '', english: '', error: 'Empty text' },
-          });
-          break;
-        }
-        try {
-          const ctx = opts.agent.ctx;
-          const history = recentTextTurns(ctx.messages);
-          const result = await enhanceUserPrompt({
-            provider: ctx.provider,
-            model: ctx.model,
-            text,
-            history,
-            timeoutMs: 90000,
-            onError: (reason) => {
-              console.warn(
-                JSON.stringify({
-                  level: 'warn',
-                  event: 'model.refine_failed',
-                  reason,
-                  timestamp: new Date().toISOString(),
-                }),
-              );
-            },
-          });
-          if (result) {
-            send(ws, {
-              type: 'model.refine_result',
-              payload: { refined: result.refined, english: result.english },
-            });
-          } else {
-            send(ws, {
-              type: 'model.refine_result',
-              payload: { refined: text, english: text, error: 'Refinement returned no result' },
-            });
-          }
-        } catch (err) {
-          send(ws, {
-            type: 'model.refine_result',
-            payload: {
-              refined: text,
-              english: text,
-              error: err instanceof Error ? err.message : String(err),
-            },
-          });
-        }
+        await handleModelRefine(agentConfigCtx, ws, (msg as { payload: { text: string } }).payload.text);
         break;
       }
 

--- a/packages/cli/src/webui-server/ws-handlers/agent-config.ts
+++ b/packages/cli/src/webui-server/ws-handlers/agent-config.ts
@@ -1,0 +1,178 @@
+import { type Agent, enhanceUserPrompt, type ModeStore, recentTextTurns } from '@wrongstack/core';
+import { makeProviderFromConfig } from '@wrongstack/providers';
+import type { WebSocket } from 'ws';
+import { loadSavedProviders } from '../provider-config.js';
+import type { WsCommon } from './index.js';
+
+/**
+ * PR 5e of Issue #30: agent-configuration WebSocket handlers —
+ * `modes.list` / `mode.switch` (agent mode) and `model.switch` /
+ * `model.refine` (provider+model). The first three re-broadcast a fresh
+ * `session.start` so every browser tab reflects the change.
+ *
+ * The session.start payload is built by `runWebUI`'s closure
+ * (`buildSessionStartPayload`, which reads a large amount of run state);
+ * it's threaded in here as the `buildSessionStart` callback rather than
+ * reconstructed. The other former captures (`opts.modeStore`,
+ * `opts.agent`, `opts.globalConfigPath`) are `AgentConfigContext` fields.
+ */
+
+export interface AgentConfigContext extends WsCommon {
+  /** The running agent — mode/model/provider live on its ctx. */
+  agent: Agent;
+  /** Mode store backing modes.list / mode.switch (optional). */
+  modeStore: ModeStore | undefined;
+  /** Global config path — model.switch reads saved provider configs from it. */
+  globalConfigPath: string | undefined;
+  /** Build the session.start payload (runWebUI's closure), broadcast on a config change. */
+  buildSessionStart: (overrides?: Record<string, unknown>) => Promise<unknown>;
+}
+
+function sendResult(ctx: WsCommon, ws: WebSocket, success: boolean, message: string): void {
+  ctx.send(ws, { type: 'key.operation_result', payload: { success, message } });
+}
+
+export async function handleModesList(ctx: AgentConfigContext, ws: WebSocket): Promise<void> {
+  if (!ctx.modeStore) {
+    ctx.send(ws, {
+      type: 'modes.list',
+      payload: { modes: [], activeId: 'default', error: 'Mode store not available' },
+    });
+    return;
+  }
+  try {
+    const modes = await ctx.modeStore.listModes();
+    const active = await ctx.modeStore.getActiveMode();
+    ctx.send(ws, {
+      type: 'modes.list',
+      payload: {
+        modes: modes.map((m) => ({
+          id: m.id,
+          name: m.name,
+          description: m.description,
+          isActive: m.id === (active?.id ?? 'default'),
+        })),
+        activeId: active?.id ?? 'default',
+      },
+    });
+  } catch (err) {
+    ctx.send(ws, {
+      type: 'modes.list',
+      payload: {
+        modes: [],
+        activeId: 'default',
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
+  }
+}
+
+export async function handleModeSwitch(
+  ctx: AgentConfigContext,
+  ws: WebSocket,
+  id: string,
+): Promise<void> {
+  if (!ctx.modeStore) {
+    sendResult(ctx, ws, false, 'Mode store not available');
+    return;
+  }
+  try {
+    if (id === 'default') {
+      await ctx.modeStore.setActiveMode(null);
+    } else {
+      const found = await ctx.modeStore.getMode(id);
+      if (!found) throw new Error(`Unknown mode "${id}"`);
+      await ctx.modeStore.setActiveMode(id);
+    }
+    // Store the mode in context.meta so the agent sees it on the next turn.
+    ctx.agent.ctx.meta['mode'] = id;
+    sendResult(ctx, ws, true, `Switched to mode "${id}"`);
+    const payload = await ctx.buildSessionStart({ mode: id });
+    ctx.broadcast({ type: 'session.start', payload });
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleModelSwitch(
+  ctx: AgentConfigContext,
+  ws: WebSocket,
+  payload: { provider: string; model: string },
+): Promise<void> {
+  const { provider: newProvider, model: newModel } = payload;
+  try {
+    const actx = ctx.agent.ctx;
+    actx.model = newModel;
+
+    // Create a new provider instance from the saved config.
+    const saved = await loadSavedProviders(ctx.globalConfigPath);
+    const providerCfg = saved[newProvider] ?? { type: newProvider };
+    actx.provider = makeProviderFromConfig(newProvider, providerCfg);
+
+    sendResult(ctx, ws, true, `Switched to ${newProvider} / ${newModel}`);
+    const payloadOut = await ctx.buildSessionStart();
+    ctx.broadcast({ type: 'session.start', payload: payloadOut });
+  } catch (err) {
+    sendResult(
+      ctx,
+      ws,
+      false,
+      `Switch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export async function handleModelRefine(
+  ctx: AgentConfigContext,
+  ws: WebSocket,
+  text: string,
+): Promise<void> {
+  if (!text?.trim()) {
+    ctx.send(ws, {
+      type: 'model.refine_result',
+      payload: { refined: '', english: '', error: 'Empty text' },
+    });
+    return;
+  }
+  try {
+    const actx = ctx.agent.ctx;
+    const history = recentTextTurns(actx.messages);
+    const result = await enhanceUserPrompt({
+      provider: actx.provider,
+      model: actx.model,
+      text,
+      history,
+      timeoutMs: 90000,
+      onError: (reason) => {
+        ctx.log(
+          JSON.stringify({
+            level: 'warn',
+            event: 'model.refine_failed',
+            reason,
+            timestamp: new Date().toISOString(),
+          }),
+        );
+      },
+    });
+    if (result) {
+      ctx.send(ws, {
+        type: 'model.refine_result',
+        payload: { refined: result.refined, english: result.english },
+      });
+    } else {
+      ctx.send(ws, {
+        type: 'model.refine_result',
+        payload: { refined: text, english: text, error: 'Refinement returned no result' },
+      });
+    }
+  } catch (err) {
+    ctx.send(ws, {
+      type: 'model.refine_result',
+      payload: {
+        refined: text,
+        english: text,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
+  }
+}

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -50,6 +50,13 @@ export interface WsHandlerContext extends WsCommon {
 }
 
 export {
+  type AgentConfigContext,
+  handleModelRefine,
+  handleModelSwitch,
+  handleModeSwitch,
+  handleModesList,
+} from './agent-config.js';
+export {
   type BrainHandlerContext,
   handleBrainAsk,
   handleBrainRisk,

--- a/packages/cli/tests/webui-server/ws-handlers-agent-config.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-agent-config.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import type { AgentConfigContext } from '../../src/webui-server/ws-handlers/agent-config.js';
+import type { WsServerMessage } from '../../src/webui-server/ws-handlers/index.js';
+import {
+  handleModelRefine,
+  handleModelSwitch,
+  handleModeSwitch,
+  handleModesList,
+} from '../../src/webui-server/ws-handlers/index.js';
+
+/**
+ * PR 5e of Issue #30: agent-config ws-handler unit tests.
+ *
+ * modes/mode.switch run against a stub mode store; model.switch/refine
+ * use a fake agent ctx. buildSessionStart is a spy so no real
+ * session.start payload is constructed.
+ */
+
+const FAKE_WS = {} as WebSocket;
+
+function makeModeStore(modes: Array<{ id: string; name: string; description: string }>) {
+  let active: string | null = null;
+  return {
+    listModes: async () => modes,
+    getActiveMode: async () => (active ? modes.find((m) => m.id === active) : null),
+    getMode: async (id: string) => modes.find((m) => m.id === id) ?? null,
+    setActiveMode: async (id: string | null) => {
+      active = id;
+    },
+    _active: () => active,
+  };
+}
+
+function makeCtx(over: Partial<AgentConfigContext> = {}): {
+  ctx: AgentConfigContext;
+  sent: WsServerMessage[];
+  bc: WsServerMessage[];
+  builtWith: Array<Record<string, unknown> | undefined>;
+  agentCtx: {
+    meta: Record<string, unknown>;
+    model: string;
+    provider: unknown;
+    messages: unknown[];
+  };
+} {
+  const sent: WsServerMessage[] = [];
+  const bc: WsServerMessage[] = [];
+  const builtWith: Array<Record<string, unknown> | undefined> = [];
+  const agentCtx = {
+    meta: {} as Record<string, unknown>,
+    model: 'old-model',
+    provider: {},
+    messages: [],
+  };
+  const ctx: AgentConfigContext = {
+    agent: { ctx: agentCtx } as never,
+    modeStore: undefined,
+    globalConfigPath: undefined,
+    buildSessionStart: async (o) => {
+      builtWith.push(o);
+      return { sessionStart: true, o };
+    },
+    send: (_ws, m) => sent.push(m),
+    broadcast: (m) => bc.push(m),
+    log: () => {},
+    ...over,
+  };
+  return { ctx, sent, bc, builtWith, agentCtx };
+}
+
+const result = (sent: WsServerMessage[]) =>
+  sent.filter((m) => m.type === 'key.operation_result').at(-1)?.payload as
+    | { success: boolean; message: string }
+    | undefined;
+const lastOf = (msgs: WsServerMessage[], type: string) =>
+  msgs.filter((m) => m.type === type).at(-1);
+
+describe('handleModesList', () => {
+  it('errors when no mode store is wired', async () => {
+    const { ctx, sent } = makeCtx({ modeStore: undefined });
+    await handleModesList(ctx, FAKE_WS);
+    expect(lastOf(sent, 'modes.list')?.payload).toMatchObject({
+      error: 'Mode store not available',
+    });
+  });
+
+  it('lists modes and marks the active one', async () => {
+    const store = makeModeStore([
+      { id: 'plan', name: 'Plan', description: 'planning' },
+      { id: 'build', name: 'Build', description: 'building' },
+    ]);
+    await store.setActiveMode('build');
+    const { ctx, sent } = makeCtx({ modeStore: store as never });
+    await handleModesList(ctx, FAKE_WS);
+    const p = lastOf(sent, 'modes.list')?.payload as {
+      modes: Array<{ id: string; isActive: boolean }>;
+      activeId: string;
+    };
+    expect(p.activeId).toBe('build');
+    expect(p.modes.find((m) => m.id === 'build')?.isActive).toBe(true);
+  });
+});
+
+describe('handleModeSwitch', () => {
+  it('rejects when no mode store is wired', async () => {
+    const { ctx, sent } = makeCtx({ modeStore: undefined });
+    await handleModeSwitch(ctx, FAKE_WS, 'plan');
+    expect(result(sent)).toMatchObject({ success: false });
+  });
+
+  it('switches to a known mode, sets meta, broadcasts session.start', async () => {
+    const store = makeModeStore([{ id: 'plan', name: 'Plan', description: 'p' }]);
+    const { ctx, sent, bc, builtWith, agentCtx } = makeCtx({ modeStore: store as never });
+    await handleModeSwitch(ctx, FAKE_WS, 'plan');
+    expect(result(sent)?.success).toBe(true);
+    expect(agentCtx.meta['mode']).toBe('plan');
+    expect(store._active()).toBe('plan');
+    expect(builtWith).toEqual([{ mode: 'plan' }]);
+    expect(lastOf(bc, 'session.start')).toBeDefined();
+  });
+
+  it('switching to default clears the active mode', async () => {
+    const store = makeModeStore([{ id: 'plan', name: 'Plan', description: 'p' }]);
+    await store.setActiveMode('plan');
+    const { ctx } = makeCtx({ modeStore: store as never });
+    await handleModeSwitch(ctx, FAKE_WS, 'default');
+    expect(store._active()).toBeNull();
+  });
+
+  it('rejects an unknown mode', async () => {
+    const store = makeModeStore([{ id: 'plan', name: 'Plan', description: 'p' }]);
+    const { ctx, sent } = makeCtx({ modeStore: store as never });
+    await handleModeSwitch(ctx, FAKE_WS, 'nope');
+    expect(result(sent)?.success).toBe(false);
+    expect(result(sent)?.message).toContain('Unknown mode');
+  });
+});
+
+describe('handleModelSwitch', () => {
+  it('updates ctx.model and emits a result', async () => {
+    const { ctx, sent, agentCtx } = makeCtx({ globalConfigPath: undefined });
+    await handleModelSwitch(ctx, FAKE_WS, { provider: 'anthropic', model: 'claude-test' });
+    // model is set before the provider step, regardless of provider construction outcome
+    expect(agentCtx.model).toBe('claude-test');
+    expect(result(sent)).toBeDefined();
+  });
+});
+
+describe('handleModelRefine', () => {
+  it('rejects empty text without calling the provider', async () => {
+    const { ctx, sent } = makeCtx();
+    await handleModelRefine(ctx, FAKE_WS, '   ');
+    expect(lastOf(sent, 'model.refine_result')?.payload).toMatchObject({ error: 'Empty text' });
+  });
+});


### PR DESCRIPTION
Continues the ws-handlers extraction with the **agent-configuration**
group: `modes.list` / `mode.switch` (agent mode) and `model.switch` /
`model.refine` (provider+model) — 4 handlers.

## What moves
- **`ws-handlers/agent-config.ts`** on an `AgentConfigContext extends
  WsCommon` (`{ agent, modeStore, globalConfigPath, buildSessionStart }`).
  The `session.start` payload is built by runWebUI's closure, threaded in
  as the `buildSessionStart` callback (mode/model switches re-broadcast
  `session.start`). `makeProviderFromConfig` / `loadSavedProviders` /
  `enhanceUserPrompt` / `recentTextTurns` are now static imports.
- **`webui-server.ts`** builds `agentConfigCtx` once; the 4 cases
  delegate. **~130 inline lines removed.** Dropped now-unused core imports.

## Tests
New `tests/webui-server/ws-handlers-agent-config.test.ts` (8 cases): mode
listing + active marking, switch (known/default/unknown/no-store) with
meta + `session.start` broadcast, `model.switch` updates ctx.model,
`model.refine` empty-text guard.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- full webui-server suite (17 files) **102/102** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)