### PR TITLE
refactor(cli): extract project ws-handlers + fix context TDZ (PR 5g of #30)

### DIFF
--- a/docs/refactor-next.md
+++ b/docs/refactor-next.md
@@ -22,7 +22,8 @@ refactor). Update this before switching context, handing off, or resuming.
 | 5d | ws-handlers/ — **worklist group** (todos/tasks/plan) | ✅ merged | #64 |
 | 5e | ws-handlers/ — **agent-config** (modes/model) | ✅ merged | #65 |
 | 5f | ws-handlers/ — **prefs** (prefs/autonomy.switch) | ✅ merged | #66 |
-| 5g | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
+| 5g | ws-handlers/ — **projects** (list/select/add/working_dir) | ✅ merged | #67 |
+| 5h | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
 
 `webui-server.ts` is ~3000 lines (down from ~3250). The self-contained
 concerns now live under `packages/cli/src/webui-server/`:
@@ -43,27 +44,31 @@ webui-server/
     worklist.ts         — todos/tasks/plan handlers          (PR 5d)
     agent-config.ts     — modes/mode.switch/model.*          (PR 5e)
     prefs.ts            — prefs.get/update, autonomy.switch   (PR 5f)
+    projects.ts         — projects.list/select/add, working_dir (PR 5g)
 ```
 
 Per-group contexts now extend a small `WsCommon` base (`send`/`broadcast`/
-`log`) rather than one shared god-object growing a field per concern.
+`log`) rather than one shared god-object growing a field per concern. All
+contexts are now built **before** the WS connection handler is wired, so a
+fast client message can't reach a handler before its context initializes
+(fixed a latent TDZ in PR 5g).
 
 A module-map doc comment at the top of `webui-server.ts` points to each.
 
 ---
 
-## PR 5g — remaining ws-handler groups (🔴 in progress)
+## PR 5h — remaining ws-handler groups (🔴 in progress)
 
 Extracted so far: **providers** (5), **brain** (5b), **introspection**
-(5c), **worklist** (5d), **agent-config** (5e), **prefs** (5f) — each
-fully unit-tested, threaded via a per-group context extending `WsCommon`.
-Current reality:
+(5c), **worklist** (5d), **agent-config** (5e), **prefs** (5f),
+**projects** (5g) — each fully unit-tested, threaded via a per-group
+context extending `WsCommon`. Current reality:
 
 - **Already delegated** — `memory.*`, `files.*`, `mailbox.*`, `shell.open`
   cases already call the shared `@wrongstack/webui/server` handlers. No
   CLI-local extraction to do.
 - **Still inline** — the `handleMessage` switch cases for
-  `sessions` / `session.*`, `context.*`, `projects.*`, plus
+  `sessions` / `session.*`, `context.*`, plus
   `handleUserMessage`. These
   are coupled to run-loop state (the abort controllers, client map,
   custom-mode store, session writer/store, the session.start payload

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -55,9 +55,7 @@ import {
   atomicWrite,
   DEFAULT_CONTEXT_WINDOW_MODE_ID,
   DefaultSecretScrubber,
-  DefaultSystemPromptBuilder,
   GlobalMailbox,
-  projectSlug,
   repairToolUseAdjacency,
   resolveContextWindowPolicy,
   resolveProjectDir,
@@ -99,6 +97,7 @@ import {
   type BrainHandlerContext,
   type IntrospectionContext,
   type PrefsContext,
+  type ProjectsContext,
   type WorklistContext,
   type WsHandlerContext,
   handleAutonomySwitch,
@@ -118,6 +117,9 @@ import {
   handlePlanGet,
   handlePlanItemUpdate,
   handlePlanTemplateUse,
+  handleProjectsAdd,
+  handleProjectsList,
+  handleProjectsSelect,
   handleProviderAdd,
   handleProviderModels,
   handleProviderRemove,
@@ -132,6 +134,7 @@ import {
   handleTodosGet,
   handleTodosRemove,
   handleToolsList,
+  handleWorkingDirSet,
 } from './webui-server/ws-handlers/index.js';
 import { WebSocket, WebSocketServer } from 'ws';
 
@@ -1005,6 +1008,88 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     );
   }
 
+  // Shared state for the extracted ws-handler groups (PR 5 of #30).
+  // `send`/`broadcast` are hoisted function declarations, so capturing
+  // them here is safe even though they're defined further down.
+  const wsHandlerCtx: WsHandlerContext = {
+    providerStore: createProviderConfigStore(opts.globalConfigPath),
+    modelsRegistry: opts.modelsRegistry,
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
+  const brainCtx: BrainHandlerContext = {
+    brainSettings: opts.brainSettings,
+    getBrainLog: opts.getBrainLog,
+    // Prefer the host-supplied arbiter; otherwise resolve the one bound
+    // in the agent container (if any). Mirrors the former inline lookup.
+    resolveArbiter: () =>
+      opts.brain ??
+      (opts.agent.container.has(TOKENS.BrainArbiter)
+        ? opts.agent.container.resolve(TOKENS.BrainArbiter)
+        : undefined),
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
+  const introspectionCtx: IntrospectionContext = {
+    agent: opts.agent,
+    skillLoader: opts.skillLoader,
+    modelsRegistry: opts.modelsRegistry,
+    projectRoot: opts.projectRoot,
+    sessionId: opts.session.id,
+    sessionStartedAt,
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
+  const worklistCtx: WorklistContext = {
+    agent: opts.agent,
+    sessionId: opts.session.id,
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
+  const agentConfigCtx: AgentConfigContext = {
+    agent: opts.agent,
+    modeStore: opts.modeStore,
+    globalConfigPath: opts.globalConfigPath,
+    buildSessionStart: (overrides) => buildSessionStartPayload(overrides),
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
+  const prefsCtx: PrefsContext = {
+    agent: opts.agent,
+    prefSnapshot,
+    persistPrefs: persistPrefsToConfig,
+    onAutonomySwitch: opts.onAutonomySwitch,
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
+
+  // projects.select re-roots the run in place, so `opts` is passed by
+  // reference (the handlers mutate opts.projectRoot / opts.sessionStore).
+  const projectsCtx: ProjectsContext = {
+    opts,
+    abortControllers,
+    abortLegacyRun: () => {
+      if (abortController) {
+        abortController.abort();
+        abortController = null;
+      }
+    },
+    buildSessionStart: (overrides) => buildSessionStartPayload(overrides),
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
   return new Promise<void>((resolve) => {
     wss.on('listening', () => {
       console.log(`[WebUI] WebSocket server running on ws://${host}:${port}`);
@@ -1248,72 +1333,6 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
 
     registerWebuiSignalHandlers(signalShutdown);
   });
-
-  // Shared state for the extracted ws-handler groups (PR 5 of #30).
-  // `send`/`broadcast` are hoisted function declarations, so capturing
-  // them here is safe even though they're defined further down.
-  const wsHandlerCtx: WsHandlerContext = {
-    providerStore: createProviderConfigStore(opts.globalConfigPath),
-    modelsRegistry: opts.modelsRegistry,
-    send,
-    broadcast,
-    log: (m) => console.log(m),
-  };
-
-  const brainCtx: BrainHandlerContext = {
-    brainSettings: opts.brainSettings,
-    getBrainLog: opts.getBrainLog,
-    // Prefer the host-supplied arbiter; otherwise resolve the one bound
-    // in the agent container (if any). Mirrors the former inline lookup.
-    resolveArbiter: () =>
-      opts.brain ??
-      (opts.agent.container.has(TOKENS.BrainArbiter)
-        ? opts.agent.container.resolve(TOKENS.BrainArbiter)
-        : undefined),
-    send,
-    broadcast,
-    log: (m) => console.log(m),
-  };
-
-  const introspectionCtx: IntrospectionContext = {
-    agent: opts.agent,
-    skillLoader: opts.skillLoader,
-    modelsRegistry: opts.modelsRegistry,
-    projectRoot: opts.projectRoot,
-    sessionId: opts.session.id,
-    sessionStartedAt,
-    send,
-    broadcast,
-    log: (m) => console.log(m),
-  };
-
-  const worklistCtx: WorklistContext = {
-    agent: opts.agent,
-    sessionId: opts.session.id,
-    send,
-    broadcast,
-    log: (m) => console.log(m),
-  };
-
-  const agentConfigCtx: AgentConfigContext = {
-    agent: opts.agent,
-    modeStore: opts.modeStore,
-    globalConfigPath: opts.globalConfigPath,
-    buildSessionStart: (overrides) => buildSessionStartPayload(overrides),
-    send,
-    broadcast,
-    log: (m) => console.log(m),
-  };
-
-  const prefsCtx: PrefsContext = {
-    agent: opts.agent,
-    prefSnapshot,
-    persistPrefs: persistPrefsToConfig,
-    onAutonomySwitch: opts.onAutonomySwitch,
-    send,
-    broadcast,
-    log: (m) => console.log(m),
-  };
 
   async function handleMessage(
     ws: WebSocket,
@@ -2159,258 +2178,34 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         break;
 
       case 'projects.list': {
-        // Read the project manifest from ~/.wrongstack/projects.json
-        const projectsBase = opts.globalConfigPath
-          ? path.resolve(path.dirname(opts.globalConfigPath))
-          : wstackGlobalRoot();
-        const manifestPath = path.join(projectsBase, 'projects.json');
-        try {
-          const raw = await fs.readFile(manifestPath, 'utf8');
-          const manifest = JSON.parse(raw) as {
-            projects: Array<{ name: string; root: string; slug: string; lastSeen?: string }>;
-          };
-          send(ws, {
-            type: 'projects.list',
-            payload: { projects: manifest.projects ?? [] },
-          });
-        } catch {
-          send(ws, { type: 'projects.list', payload: { projects: [] } });
-        }
+        await handleProjectsList(projectsCtx, ws);
         break;
       }
 
       case 'projects.select': {
-        // In-process project switch — mirrors the standalone server's handler:
-        // re-root everything the handlers read at call time (opts.projectRoot,
-        // agent ctx, session store), finalize the old session writer, start a
-        // fresh session in the new project, and broadcast a reset
-        // session.start so every client re-renders (sessions, file manager,
-        // mailbox, context bar).
-        //
-        // An older version spawned a NEW interactive wstack with
-        // stdio:'inherit' into the host's terminal and changed nothing in the
-        // browser — the WebUI stayed on the old project.
-        const { root, name: projectName } = (
-          msg as { payload: { root: string; name?: string | undefined } }
-        ).payload;
-        try {
-          const resolved = path.resolve(root);
-          const stat = await fs.stat(resolved).catch(() => null);
-          if (!stat?.isDirectory()) {
-            send(ws, {
-              type: 'projects.selected',
-              payload: {
-                root,
-                name: projectName ?? path.basename(root),
-                message: `Cannot switch: not a directory: ${resolved}`,
-              },
-            });
-            break;
-          }
-
-          // Manifest: bump lastSeen, or auto-register an unknown root.
-          const { loadManifest, saveManifest } = await import('./slash-commands/project-utils.js');
-          const manifest = await loadManifest(opts.globalConfigPath);
-          const entry = manifest.projects.find((p) => path.resolve(p.root) === resolved);
-          const displayName = projectName?.trim() || entry?.name || path.basename(resolved);
-          if (entry) {
-            entry.lastSeen = new Date().toISOString();
-          } else {
-            manifest.projects.push({
-              name: displayName,
-              root: resolved,
-              slug: projectSlug(resolved),
-              lastSeen: new Date().toISOString(),
-              createdAt: new Date().toISOString(),
-            });
-          }
-          await saveManifest(manifest, opts.globalConfigPath);
-
-          // Abort any in-flight run — its context is about to be re-rooted.
-          if (abortController) {
-            abortController.abort();
-            abortController = null;
-          }
-          // Also clear the per-socket controller for this switching client
-          // so a subsequent `case 'abort'` from a reconnected socket starts
-          // clean. We do NOT iterate other sockets' controllers — a project
-          // switch is a server-wide state change and other sockets should see
-          // it via the projects.list broadcast below, not be aborted.
-          abortControllers.delete(ws);
-
-          const ctx = opts.agent.ctx;
-          const oldSessionId = ctx.session?.id ?? opts.session.id;
-
-          // Finalize the writer we are leaving. Usage captured before the
-          // counter reset below (the closure runs after it).
-          const oldWriter = ctx.session;
-          const oldUsage = ctx.tokenCounter.total();
-          if (oldWriter) {
-            void (async () => {
-              await oldWriter
-                .append({ type: 'session_end', ts: new Date().toISOString(), usage: oldUsage })
-                .catch(() => undefined);
-              await oldWriter.close().catch(() => undefined);
-            })();
-          }
-
-          // Re-root: every handler resolves opts.projectRoot / ctx at call
-          // time (files.*, mailbox.*, goal, …), so mutating these re-roots
-          // them all without further plumbing.
-          opts.projectRoot = resolved;
-          ctx.cwd = resolved;
-          ctx.projectRoot = resolved;
-
-          // Rebuild the system prompt for the NEW project. The environment
-          // block (project root, git status, languages) is baked into the
-          // prompt at boot; without this rebuild the agent keeps the
-          // launch-directory environment and tries to operate in the old
-          // folder until tool errors correct it. Best-effort — a failure here
-          // leaves the prior prompt rather than breaking the switch.
-          try {
-            const switchMode =
-              opts.modeId && opts.modeId !== 'default' && opts.modeStore
-                ? await opts.modeStore.getMode(opts.modeId)
-                : undefined;
-            const switchBuilder = new DefaultSystemPromptBuilder({
-              memoryStore: opts.memoryStore,
-              skillLoader: opts.skillLoader,
-              modeStore: opts.modeStore,
-              modeId: opts.modeId ?? 'default',
-              modePrompt: switchMode?.prompt ?? '',
-            });
-            ctx.systemPrompt = await switchBuilder.build({
-              cwd: resolved,
-              projectRoot: resolved,
-              tools: opts.agent.tools.list(),
-              provider: (ctx.provider as { id?: string }).id,
-              model: ctx.model,
-            });
-          } catch {
-            /* best-effort — keep the prior system prompt if rebuild fails */
-          }
-
-          // Fresh per-project session store + session.
-          const globalRoot = opts.globalConfigPath
-            ? path.dirname(opts.globalConfigPath)
-            : wstackGlobalRoot();
-          const newSessionsDir = path.join(resolveProjectDir(resolved, globalRoot), 'sessions');
-          await fs.mkdir(newSessionsDir, { recursive: true });
-          const newStore = new DefaultSessionStore({ dir: newSessionsDir });
-          opts.sessionStore = newStore;
-          const newWriter = await newStore.create({
-            id: '',
-            title: '',
-            model: ctx.model,
-            provider: (ctx.provider as { id?: string }).id ?? '',
-          });
-          ctx.session = newWriter;
-          opts.onSessionSwapped?.(newWriter.id);
-          ctx.state.replaceMessages([]);
-          ctx.state.replaceTodos([]);
-          ctx.readFiles.clear();
-          ctx.fileMtimes.clear();
-          ctx.tokenCounter.reset();
-
-          send(ws, {
-            type: 'projects.selected',
-            payload: {
-              root: resolved,
-              name: displayName,
-              message: `Switched to ${displayName}`,
-            },
-          });
-          // Full-state broadcast so ALL clients re-root their panels.
-          const switchedP = await buildSessionStartPayload({
-            reset: true,
-            clearedSessionId: oldSessionId,
-          });
-          broadcast({ type: 'session.start', payload: switchedP });
-        } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
-        }
+        await handleProjectsSelect(
+          projectsCtx,
+          ws,
+          (msg as { payload: { root: string; name?: string | undefined } }).payload,
+        );
         break;
       }
 
       case 'projects.add': {
-        // Register a folder in the project manifest (Projects panel "Add").
-        // Ported from the standalone server — this message used to fall
-        // through to "Unknown message type" here, so adding a project from
-        // the WebUI silently did nothing on the embedded server.
-        const { root: addRoot, name: addName } = (
-          msg as { payload: { root: string; name?: string | undefined } }
-        ).payload;
-        try {
-          const resolved = path.resolve(addRoot);
-          const stat = await fs.stat(resolved).catch(() => null);
-          if (!stat?.isDirectory()) throw new Error(`Not a directory: ${resolved}`);
-
-          const { loadManifest, saveManifest, ensureProjectDataDir } = await import(
-            './slash-commands/project-utils.js'
-          );
-          const manifest = await loadManifest(opts.globalConfigPath);
-          const existing = manifest.projects.find((p) => path.resolve(p.root) === resolved);
-          if (existing) {
-            send(ws, {
-              type: 'projects.added',
-              payload: {
-                name: existing.name,
-                root: existing.root,
-                slug: existing.slug,
-                message: `Already registered as "${existing.name}"`,
-              },
-            });
-            break;
-          }
-          const name = addName?.trim() || path.basename(resolved);
-          const slug = projectSlug(resolved);
-          await ensureProjectDataDir(slug, opts.globalConfigPath);
-          const now = new Date().toISOString();
-          manifest.projects.push({ name, root: resolved, slug, lastSeen: now, createdAt: now });
-          await saveManifest(manifest, opts.globalConfigPath);
-          send(ws, {
-            type: 'projects.added',
-            payload: { name, root: resolved, slug, message: `Registered project "${name}"` },
-          });
-        } catch (err) {
-          send(ws, {
-            type: 'projects.added',
-            payload: {
-              name: path.basename(addRoot),
-              root: addRoot,
-              slug: '',
-              message: err instanceof Error ? err.message : String(err),
-            },
-          });
-        }
+        await handleProjectsAdd(
+          projectsCtx,
+          ws,
+          (msg as { payload: { root: string; name?: string | undefined } }).payload,
+        );
         break;
       }
 
       case 'working_dir.set': {
-        // FileExplorer breadcrumb navigation. Ported from the standalone
-        // server (used to be an unknown message here).
-        const { path: newPath } = (msg as { payload: { path: string } }).payload;
-        try {
-          const wdRoot = opts.projectRoot ?? opts.agent.ctx.projectRoot;
-          const resolved = path.resolve(wdRoot, newPath);
-          if (!resolved.startsWith(wdRoot + path.sep) && resolved !== wdRoot) {
-            sendResult(ws, false, `Path must stay inside the project root: ${wdRoot}`);
-            break;
-          }
-          const stat = await fs.stat(resolved).catch(() => null);
-          if (!stat?.isDirectory()) {
-            sendResult(ws, false, `Directory not found or not accessible: ${resolved}`);
-            break;
-          }
-          opts.agent.ctx.cwd = resolved;
-          broadcast({
-            type: 'working_dir.changed',
-            payload: { cwd: resolved, projectRoot: wdRoot },
-          });
-          sendResult(ws, true, `Working directory set to ${resolved}`);
-        } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
-        }
+        await handleWorkingDirSet(
+          projectsCtx,
+          ws,
+          (msg as { payload: { path: string } }).payload.path,
+        );
         break;
       }
 

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -76,6 +76,14 @@ export {
   type PrefsContext,
 } from './prefs.js';
 export {
+  handleProjectsAdd,
+  handleProjectsList,
+  handleProjectsSelect,
+  handleWorkingDirSet,
+  type ProjectsContext,
+  type ProjectsOptions,
+} from './projects.js';
+export {
   handleKeyDelete,
   handleKeySetActive,
   handleKeyUpsert,

--- a/packages/cli/src/webui-server/ws-handlers/projects.ts
+++ b/packages/cli/src/webui-server/ws-handlers/projects.ts
@@ -1,0 +1,285 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  type Agent,
+  DefaultSystemPromptBuilder,
+  type MemoryStore,
+  type ModeStore,
+  projectSlug,
+  resolveProjectDir,
+  type SessionStore,
+  type SessionWriter,
+  type SkillLoader,
+  wstackGlobalRoot,
+} from '@wrongstack/core';
+import { DefaultSessionStore } from '@wrongstack/core/storage';
+import type { WebSocket } from 'ws';
+import {
+  ensureProjectDataDir,
+  loadManifest,
+  saveManifest,
+} from '../../slash-commands/project-utils.js';
+import type { WsCommon } from './index.js';
+
+/**
+ * PR 5g of Issue #30: project-management WebSocket handlers —
+ * `projects.list`, `projects.select`, `projects.add`, and
+ * `working_dir.set`.
+ *
+ * `projects.select` is the heavyweight: it re-roots the entire run in
+ * place (mutates `opts.projectRoot` / `opts.sessionStore`, aborts the
+ * in-flight run, finalizes the old session writer, rebuilds the system
+ * prompt, starts a fresh session, and broadcasts a reset session.start).
+ * Because every other handler reads `opts.projectRoot` / `ctx` at call
+ * time, mutating those fields re-roots them all without further plumbing.
+ *
+ * To keep that working from a module, `opts` is passed by reference (the
+ * SAME object runWebUI holds — `ProjectsOptions` is just the subset these
+ * handlers touch), the legacy abort slot is a callback, and the
+ * session.start payload builder is the `buildSessionStart` callback.
+ */
+
+/** The subset of CliWebUIOptions the project handlers read/mutate. Passed by reference. */
+export interface ProjectsOptions {
+  projectRoot?: string | undefined;
+  globalConfigPath?: string | undefined;
+  agent: Agent;
+  modeId?: string | undefined;
+  modeStore?: ModeStore | undefined;
+  memoryStore?: MemoryStore | undefined;
+  skillLoader?: SkillLoader | undefined;
+  sessionStore?: SessionStore | undefined;
+  session: SessionWriter;
+  onSessionSwapped?: ((newSessionId: string) => void) | undefined;
+}
+
+export interface ProjectsContext extends WsCommon {
+  /** The live options object (mutated in place by projects.select). */
+  opts: ProjectsOptions;
+  /** Per-socket abort controllers — the switching socket's is dropped on select. */
+  abortControllers: Map<WebSocket, AbortController>;
+  /** Abort the legacy single-slot in-flight run and clear it (run-loop closure). */
+  abortLegacyRun: () => void;
+  /** Build the reset session.start payload (runWebUI closure). */
+  buildSessionStart: (overrides?: Record<string, unknown>) => Promise<unknown>;
+}
+
+function sendResult(ctx: WsCommon, ws: WebSocket, success: boolean, message: string): void {
+  ctx.send(ws, { type: 'key.operation_result', payload: { success, message } });
+}
+
+export async function handleProjectsList(ctx: ProjectsContext, ws: WebSocket): Promise<void> {
+  // Read the project manifest from ~/.wrongstack/projects.json
+  const projectsBase = ctx.opts.globalConfigPath
+    ? path.resolve(path.dirname(ctx.opts.globalConfigPath))
+    : wstackGlobalRoot();
+  const manifestPath = path.join(projectsBase, 'projects.json');
+  try {
+    const raw = await fs.readFile(manifestPath, 'utf8');
+    const manifest = JSON.parse(raw) as {
+      projects: Array<{ name: string; root: string; slug: string; lastSeen?: string }>;
+    };
+    ctx.send(ws, { type: 'projects.list', payload: { projects: manifest.projects ?? [] } });
+  } catch {
+    ctx.send(ws, { type: 'projects.list', payload: { projects: [] } });
+  }
+}
+
+export async function handleProjectsSelect(
+  ctx: ProjectsContext,
+  ws: WebSocket,
+  payload: { root: string; name?: string | undefined },
+): Promise<void> {
+  const { opts } = ctx;
+  const { root, name: projectName } = payload;
+  try {
+    const resolved = path.resolve(root);
+    const stat = await fs.stat(resolved).catch(() => null);
+    if (!stat?.isDirectory()) {
+      ctx.send(ws, {
+        type: 'projects.selected',
+        payload: {
+          root,
+          name: projectName ?? path.basename(root),
+          message: `Cannot switch: not a directory: ${resolved}`,
+        },
+      });
+      return;
+    }
+
+    // Manifest: bump lastSeen, or auto-register an unknown root.
+    const manifest = await loadManifest(opts.globalConfigPath);
+    const entry = manifest.projects.find((p) => path.resolve(p.root) === resolved);
+    const displayName = projectName?.trim() || entry?.name || path.basename(resolved);
+    if (entry) {
+      entry.lastSeen = new Date().toISOString();
+    } else {
+      manifest.projects.push({
+        name: displayName,
+        root: resolved,
+        slug: projectSlug(resolved),
+        lastSeen: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+      });
+    }
+    await saveManifest(manifest, opts.globalConfigPath);
+
+    // Abort any in-flight run — its context is about to be re-rooted. The
+    // legacy single slot (project-switch path) and this switching socket's
+    // controller both clear; other sockets see the change via the
+    // broadcast below rather than being aborted.
+    ctx.abortLegacyRun();
+    ctx.abortControllers.delete(ws);
+
+    const actx = opts.agent.ctx;
+    const oldSessionId = actx.session?.id ?? opts.session.id;
+
+    // Finalize the writer we are leaving. Usage captured before the counter
+    // reset below (the closure runs after it).
+    const oldWriter = actx.session;
+    const oldUsage = actx.tokenCounter.total();
+    if (oldWriter) {
+      void (async () => {
+        await oldWriter
+          .append({ type: 'session_end', ts: new Date().toISOString(), usage: oldUsage })
+          .catch(() => undefined);
+        await oldWriter.close().catch(() => undefined);
+      })();
+    }
+
+    // Re-root: every handler resolves opts.projectRoot / ctx at call time
+    // (files.*, mailbox.*, goal, …), so mutating these re-roots them all.
+    opts.projectRoot = resolved;
+    actx.cwd = resolved;
+    actx.projectRoot = resolved;
+
+    // Rebuild the system prompt for the NEW project (best-effort).
+    try {
+      const switchMode =
+        opts.modeId && opts.modeId !== 'default' && opts.modeStore
+          ? await opts.modeStore.getMode(opts.modeId)
+          : undefined;
+      const switchBuilder = new DefaultSystemPromptBuilder({
+        memoryStore: opts.memoryStore,
+        skillLoader: opts.skillLoader,
+        modeStore: opts.modeStore,
+        modeId: opts.modeId ?? 'default',
+        modePrompt: switchMode?.prompt ?? '',
+      });
+      actx.systemPrompt = await switchBuilder.build({
+        cwd: resolved,
+        projectRoot: resolved,
+        tools: opts.agent.tools.list(),
+        provider: (actx.provider as { id?: string }).id,
+        model: actx.model,
+      });
+    } catch {
+      /* best-effort — keep the prior system prompt if rebuild fails */
+    }
+
+    // Fresh per-project session store + session.
+    const globalRoot = opts.globalConfigPath
+      ? path.dirname(opts.globalConfigPath)
+      : wstackGlobalRoot();
+    const newSessionsDir = path.join(resolveProjectDir(resolved, globalRoot), 'sessions');
+    await fs.mkdir(newSessionsDir, { recursive: true });
+    const newStore = new DefaultSessionStore({ dir: newSessionsDir });
+    opts.sessionStore = newStore;
+    const newWriter = await newStore.create({
+      id: '',
+      title: '',
+      model: actx.model,
+      provider: (actx.provider as { id?: string }).id ?? '',
+    });
+    actx.session = newWriter;
+    opts.onSessionSwapped?.(newWriter.id);
+    actx.state.replaceMessages([]);
+    actx.state.replaceTodos([]);
+    actx.readFiles.clear();
+    actx.fileMtimes.clear();
+    actx.tokenCounter.reset();
+
+    ctx.send(ws, {
+      type: 'projects.selected',
+      payload: { root: resolved, name: displayName, message: `Switched to ${displayName}` },
+    });
+    // Full-state broadcast so ALL clients re-root their panels.
+    const switchedP = await ctx.buildSessionStart({ reset: true, clearedSessionId: oldSessionId });
+    ctx.broadcast({ type: 'session.start', payload: switchedP });
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleProjectsAdd(
+  ctx: ProjectsContext,
+  ws: WebSocket,
+  payload: { root: string; name?: string | undefined },
+): Promise<void> {
+  const { root: addRoot, name: addName } = payload;
+  try {
+    const resolved = path.resolve(addRoot);
+    const stat = await fs.stat(resolved).catch(() => null);
+    if (!stat?.isDirectory()) throw new Error(`Not a directory: ${resolved}`);
+
+    const manifest = await loadManifest(ctx.opts.globalConfigPath);
+    const existing = manifest.projects.find((p) => path.resolve(p.root) === resolved);
+    if (existing) {
+      ctx.send(ws, {
+        type: 'projects.added',
+        payload: {
+          name: existing.name,
+          root: existing.root,
+          slug: existing.slug,
+          message: `Already registered as "${existing.name}"`,
+        },
+      });
+      return;
+    }
+    const name = addName?.trim() || path.basename(resolved);
+    const slug = projectSlug(resolved);
+    await ensureProjectDataDir(slug, ctx.opts.globalConfigPath);
+    const now = new Date().toISOString();
+    manifest.projects.push({ name, root: resolved, slug, lastSeen: now, createdAt: now });
+    await saveManifest(manifest, ctx.opts.globalConfigPath);
+    ctx.send(ws, {
+      type: 'projects.added',
+      payload: { name, root: resolved, slug, message: `Registered project "${name}"` },
+    });
+  } catch (err) {
+    ctx.send(ws, {
+      type: 'projects.added',
+      payload: {
+        name: path.basename(addRoot),
+        root: addRoot,
+        slug: '',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    });
+  }
+}
+
+export async function handleWorkingDirSet(
+  ctx: ProjectsContext,
+  ws: WebSocket,
+  newPath: string,
+): Promise<void> {
+  try {
+    const wdRoot = ctx.opts.projectRoot ?? ctx.opts.agent.ctx.projectRoot;
+    const resolved = path.resolve(wdRoot, newPath);
+    if (!resolved.startsWith(wdRoot + path.sep) && resolved !== wdRoot) {
+      sendResult(ctx, ws, false, `Path must stay inside the project root: ${wdRoot}`);
+      return;
+    }
+    const stat = await fs.stat(resolved).catch(() => null);
+    if (!stat?.isDirectory()) {
+      sendResult(ctx, ws, false, `Directory not found or not accessible: ${resolved}`);
+      return;
+    }
+    ctx.opts.agent.ctx.cwd = resolved;
+    ctx.broadcast({ type: 'working_dir.changed', payload: { cwd: resolved, projectRoot: wdRoot } });
+    sendResult(ctx, ws, true, `Working directory set to ${resolved}`);
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}

--- a/packages/cli/tests/webui-server/ws-handlers-projects.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-projects.test.ts
@@ -1,0 +1,230 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import type { WsServerMessage } from '../../src/webui-server/ws-handlers/index.js';
+import {
+  handleProjectsAdd,
+  handleProjectsList,
+  handleProjectsSelect,
+  handleWorkingDirSet,
+} from '../../src/webui-server/ws-handlers/index.js';
+import type {
+  ProjectsContext,
+  ProjectsOptions,
+} from '../../src/webui-server/ws-handlers/projects.js';
+
+/**
+ * PR 5g of Issue #30: project ws-handler unit tests.
+ *
+ * list/add/working_dir.set round-trip through a real temp config dir;
+ * projects.select drives the full in-place re-root against a fake agent
+ * ctx + a real on-disk session store.
+ */
+
+const FAKE_WS = {} as WebSocket;
+
+let tmpDir = '';
+let configPath = '';
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wstack-pr5g-'));
+  configPath = path.join(tmpDir, 'config.json');
+});
+afterEach(async () => {
+  if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+  tmpDir = '';
+  configPath = '';
+});
+
+function makeAgentCtx(root: string) {
+  return {
+    cwd: root,
+    projectRoot: root,
+    model: 'claude-test',
+    provider: { id: 'anthropic' },
+    systemPrompt: 'old prompt',
+    session: { id: 'old-session', append: async () => {}, close: async () => {} },
+    tokenCounter: { total: () => ({ input: 0, output: 0 }), reset: () => {} },
+    readFiles: new Set<string>(['x']),
+    fileMtimes: new Map<string, number>([['x', 1]]),
+    messages: [{ role: 'user' }],
+    todos: [{ id: 't' }],
+    state: { replaceMessages: () => {}, replaceTodos: () => {} },
+  };
+}
+
+function makeCtx(over: Partial<ProjectsOptions> = {}): {
+  ctx: ProjectsContext;
+  sent: WsServerMessage[];
+  bc: WsServerMessage[];
+  aborted: number;
+  swapped: string[];
+  opts: ProjectsOptions;
+} {
+  const sent: WsServerMessage[] = [];
+  const bc: WsServerMessage[] = [];
+  const swapped: string[] = [];
+  let aborted = 0;
+  const opts: ProjectsOptions = {
+    projectRoot: tmpDir,
+    globalConfigPath: configPath,
+    agent: { ctx: makeAgentCtx(tmpDir), tools: { list: () => [] } } as never,
+    modeId: 'default',
+    modeStore: undefined,
+    memoryStore: undefined,
+    skillLoader: undefined,
+    sessionStore: undefined,
+    session: { id: 'startup' } as never,
+    onSessionSwapped: (id) => swapped.push(id),
+    ...over,
+  };
+  const ctx: ProjectsContext = {
+    opts,
+    abortControllers: new Map(),
+    abortLegacyRun: () => {
+      aborted++;
+    },
+    buildSessionStart: async (o) => ({ sessionStart: true, o }),
+    send: (_ws, m) => sent.push(m),
+    broadcast: (m) => bc.push(m),
+    log: () => {},
+  };
+  return {
+    ctx,
+    sent,
+    bc,
+    get aborted() {
+      return aborted;
+    },
+    swapped,
+    opts,
+  };
+}
+
+const lastOf = (msgs: WsServerMessage[], type: string) =>
+  msgs.filter((m) => m.type === type).at(-1);
+
+describe('handleProjectsList', () => {
+  it('returns [] when no manifest exists', async () => {
+    const { ctx, sent } = makeCtx();
+    await handleProjectsList(ctx, FAKE_WS);
+    expect((lastOf(sent, 'projects.list')?.payload as { projects: unknown[] }).projects).toEqual(
+      [],
+    );
+  });
+
+  it('returns the manifest projects when present', async () => {
+    await fs.writeFile(
+      path.join(tmpDir, 'projects.json'),
+      JSON.stringify({ projects: [{ name: 'a', root: '/a', slug: 'a' }] }),
+    );
+    const { ctx, sent } = makeCtx();
+    await handleProjectsList(ctx, FAKE_WS);
+    const p = lastOf(sent, 'projects.list')?.payload as { projects: Array<{ name: string }> };
+    expect(p.projects).toHaveLength(1);
+    expect(p.projects[0]?.name).toBe('a');
+  });
+});
+
+describe('handleProjectsAdd', () => {
+  it('registers a new directory and reports it', async () => {
+    const proj = path.join(tmpDir, 'proj');
+    await fs.mkdir(proj);
+    const { ctx, sent } = makeCtx();
+    await handleProjectsAdd(ctx, FAKE_WS, { root: proj, name: 'Proj' });
+    expect(lastOf(sent, 'projects.added')?.payload).toMatchObject({
+      name: 'Proj',
+      message: expect.stringContaining('Registered'),
+    });
+    // Persisted to the manifest.
+    const raw = await fs.readFile(path.join(tmpDir, 'projects.json'), 'utf8');
+    expect(JSON.parse(raw).projects.some((p: { root: string }) => p.root === proj)).toBe(true);
+  });
+
+  it('reports an already-registered directory', async () => {
+    const proj = path.join(tmpDir, 'proj2');
+    await fs.mkdir(proj);
+    const first = makeCtx();
+    await handleProjectsAdd(first.ctx, FAKE_WS, { root: proj });
+    const second = makeCtx();
+    await handleProjectsAdd(second.ctx, FAKE_WS, { root: proj });
+    expect(
+      (lastOf(second.sent, 'projects.added')?.payload as { message: string }).message,
+    ).toContain('Already registered');
+  });
+
+  it('reports a non-directory error', async () => {
+    const { ctx, sent } = makeCtx();
+    await handleProjectsAdd(ctx, FAKE_WS, { root: path.join(tmpDir, 'nope') });
+    expect((lastOf(sent, 'projects.added')?.payload as { message: string }).message).toContain(
+      'Not a directory',
+    );
+  });
+});
+
+describe('handleWorkingDirSet', () => {
+  it('sets cwd to a valid subdirectory and broadcasts', async () => {
+    const sub = path.join(tmpDir, 'sub');
+    await fs.mkdir(sub);
+    const { ctx, sent, bc, opts } = makeCtx();
+    await handleWorkingDirSet(ctx, FAKE_WS, 'sub');
+    expect((opts.agent as { ctx: { cwd: string } }).ctx.cwd).toBe(sub);
+    expect(lastOf(bc, 'working_dir.changed')?.payload).toMatchObject({ cwd: sub });
+    const res = sent.find((m) => m.type === 'key.operation_result')?.payload as {
+      success: boolean;
+    };
+    expect(res.success).toBe(true);
+  });
+
+  it('rejects a path outside the project root', async () => {
+    const { ctx, sent } = makeCtx();
+    await handleWorkingDirSet(ctx, FAKE_WS, '../escape');
+    const res = sent.find((m) => m.type === 'key.operation_result')?.payload as {
+      success: boolean;
+      message: string;
+    };
+    expect(res.success).toBe(false);
+    expect(res.message).toContain('stay inside');
+  });
+
+  it('rejects a missing directory', async () => {
+    const { ctx, sent } = makeCtx();
+    await handleWorkingDirSet(ctx, FAKE_WS, 'does-not-exist');
+    const res = sent.find((m) => m.type === 'key.operation_result')?.payload as {
+      success: boolean;
+    };
+    expect(res.success).toBe(false);
+  });
+});
+
+describe('handleProjectsSelect', () => {
+  it('rejects a non-directory without re-rooting', async () => {
+    const { ctx, sent, opts } = makeCtx();
+    const before = opts.projectRoot;
+    await handleProjectsSelect(ctx, FAKE_WS, { root: path.join(tmpDir, 'ghost') });
+    expect((lastOf(sent, 'projects.selected')?.payload as { message: string }).message).toContain(
+      'Cannot switch',
+    );
+    expect(opts.projectRoot).toBe(before);
+  });
+
+  it('re-roots the run in place, swaps the session, and broadcasts', async () => {
+    const newProj = path.join(tmpDir, 'newproj');
+    await fs.mkdir(newProj);
+    const t = makeCtx();
+    await handleProjectsSelect(t.ctx, FAKE_WS, { root: newProj, name: 'New' });
+
+    // opts mutated in place (other handlers read these at call time).
+    expect(t.opts.projectRoot).toBe(newProj);
+    expect((t.opts.agent as { ctx: { projectRoot: string } }).ctx.projectRoot).toBe(newProj);
+    // In-flight run aborted, a fresh session writer swapped in.
+    expect(t.aborted).toBe(1);
+    expect(t.opts.sessionStore).toBeDefined();
+    expect(t.swapped).toHaveLength(1);
+    // Reported + full-state broadcast.
+    expect((lastOf(t.sent, 'projects.selected')?.payload as { name: string }).name).toBe('New');
+    expect(lastOf(t.bc, 'session.start')).toBeDefined();
+  });
+});


### PR DESCRIPTION
Continues the ws-handlers extraction with the **project** group:
`projects.list` / `projects.select` / `projects.add` / `working_dir.set`.

## What moves
- **`ws-handlers/projects.ts`** on a `ProjectsContext extends WsCommon`.
  `projects.select` is the heavyweight — it re-roots the run in place
  (mutates `opts.projectRoot`/`opts.sessionStore`, aborts the in-flight
  run, finalizes the old session writer, rebuilds the system prompt, swaps
  a fresh session, broadcasts a reset `session.start`). `opts` is passed
  by reference (a focused `ProjectsOptions` subset, mutated in place so the
  other handlers re-root too); the legacy abort slot is an `abortLegacyRun`
  callback; the payload builder is `buildSessionStart`.
- **`webui-server.ts`** builds `projectsCtx`; the 4 cases delegate.
  ~190 inline lines removed.

## Bug fix: context TDZ
All ws-handler context consts are now declared **before** `return new
Promise` (before the WS connection handler is wired), so a fast client
message can't reach `handleMessage` before its context const initializes.
This surfaced as the projects integration test timing out (`Cannot access
'projectsCtx' before initialization`); the prior groups shared the same
latent window but their tests didn't trip it.

## Tests
New `tests/webui-server/ws-handlers-projects.test.ts` (10 cases): list,
add (new/existing/not-a-dir), working_dir (valid/outside-root/missing),
select not-a-dir + a **full re-root happy path** against a real on-disk
session store.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- full webui-server suite (19 files) **116/116** ✅ (incl. the projects
  integration test that the TDZ fix repaired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)