### PR TITLE
refactor(cli): extract prefs (prefs/autonomy.switch) ws-handlers (PR 5f of #30)

### DIFF
--- a/docs/refactor-next.md
+++ b/docs/refactor-next.md
@@ -21,7 +21,8 @@ refactor). Update this before switching context, handing off, or resuming.
 | 5c | ws-handlers/ — **introspection group** | ✅ merged | #63 |
 | 5d | ws-handlers/ — **worklist group** (todos/tasks/plan) | ✅ merged | #64 |
 | 5e | ws-handlers/ — **agent-config** (modes/model) | ✅ merged | #65 |
-| 5f | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
+| 5f | ws-handlers/ — **prefs** (prefs/autonomy.switch) | ✅ merged | #66 |
+| 5g | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
 
 `webui-server.ts` is ~3000 lines (down from ~3250). The self-contained
 concerns now live under `packages/cli/src/webui-server/`:
@@ -41,6 +42,7 @@ webui-server/
     introspection.ts    — skills/tools/diag/stats snapshots  (PR 5c)
     worklist.ts         — todos/tasks/plan handlers          (PR 5d)
     agent-config.ts     — modes/mode.switch/model.*          (PR 5e)
+    prefs.ts            — prefs.get/update, autonomy.switch   (PR 5f)
 ```
 
 Per-group contexts now extend a small `WsCommon` base (`send`/`broadcast`/
@@ -50,19 +52,19 @@ A module-map doc comment at the top of `webui-server.ts` points to each.
 
 ---
 
-## PR 5f — remaining ws-handler groups (🔴 in progress)
+## PR 5g — remaining ws-handler groups (🔴 in progress)
 
 Extracted so far: **providers** (5), **brain** (5b), **introspection**
-(5c), **worklist** todos/tasks/plan (5d), **agent-config** modes/model
-(5e) — each fully unit-tested, threaded via a per-group context extending
-`WsCommon`. Current reality:
+(5c), **worklist** (5d), **agent-config** (5e), **prefs** (5f) — each
+fully unit-tested, threaded via a per-group context extending `WsCommon`.
+Current reality:
 
 - **Already delegated** — `memory.*`, `files.*`, `mailbox.*`, `shell.open`
   cases already call the shared `@wrongstack/webui/server` handlers. No
   CLI-local extraction to do.
 - **Still inline** — the `handleMessage` switch cases for
-  `sessions` / `session.*`, `context.*`, `projects.*`,
-  `autonomy.switch`, `prefs.*`, plus `handleUserMessage`. These
+  `sessions` / `session.*`, `context.*`, `projects.*`, plus
+  `handleUserMessage`. These
   are coupled to run-loop state (the abort controllers, client map,
   custom-mode store, session writer/store, the session.start payload
   builder, the prefs-snapshot/persist closures) — extract test-first, one

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -98,12 +98,16 @@ import {
   type AgentConfigContext,
   type BrainHandlerContext,
   type IntrospectionContext,
+  type PrefsContext,
   type WorklistContext,
   type WsHandlerContext,
+  handleAutonomySwitch,
   handleBrainAsk,
   handleBrainRisk,
   handleBrainStatus,
   handleDiagGet,
+  handlePrefsGet,
+  handlePrefsUpdate,
   handleKeyDelete,
   handleKeySetActive,
   handleKeyUpsert,
@@ -1301,6 +1305,16 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     log: (m) => console.log(m),
   };
 
+  const prefsCtx: PrefsContext = {
+    agent: opts.agent,
+    prefSnapshot,
+    persistPrefs: persistPrefsToConfig,
+    onAutonomySwitch: opts.onAutonomySwitch,
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
   async function handleMessage(
     ws: WebSocket,
     client: ConnectedClient,
@@ -1614,14 +1628,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'autonomy.switch': {
-        const { mode } = (msg as { payload: { mode: string } }).payload;
-        opts.agent.ctx.meta['autonomy'] = mode;
-        // Flip the CLI's REAL autonomy state (same setter the TUI uses) —
-        // meta alone is advisory and the running loop never reads it.
-        opts.onAutonomySwitch?.(mode);
-        sendResult(ws, true, `Autonomy mode set to "${mode}"`);
-        broadcast({ type: 'prefs.updated', payload: { autonomy: mode } });
-        void persistPrefsToConfig({ autonomy: mode });
+        handleAutonomySwitch(prefsCtx, ws, (msg as { payload: { mode: string } }).payload.mode);
         break;
       }
 
@@ -2115,24 +2122,12 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       // ── Preferences ──────────────────────────────────────────
 
       case 'prefs.get': {
-        // Return the current pref snapshot from context.meta so the
-        // frontend can seed its local-prefs store from the server's truth.
-        send(ws, { type: 'prefs.updated', payload: prefSnapshot() });
+        handlePrefsGet(prefsCtx, ws);
         break;
       }
 
       case 'prefs.update': {
-        // Batch preference update. Merges arbitrary key/value pairs into
-        // context.meta so the runtime can read them immediately, broadcasts
-        // the full pref snapshot to every connected client so all browser
-        // tabs stay in sync, and persists the durable keys to config.json
-        // (same key mapping the TUI settings picker writes).
-        const payload = (msg as { payload: Record<string, unknown> }).payload;
-        for (const [key, val] of Object.entries(payload)) {
-          opts.agent.ctx.meta[key] = val;
-        }
-        void persistPrefsToConfig(payload);
-        broadcast({ type: 'prefs.updated', payload: prefSnapshot() });
+        handlePrefsUpdate(prefsCtx, ws, (msg as { payload: Record<string, unknown> }).payload);
         break;
       }
 

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -70,6 +70,12 @@ export {
   type IntrospectionContext,
 } from './introspection.js';
 export {
+  handleAutonomySwitch,
+  handlePrefsGet,
+  handlePrefsUpdate,
+  type PrefsContext,
+} from './prefs.js';
+export {
   handleKeyDelete,
   handleKeySetActive,
   handleKeyUpsert,

--- a/packages/cli/src/webui-server/ws-handlers/prefs.ts
+++ b/packages/cli/src/webui-server/ws-handlers/prefs.ts
@@ -1,0 +1,61 @@
+import type { Agent } from '@wrongstack/core';
+import type { WebSocket } from 'ws';
+import type { WsCommon } from './index.js';
+
+/**
+ * PR 5f of Issue #30: preference WebSocket handlers — `prefs.get`,
+ * `prefs.update`, and `autonomy.switch`.
+ *
+ * The durable logic (which keys are persisted, the config.json key
+ * mapping, and the live pref snapshot off `ctx.meta`) lives in runWebUI's
+ * `prefSnapshot` / `persistPrefsToConfig` closures and the host's real
+ * autonomy setter; they're threaded in here as callbacks. The handlers
+ * themselves just write `ctx.meta`, fan the snapshot out, and persist.
+ */
+
+export interface PrefsContext extends WsCommon {
+  /** The running agent — preferences live on `agent.ctx.meta`. */
+  agent: Agent;
+  /** Snapshot the durable prefs off ctx.meta (runWebUI closure). */
+  prefSnapshot: () => Record<string, unknown>;
+  /** Persist the durable keys to config.json, fire-and-forget (runWebUI closure). */
+  persistPrefs: (payload: Record<string, unknown>) => Promise<void>;
+  /** Flip the CLI's real autonomy state (same setter the TUI uses), if wired. */
+  onAutonomySwitch: ((mode: string) => void) | undefined;
+}
+
+function sendResult(ctx: WsCommon, ws: WebSocket, success: boolean, message: string): void {
+  ctx.send(ws, { type: 'key.operation_result', payload: { success, message } });
+}
+
+export function handlePrefsGet(ctx: PrefsContext, ws: WebSocket): void {
+  // Return the current pref snapshot from context.meta so the frontend
+  // can seed its local-prefs store from the server's truth.
+  ctx.send(ws, { type: 'prefs.updated', payload: ctx.prefSnapshot() });
+}
+
+export function handlePrefsUpdate(
+  ctx: PrefsContext,
+  _ws: WebSocket,
+  payload: Record<string, unknown>,
+): void {
+  // Batch preference update. Merge arbitrary key/value pairs into
+  // context.meta so the runtime can read them immediately, persist the
+  // durable keys to config.json, then broadcast the full snapshot so all
+  // browser tabs stay in sync.
+  for (const [key, val] of Object.entries(payload)) {
+    ctx.agent.ctx.meta[key] = val;
+  }
+  void ctx.persistPrefs(payload);
+  ctx.broadcast({ type: 'prefs.updated', payload: ctx.prefSnapshot() });
+}
+
+export function handleAutonomySwitch(ctx: PrefsContext, ws: WebSocket, mode: string): void {
+  ctx.agent.ctx.meta['autonomy'] = mode;
+  // Flip the CLI's REAL autonomy state (same setter the TUI uses) — meta
+  // alone is advisory and the running loop never reads it.
+  ctx.onAutonomySwitch?.(mode);
+  sendResult(ctx, ws, true, `Autonomy mode set to "${mode}"`);
+  ctx.broadcast({ type: 'prefs.updated', payload: { autonomy: mode } });
+  void ctx.persistPrefs({ autonomy: mode });
+}

--- a/packages/cli/tests/webui-server/ws-handlers-prefs.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-prefs.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import type { WsServerMessage } from '../../src/webui-server/ws-handlers/index.js';
+import {
+  handleAutonomySwitch,
+  handlePrefsGet,
+  handlePrefsUpdate,
+} from '../../src/webui-server/ws-handlers/index.js';
+import type { PrefsContext } from '../../src/webui-server/ws-handlers/prefs.js';
+
+/**
+ * PR 5f of Issue #30: prefs ws-handler unit tests.
+ *
+ * Drives the handlers with a fake agent ctx and spy prefSnapshot /
+ * persistPrefs / onAutonomySwitch callbacks (the durable logic stays in
+ * runWebUI's closures).
+ */
+
+const FAKE_WS = {} as WebSocket;
+
+function makeCtx(over: Partial<PrefsContext> = {}): {
+  ctx: PrefsContext;
+  sent: WsServerMessage[];
+  bc: WsServerMessage[];
+  persisted: Array<Record<string, unknown>>;
+  switched: string[];
+  meta: Record<string, unknown>;
+} {
+  const sent: WsServerMessage[] = [];
+  const bc: WsServerMessage[] = [];
+  const persisted: Array<Record<string, unknown>> = [];
+  const switched: string[] = [];
+  const meta: Record<string, unknown> = {};
+  const ctx: PrefsContext = {
+    agent: { ctx: { meta } } as never,
+    prefSnapshot: () => ({ ...meta }),
+    persistPrefs: async (p) => {
+      persisted.push(p);
+    },
+    onAutonomySwitch: (m) => switched.push(m),
+    send: (_ws, m) => sent.push(m),
+    broadcast: (m) => bc.push(m),
+    log: () => {},
+    ...over,
+  };
+  return { ctx, sent, bc, persisted, switched, meta };
+}
+
+const lastOf = (msgs: WsServerMessage[], type: string) =>
+  msgs.filter((m) => m.type === type).at(-1);
+
+describe('handlePrefsGet', () => {
+  it('sends the current snapshot', () => {
+    const { ctx, sent, meta } = makeCtx();
+    meta['autonomy'] = 'auto';
+    handlePrefsGet(ctx, FAKE_WS);
+    expect(lastOf(sent, 'prefs.updated')?.payload).toEqual({ autonomy: 'auto' });
+  });
+});
+
+describe('handlePrefsUpdate', () => {
+  it('merges into meta, persists the payload, broadcasts the snapshot', () => {
+    const { ctx, bc, persisted, meta } = makeCtx();
+    handlePrefsUpdate(ctx, FAKE_WS, { yolo: true, maxIterations: 9 });
+    expect(meta).toMatchObject({ yolo: true, maxIterations: 9 });
+    expect(persisted).toEqual([{ yolo: true, maxIterations: 9 }]);
+    expect(lastOf(bc, 'prefs.updated')?.payload).toMatchObject({ yolo: true, maxIterations: 9 });
+  });
+});
+
+describe('handleAutonomySwitch', () => {
+  it('sets meta, flips the real autonomy state, broadcasts, persists', () => {
+    const { ctx, sent, bc, persisted, switched, meta } = makeCtx();
+    handleAutonomySwitch(ctx, FAKE_WS, 'suggest');
+    expect(meta['autonomy']).toBe('suggest');
+    expect(switched).toEqual(['suggest']);
+    const res = sent.find((m) => m.type === 'key.operation_result')?.payload as {
+      success: boolean;
+    };
+    expect(res.success).toBe(true);
+    expect(lastOf(bc, 'prefs.updated')?.payload).toEqual({ autonomy: 'suggest' });
+    expect(persisted).toEqual([{ autonomy: 'suggest' }]);
+  });
+
+  it('tolerates a missing onAutonomySwitch (advisory meta only)', () => {
+    const { ctx, meta } = makeCtx({ onAutonomySwitch: undefined });
+    expect(() => handleAutonomySwitch(ctx, FAKE_WS, 'off')).not.toThrow();
+    expect(meta['autonomy']).toBe('off');
+  });
+});


### PR DESCRIPTION
Continues the ws-handlers extraction with the **prefs** group: `prefs.get`,
`prefs.update`, and `autonomy.switch` — 3 handlers.

## What moves
- **`ws-handlers/prefs.ts`** on a `PrefsContext extends WsCommon`. The
  durable logic (which keys persist, the config.json key mapping, the meta
  snapshot, the host's real autonomy setter) stays in runWebUI's closures
  and is threaded in as callbacks (`prefSnapshot` / `persistPrefs` /
  `onAutonomySwitch`). The handlers just write `ctx.meta`, fan the
  snapshot out, and persist.
- **`webui-server.ts`** builds `prefsCtx` once; the 3 cases delegate.
  ~40 inline lines removed.

## Tests
New `tests/webui-server/ws-handlers-prefs.test.ts` (4 cases): get sends
snapshot; update merges meta + persists + broadcasts; `autonomy.switch`
sets meta + flips real state + broadcasts + persists, and tolerates a
missing `onAutonomySwitch`.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- full webui-server suite (18 files) **106/106** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)