### PR TITLE
refactor(cli): extract context ws-handlers into ws-handlers/context.ts (PR 5h of #30)

### DIFF
--- a/docs/refactor-next.md
+++ b/docs/refactor-next.md
@@ -23,7 +23,8 @@ refactor). Update this before switching context, handing off, or resuming.
 | 5e | ws-handlers/ — **agent-config** (modes/model) | ✅ merged | #65 |
 | 5f | ws-handlers/ — **prefs** (prefs/autonomy.switch) | ✅ merged | #66 |
 | 5g | ws-handlers/ — **projects** (list/select/add/working_dir) | ✅ merged | #67 |
-| 5h | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
+| 5h | ws-handlers/ — **context** (clear/debug/compact/repair/modes) | ✅ merged | #68 |
+| 5i | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
 
 `webui-server.ts` is ~3000 lines (down from ~3250). The self-contained
 concerns now live under `packages/cli/src/webui-server/`:
@@ -45,6 +46,7 @@ webui-server/
     agent-config.ts     — modes/mode.switch/model.*          (PR 5e)
     prefs.ts            — prefs.get/update, autonomy.switch   (PR 5f)
     projects.ts         — projects.list/select/add, working_dir (PR 5g)
+    context.ts          — context.clear/debug/compact/repair/modes (PR 5h)
 ```
 
 Per-group contexts now extend a small `WsCommon` base (`send`/`broadcast`/
@@ -57,18 +59,18 @@ A module-map doc comment at the top of `webui-server.ts` points to each.
 
 ---
 
-## PR 5h — remaining ws-handler groups (🔴 in progress)
+## PR 5i — remaining ws-handler groups (🔴 in progress)
 
 Extracted so far: **providers** (5), **brain** (5b), **introspection**
 (5c), **worklist** (5d), **agent-config** (5e), **prefs** (5f),
-**projects** (5g) — each fully unit-tested, threaded via a per-group
-context extending `WsCommon`. Current reality:
+**projects** (5g), **context** (5h) — each fully unit-tested, threaded via
+a per-group context extending `WsCommon`. Current reality:
 
 - **Already delegated** — `memory.*`, `files.*`, `mailbox.*`, `shell.open`
   cases already call the shared `@wrongstack/webui/server` handlers. No
   CLI-local extraction to do.
 - **Still inline** — the `handleMessage` switch cases for
-  `sessions` / `session.*`, `context.*`, plus
+  `sessions` / `session.*`, `process.*`, plus
   `handleUserMessage`. These
   are coupled to run-loop state (the abort controllers, client map,
   custom-mode store, session writer/store, the session.start payload

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -56,8 +56,6 @@ import {
   DEFAULT_CONTEXT_WINDOW_MODE_ID,
   DefaultSecretScrubber,
   GlobalMailbox,
-  repairToolUseAdjacency,
-  resolveContextWindowPolicy,
   resolveProjectDir,
   TOKENS,
   type TodoItem,
@@ -95,6 +93,7 @@ import { startStaticServe } from './webui-server/static-serve.js';
 import {
   type AgentConfigContext,
   type BrainHandlerContext,
+  type ContextHandlerContext,
   type IntrospectionContext,
   type PrefsContext,
   type ProjectsContext,
@@ -104,6 +103,15 @@ import {
   handleBrainAsk,
   handleBrainRisk,
   handleBrainStatus,
+  handleContextClear,
+  handleContextCompact,
+  handleContextDebug,
+  handleContextModeCreate,
+  handleContextModeDelete,
+  handleContextModeSwitch,
+  handleContextModeUpdate,
+  handleContextModesList,
+  handleContextRepair,
   handleDiagGet,
   handlePrefsGet,
   handlePrefsUpdate,
@@ -143,12 +151,6 @@ import { WebSocket, WebSocketServer } from 'ws';
 // directly, so we adapt that to the Logger interface expected by the handler.
 // PR 1 of Issue #30: extracted to `./webui-server/logger-shim.js`.
 import { consoleLogger } from './webui-server/logger-shim.js';
-
-// PR 3 of Issue #30: extracted to `./webui-server/context-breakdown.js`.
-import { estimateContextBreakdown } from './webui-server/context-breakdown.js';
-type PromptBlock = import('./webui-server/context-breakdown.js').PromptBlock;
-type ToolLike = import('./webui-server/context-breakdown.js').ToolLike;
-type MessageLike = import('./webui-server/context-breakdown.js').MessageLike;
 
 // ── Cost computation helpers (inlined from @wrongstack/webui/server/usage-cost.ts) ──
 // PR 2 of Issue #30: extracted to `./webui-server/cost-helpers.js`.
@@ -1090,6 +1092,15 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     broadcast,
     log: (m) => console.log(m),
   };
+
+  const contextHandlerCtx: ContextHandlerContext = {
+    agent: opts.agent,
+    buildSessionStart: (overrides) => buildSessionStartPayload(overrides),
+    getCustomModeStore,
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
   return new Promise<void>((resolve) => {
     wss.on('listening', () => {
       console.log(`[WebUI] WebSocket server running on ws://${host}:${port}`);
@@ -1573,15 +1584,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'context.clear': {
-        // In-memory wipe — same as session.new but reuses the current session.
-        const ctx = opts.agent.ctx;
-        ctx.state.replaceMessages([]);
-        ctx.state.replaceTodos([]);
-        ctx.readFiles.clear();
-        ctx.fileMtimes.clear();
-        sendResult(ws, true, 'Context cleared');
-        const ctxClearP = await buildSessionStartPayload({ reset: true });
-        broadcast({ type: 'session.start', payload: ctxClearP });
+        await handleContextClear(contextHandlerCtx, ws);
         break;
       }
 
@@ -1891,228 +1894,86 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'context.debug': {
-        // Per-section token estimate so users can see what's eating the context window.
-        const ctx = opts.agent.ctx;
-        const breakdown = estimateContextBreakdown({
-          systemPrompt: ctx.systemPrompt as ReadonlyArray<PromptBlock>,
-          tools: opts.agent.tools.list() as ReadonlyArray<ToolLike>,
-          messages: ctx.messages as ReadonlyArray<MessageLike>,
-        });
-        send(ws, {
-          type: 'context.debug',
-          payload: {
-            ...breakdown,
-            mode: (ctx.meta['contextWindowMode'] as string) ?? DEFAULT_CONTEXT_WINDOW_MODE_ID,
-            policy: ctx.meta['contextWindowPolicy'] ?? null,
-          },
-        });
+        handleContextDebug(contextHandlerCtx, ws);
         break;
       }
 
       case 'context.compact': {
-        const aggressive = !!(msg as { payload?: { aggressive?: boolean | undefined } }).payload
-          ?.aggressive;
-        try {
-          const compactor = opts.agent.container.resolve(TOKENS.Compactor);
-          if (!compactor) {
-            sendResult(ws, false, 'Compactor not available');
-            break;
-          }
-          const before = opts.agent.ctx.tokenCounter.total();
-          const report = await compactor.compact(opts.agent.ctx, { aggressive });
-          const after = opts.agent.ctx.tokenCounter.total();
-          send(ws, {
-            type: 'context.compacted',
-            payload: {
-              before: before.input + before.output,
-              after: after.input + after.output,
-              saved: Math.max(0, before.input + before.output - after.input - after.output),
-              reductions: report.reductions ?? [],
-              repaired: report.repaired ?? false,
-            },
-          });
-          sendResult(
-            ws,
-            true,
-            `Compacted: ${before.input + before.output} → ${after.input + after.output} tokens`,
-          );
-        } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
-        }
+        await handleContextCompact(
+          contextHandlerCtx,
+          ws,
+          !!(msg as { payload?: { aggressive?: boolean | undefined } }).payload?.aggressive,
+        );
         break;
       }
 
       case 'context.repair': {
-        const ctx = opts.agent.ctx;
-        const beforeMessages = ctx.messages.length;
-        const repaired = repairToolUseAdjacency(ctx.messages);
-        if (repaired.report.changed) {
-          ctx.state.replaceMessages(repaired.messages);
-        }
-        const payload = {
-          removedToolUses: repaired.report.removedToolUses,
-          removedToolResults: repaired.report.removedToolResults,
-          removedMessages: repaired.report.removedMessages,
-          beforeMessages,
-          afterMessages: ctx.messages.length,
-        };
-        broadcast({ type: 'context.repaired', payload });
-        const removed =
-          payload.removedToolUses.length +
-          payload.removedToolResults.length +
-          payload.removedMessages;
-        sendResult(
-          ws,
-          true,
-          removed > 0
-            ? `Context repaired: removed ${removed} orphan protocol item(s)`
-            : 'Context repair found no orphan protocol blocks',
-        );
+        handleContextRepair(contextHandlerCtx, ws);
         break;
       }
 
       case 'context.modes.list': {
-        // Built-ins + file-backed custom modes (store.list() merges both),
-        // matching the standalone server.
-        const active = String(
-          opts.agent.ctx.meta['contextWindowMode'] ?? DEFAULT_CONTEXT_WINDOW_MODE_ID,
-        );
-        const modeStore = await getCustomModeStore();
-        send(ws, {
-          type: 'context.modes.list',
-          payload: {
-            activeId: active,
-            modes: modeStore.list().map((m) => ({
-              id: m.id,
-              name: m.name,
-              description: m.description,
-              isActive: m.id === active,
-              thresholds: m.thresholds,
-              preserveK: m.preserveK,
-              eliseThreshold: m.eliseThreshold,
-              custom: m.custom === true,
-            })),
-          },
-        });
+        await handleContextModesList(contextHandlerCtx, ws);
         break;
       }
 
       case 'context.mode.switch': {
-        const { id } = (msg as { payload: { id: string } }).payload;
-        // Built-in first, then custom (parity with the standalone server —
-        // custom modes were previously unswitchable here).
-        let policy = resolveContextWindowPolicy({}, id);
-        if (policy.id !== id) {
-          const modeStore = await getCustomModeStore();
-          const custom = modeStore.list().find((m) => m.custom === true && m.id === id);
-          if (!custom) {
-            sendResult(ws, false, `Unknown context mode "${id}"`);
-            break;
-          }
-          policy = custom as unknown as typeof policy;
-        }
-        opts.agent.ctx.meta['contextWindowMode'] = policy.id;
-        opts.agent.ctx.meta['contextWindowPolicy'] = policy;
-        sendResult(ws, true, `Context mode switched to ${policy.id}`);
-        broadcast({
-          type: 'context.mode.changed',
-          payload: { id: policy.id, name: policy.name, policy },
-        });
+        await handleContextModeSwitch(
+          contextHandlerCtx,
+          ws,
+          (msg as { payload: { id: string } }).payload.id,
+        );
         break;
       }
 
       case 'context.mode.create': {
-        const payload = (
-          msg as {
-            payload: {
-              id: string;
-              name: string;
-              description: string;
-              thresholds: { warn: number; soft: number; hard: number };
-              preserveK: number;
-              eliseThreshold: number;
-            };
-          }
-        ).payload;
-        const modeStore = await getCustomModeStore();
-        const result = modeStore.create({
-          id: payload.id,
-          name: payload.name,
-          description: payload.description,
-          thresholds: payload.thresholds,
-          preserveK: payload.preserveK,
-          eliseThreshold: payload.eliseThreshold,
-          custom: true,
-          aggressiveOn: 'soft',
-          targetLoad: 0.65,
-        });
-        if (result.ok)
-          await modeStore.save().catch(() => undefined); /* best-effort: user preferences */
-        sendResult(ws, result.ok, result.error ?? `Mode "${payload.id}" created`);
+        await handleContextModeCreate(
+          contextHandlerCtx,
+          ws,
+          (
+            msg as {
+              payload: {
+                id: string;
+                name: string;
+                description: string;
+                thresholds: { warn: number; soft: number; hard: number };
+                preserveK: number;
+                eliseThreshold: number;
+              };
+            }
+          ).payload,
+        );
         break;
       }
 
       case 'context.mode.update': {
-        const payload = (
-          msg as {
-            payload: {
-              id: string;
-              name?: string | undefined;
-              description?: string | undefined;
-              thresholds?:
-                | {
-                    warn?: number | undefined;
-                    soft?: number | undefined;
-                    hard?: number | undefined;
-                  }
-                | undefined;
-              preserveK?: number | undefined;
-              eliseThreshold?: number | undefined;
-            };
-          }
-        ).payload;
-        const modeStore = await getCustomModeStore();
-        // Build the patch without explicit-undefined keys
-        // (exactOptionalPropertyTypes).
-        const result = modeStore.update(payload.id, {
-          ...(payload.name !== undefined ? { name: payload.name } : {}),
-          ...(payload.description !== undefined ? { description: payload.description } : {}),
-          ...(payload.thresholds
-            ? {
-                thresholds: {
-                  warn: payload.thresholds.warn ?? 0.6,
-                  soft: payload.thresholds.soft ?? 0.75,
-                  hard: payload.thresholds.hard ?? 0.9,
-                },
-              }
-            : {}),
-          ...(payload.preserveK !== undefined ? { preserveK: payload.preserveK } : {}),
-          ...(payload.eliseThreshold !== undefined
-            ? { eliseThreshold: payload.eliseThreshold }
-            : {}),
-        });
-        if (result.ok)
-          await modeStore.save().catch(() => undefined); /* best-effort: user preferences */
-        sendResult(ws, result.ok, result.error ?? `Mode "${payload.id}" updated`);
+        await handleContextModeUpdate(
+          contextHandlerCtx,
+          ws,
+          (
+            msg as {
+              payload: {
+                id: string;
+                name?: string | undefined;
+                description?: string | undefined;
+                thresholds?:
+                  | { warn?: number | undefined; soft?: number | undefined; hard?: number | undefined }
+                  | undefined;
+                preserveK?: number | undefined;
+                eliseThreshold?: number | undefined;
+              };
+            }
+          ).payload,
+        );
         break;
       }
 
       case 'context.mode.delete': {
-        const { id } = (msg as { payload: { id: string } }).payload;
-        const ctx = opts.agent.ctx;
-        // If the active mode is being deleted, fall back to the default.
-        if (String(ctx.meta['contextWindowMode'] ?? '') === id) {
-          ctx.meta['contextWindowMode'] = DEFAULT_CONTEXT_WINDOW_MODE_ID;
-          ctx.meta['contextWindowPolicy'] = resolveContextWindowPolicy(
-            {},
-            DEFAULT_CONTEXT_WINDOW_MODE_ID,
-          );
-        }
-        const modeStore = await getCustomModeStore();
-        const result = modeStore.remove(id);
-        if (result.ok)
-          await modeStore.save().catch(() => undefined); /* best-effort: user preferences */
-        sendResult(ws, result.ok, result.error ?? `Mode "${id}" deleted`);
+        await handleContextModeDelete(
+          contextHandlerCtx,
+          ws,
+          (msg as { payload: { id: string } }).payload.id,
+        );
         break;
       }
 

--- a/packages/cli/src/webui-server/ws-handlers/context.ts
+++ b/packages/cli/src/webui-server/ws-handlers/context.ts
@@ -1,0 +1,266 @@
+import {
+  type Agent,
+  DEFAULT_CONTEXT_WINDOW_MODE_ID,
+  repairToolUseAdjacency,
+  resolveContextWindowPolicy,
+  TOKENS,
+} from '@wrongstack/core';
+import type { CustomModeStore } from '@wrongstack/webui/server';
+import type { WebSocket } from 'ws';
+import {
+  estimateContextBreakdown,
+  type MessageLike,
+  type PromptBlock,
+  type ToolLike,
+} from '../context-breakdown.js';
+import type { WsCommon } from './index.js';
+
+/**
+ * PR 5h of Issue #30: context-window WebSocket handlers — the live
+ * context (`context.clear`/`debug`/`compact`/`repair`) and the
+ * custom-context-mode CRUD (`context.modes.list`, `context.mode.switch`/
+ * `create`/`update`/`delete`).
+ *
+ * Former closure captures (`opts.agent`, `buildSessionStartPayload`, and
+ * the lazily-loaded `getCustomModeStore`) are `ContextHandlerContext`
+ * fields. The compactor is resolved off the agent container at call time,
+ * exactly as the inline cases did.
+ */
+
+export interface ContextHandlerContext extends WsCommon {
+  /** The running agent — context state/meta and the compactor container live on it. */
+  agent: Agent;
+  /** Build the reset session.start payload (runWebUI closure). */
+  buildSessionStart: (overrides?: Record<string, unknown>) => Promise<unknown>;
+  /** Lazily-loaded custom-context-mode store (runWebUI closure). */
+  getCustomModeStore: () => Promise<CustomModeStore>;
+}
+
+function sendResult(ctx: WsCommon, ws: WebSocket, success: boolean, message: string): void {
+  ctx.send(ws, { type: 'key.operation_result', payload: { success, message } });
+}
+
+export async function handleContextClear(ctx: ContextHandlerContext, ws: WebSocket): Promise<void> {
+  // In-memory wipe — same as session.new but reuses the current session.
+  const actx = ctx.agent.ctx;
+  actx.state.replaceMessages([]);
+  actx.state.replaceTodos([]);
+  actx.readFiles.clear();
+  actx.fileMtimes.clear();
+  sendResult(ctx, ws, true, 'Context cleared');
+  const payload = await ctx.buildSessionStart({ reset: true });
+  ctx.broadcast({ type: 'session.start', payload });
+}
+
+export function handleContextDebug(ctx: ContextHandlerContext, ws: WebSocket): void {
+  // Per-section token estimate so users can see what's eating the context window.
+  const actx = ctx.agent.ctx;
+  const breakdown = estimateContextBreakdown({
+    systemPrompt: actx.systemPrompt as ReadonlyArray<PromptBlock>,
+    tools: ctx.agent.tools.list() as ReadonlyArray<ToolLike>,
+    messages: actx.messages as ReadonlyArray<MessageLike>,
+  });
+  ctx.send(ws, {
+    type: 'context.debug',
+    payload: {
+      ...breakdown,
+      mode: (actx.meta['contextWindowMode'] as string) ?? DEFAULT_CONTEXT_WINDOW_MODE_ID,
+      policy: actx.meta['contextWindowPolicy'] ?? null,
+    },
+  });
+}
+
+export async function handleContextCompact(
+  ctx: ContextHandlerContext,
+  ws: WebSocket,
+  aggressive: boolean,
+): Promise<void> {
+  try {
+    const compactor = ctx.agent.container.resolve(TOKENS.Compactor);
+    if (!compactor) {
+      sendResult(ctx, ws, false, 'Compactor not available');
+      return;
+    }
+    const before = ctx.agent.ctx.tokenCounter.total();
+    const report = await compactor.compact(ctx.agent.ctx, { aggressive });
+    const after = ctx.agent.ctx.tokenCounter.total();
+    ctx.send(ws, {
+      type: 'context.compacted',
+      payload: {
+        before: before.input + before.output,
+        after: after.input + after.output,
+        saved: Math.max(0, before.input + before.output - after.input - after.output),
+        reductions: report.reductions ?? [],
+        repaired: report.repaired ?? false,
+      },
+    });
+    sendResult(
+      ctx,
+      ws,
+      true,
+      `Compacted: ${before.input + before.output} → ${after.input + after.output} tokens`,
+    );
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export function handleContextRepair(ctx: ContextHandlerContext, ws: WebSocket): void {
+  const actx = ctx.agent.ctx;
+  const beforeMessages = actx.messages.length;
+  const repaired = repairToolUseAdjacency(actx.messages);
+  if (repaired.report.changed) {
+    actx.state.replaceMessages(repaired.messages);
+  }
+  const payload = {
+    removedToolUses: repaired.report.removedToolUses,
+    removedToolResults: repaired.report.removedToolResults,
+    removedMessages: repaired.report.removedMessages,
+    beforeMessages,
+    afterMessages: actx.messages.length,
+  };
+  ctx.broadcast({ type: 'context.repaired', payload });
+  const removed =
+    payload.removedToolUses.length + payload.removedToolResults.length + payload.removedMessages;
+  sendResult(
+    ctx,
+    ws,
+    true,
+    removed > 0
+      ? `Context repaired: removed ${removed} orphan protocol item(s)`
+      : 'Context repair found no orphan protocol blocks',
+  );
+}
+
+export async function handleContextModesList(
+  ctx: ContextHandlerContext,
+  ws: WebSocket,
+): Promise<void> {
+  // Built-ins + file-backed custom modes (store.list() merges both).
+  const active = String(ctx.agent.ctx.meta['contextWindowMode'] ?? DEFAULT_CONTEXT_WINDOW_MODE_ID);
+  const modeStore = await ctx.getCustomModeStore();
+  ctx.send(ws, {
+    type: 'context.modes.list',
+    payload: {
+      activeId: active,
+      modes: modeStore.list().map((m) => ({
+        id: m.id,
+        name: m.name,
+        description: m.description,
+        isActive: m.id === active,
+        thresholds: m.thresholds,
+        preserveK: m.preserveK,
+        eliseThreshold: m.eliseThreshold,
+        custom: m.custom === true,
+      })),
+    },
+  });
+}
+
+export async function handleContextModeSwitch(
+  ctx: ContextHandlerContext,
+  ws: WebSocket,
+  id: string,
+): Promise<void> {
+  // Built-in first, then custom.
+  let policy = resolveContextWindowPolicy({}, id);
+  if (policy.id !== id) {
+    const modeStore = await ctx.getCustomModeStore();
+    const custom = modeStore.list().find((m) => m.custom === true && m.id === id);
+    if (!custom) {
+      sendResult(ctx, ws, false, `Unknown context mode "${id}"`);
+      return;
+    }
+    policy = custom as unknown as typeof policy;
+  }
+  ctx.agent.ctx.meta['contextWindowMode'] = policy.id;
+  ctx.agent.ctx.meta['contextWindowPolicy'] = policy;
+  sendResult(ctx, ws, true, `Context mode switched to ${policy.id}`);
+  ctx.broadcast({
+    type: 'context.mode.changed',
+    payload: { id: policy.id, name: policy.name, policy },
+  });
+}
+
+export async function handleContextModeCreate(
+  ctx: ContextHandlerContext,
+  ws: WebSocket,
+  payload: {
+    id: string;
+    name: string;
+    description: string;
+    thresholds: { warn: number; soft: number; hard: number };
+    preserveK: number;
+    eliseThreshold: number;
+  },
+): Promise<void> {
+  const modeStore = await ctx.getCustomModeStore();
+  const result = modeStore.create({
+    id: payload.id,
+    name: payload.name,
+    description: payload.description,
+    thresholds: payload.thresholds,
+    preserveK: payload.preserveK,
+    eliseThreshold: payload.eliseThreshold,
+    custom: true,
+    aggressiveOn: 'soft',
+    targetLoad: 0.65,
+  });
+  if (result.ok) await modeStore.save().catch(() => undefined); /* best-effort: user preferences */
+  sendResult(ctx, ws, result.ok, result.error ?? `Mode "${payload.id}" created`);
+}
+
+export async function handleContextModeUpdate(
+  ctx: ContextHandlerContext,
+  ws: WebSocket,
+  payload: {
+    id: string;
+    name?: string | undefined;
+    description?: string | undefined;
+    thresholds?:
+      | { warn?: number | undefined; soft?: number | undefined; hard?: number | undefined }
+      | undefined;
+    preserveK?: number | undefined;
+    eliseThreshold?: number | undefined;
+  },
+): Promise<void> {
+  const modeStore = await ctx.getCustomModeStore();
+  // Build the patch without explicit-undefined keys (exactOptionalPropertyTypes).
+  const result = modeStore.update(payload.id, {
+    ...(payload.name !== undefined ? { name: payload.name } : {}),
+    ...(payload.description !== undefined ? { description: payload.description } : {}),
+    ...(payload.thresholds
+      ? {
+          thresholds: {
+            warn: payload.thresholds.warn ?? 0.6,
+            soft: payload.thresholds.soft ?? 0.75,
+            hard: payload.thresholds.hard ?? 0.9,
+          },
+        }
+      : {}),
+    ...(payload.preserveK !== undefined ? { preserveK: payload.preserveK } : {}),
+    ...(payload.eliseThreshold !== undefined ? { eliseThreshold: payload.eliseThreshold } : {}),
+  });
+  if (result.ok) await modeStore.save().catch(() => undefined); /* best-effort: user preferences */
+  sendResult(ctx, ws, result.ok, result.error ?? `Mode "${payload.id}" updated`);
+}
+
+export async function handleContextModeDelete(
+  ctx: ContextHandlerContext,
+  ws: WebSocket,
+  id: string,
+): Promise<void> {
+  const actx = ctx.agent.ctx;
+  // If the active mode is being deleted, fall back to the default.
+  if (String(actx.meta['contextWindowMode'] ?? '') === id) {
+    actx.meta['contextWindowMode'] = DEFAULT_CONTEXT_WINDOW_MODE_ID;
+    actx.meta['contextWindowPolicy'] = resolveContextWindowPolicy(
+      {},
+      DEFAULT_CONTEXT_WINDOW_MODE_ID,
+    );
+  }
+  const modeStore = await ctx.getCustomModeStore();
+  const result = modeStore.remove(id);
+  if (result.ok) await modeStore.save().catch(() => undefined); /* best-effort: user preferences */
+  sendResult(ctx, ws, result.ok, result.error ?? `Mode "${id}" deleted`);
+}

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -57,6 +57,18 @@ export {
   handleModesList,
 } from './agent-config.js';
 export {
+  type ContextHandlerContext,
+  handleContextClear,
+  handleContextCompact,
+  handleContextDebug,
+  handleContextModeCreate,
+  handleContextModeDelete,
+  handleContextModeSwitch,
+  handleContextModeUpdate,
+  handleContextModesList,
+  handleContextRepair,
+} from './context.js';
+export {
   type BrainHandlerContext,
   handleBrainAsk,
   handleBrainRisk,

--- a/packages/cli/tests/webui-server/ws-handlers-context.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-context.test.ts
@@ -1,0 +1,217 @@
+import { DEFAULT_CONTEXT_WINDOW_MODE_ID, TOKENS } from '@wrongstack/core';
+import { describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import type { ContextHandlerContext } from '../../src/webui-server/ws-handlers/context.js';
+import type { WsServerMessage } from '../../src/webui-server/ws-handlers/index.js';
+import {
+  handleContextClear,
+  handleContextCompact,
+  handleContextDebug,
+  handleContextModeCreate,
+  handleContextModeDelete,
+  handleContextModeSwitch,
+  handleContextModesList,
+  handleContextModeUpdate,
+  handleContextRepair,
+} from '../../src/webui-server/ws-handlers/index.js';
+
+/**
+ * PR 5h of Issue #30: context ws-handler unit tests.
+ *
+ * Drives the handlers with a fake agent ctx, a stub compactor (via the
+ * container), and a stub custom-mode store. estimateContextBreakdown and
+ * repairToolUseAdjacency run for real against minimal inputs.
+ */
+
+const FAKE_WS = {} as WebSocket;
+
+function makeModeStore() {
+  const modes: Array<Record<string, unknown>> = [];
+  const calls: string[] = [];
+  return {
+    list: () => modes,
+    create: (m: Record<string, unknown>) => {
+      calls.push('create');
+      if (modes.some((x) => x.id === m.id)) return { ok: false, error: 'exists' };
+      modes.push(m);
+      return { ok: true };
+    },
+    update: (id: string, patch: Record<string, unknown>) => {
+      calls.push('update');
+      const m = modes.find((x) => x.id === id);
+      if (!m) return { ok: false, error: 'missing' };
+      Object.assign(m, patch);
+      return { ok: true };
+    },
+    remove: (id: string) => {
+      calls.push('remove');
+      const i = modes.findIndex((x) => x.id === id);
+      if (i < 0) return { ok: false, error: 'missing' };
+      modes.splice(i, 1);
+      return { ok: true };
+    },
+    save: async () => {
+      calls.push('save');
+    },
+    _calls: calls,
+    _modes: modes,
+  };
+}
+
+function makeCtx(
+  over: { compactor?: unknown; modeStore?: ReturnType<typeof makeModeStore> } = {},
+): {
+  ctx: ContextHandlerContext;
+  sent: WsServerMessage[];
+  bc: WsServerMessage[];
+  builtWith: unknown[];
+  actx: Record<string, unknown>;
+  modeStore: ReturnType<typeof makeModeStore>;
+} {
+  const sent: WsServerMessage[] = [];
+  const bc: WsServerMessage[] = [];
+  const builtWith: unknown[] = [];
+  const modeStore = over.modeStore ?? makeModeStore();
+  const actx = {
+    meta: {} as Record<string, unknown>,
+    messages: [] as unknown[],
+    systemPrompt: [] as unknown[],
+    readFiles: new Set<string>(['a']),
+    fileMtimes: new Map<string, number>([['a', 1]]),
+    tokenCounter: { total: () => ({ input: 100, output: 50 }) },
+    state: {
+      replaceMessages: (m: unknown[]) => {
+        actx.messages = m;
+      },
+      replaceTodos: () => {},
+    },
+  };
+  const ctx: ContextHandlerContext = {
+    agent: {
+      ctx: actx,
+      tools: { list: () => [] },
+      container: { resolve: (t: symbol) => (t === TOKENS.Compactor ? over.compactor : undefined) },
+    } as never,
+    buildSessionStart: async (o) => {
+      builtWith.push(o);
+      return { sessionStart: true };
+    },
+    getCustomModeStore: async () => modeStore as never,
+    send: (_ws, m) => sent.push(m),
+    broadcast: (m) => bc.push(m),
+    log: () => {},
+  };
+  return { ctx, sent, bc, builtWith, actx, modeStore };
+}
+
+const lastOf = (msgs: WsServerMessage[], type: string) =>
+  msgs.filter((m) => m.type === type).at(-1);
+const result = (sent: WsServerMessage[]) =>
+  sent.filter((m) => m.type === 'key.operation_result').at(-1)?.payload as
+    | { success: boolean; message: string }
+    | undefined;
+
+describe('handleContextClear', () => {
+  it('wipes state and broadcasts a reset session.start', async () => {
+    const { ctx, bc, builtWith, actx } = makeCtx();
+    actx.messages = [{ role: 'user' }];
+    await handleContextClear(ctx, FAKE_WS);
+    expect(actx.messages).toEqual([]);
+    expect(builtWith).toEqual([{ reset: true }]);
+    expect(lastOf(bc, 'session.start')).toBeDefined();
+  });
+});
+
+describe('handleContextDebug', () => {
+  it('sends a breakdown with the active mode', () => {
+    const { ctx, sent } = makeCtx();
+    handleContextDebug(ctx, FAKE_WS);
+    const p = lastOf(sent, 'context.debug')?.payload as { mode: string };
+    expect(p.mode).toBe(DEFAULT_CONTEXT_WINDOW_MODE_ID);
+  });
+});
+
+describe('handleContextCompact', () => {
+  it('errors when no compactor is available', async () => {
+    const { ctx, sent } = makeCtx({ compactor: undefined });
+    await handleContextCompact(ctx, FAKE_WS, false);
+    expect(result(sent)).toMatchObject({ success: false, message: 'Compactor not available' });
+  });
+
+  it('reports the token delta on success', async () => {
+    const compactor = { compact: async () => ({ reductions: [], repaired: true }) };
+    const { ctx, sent } = makeCtx({ compactor });
+    await handleContextCompact(ctx, FAKE_WS, true);
+    expect(lastOf(sent, 'context.compacted')?.payload).toMatchObject({ repaired: true });
+    expect(result(sent)?.success).toBe(true);
+  });
+});
+
+describe('handleContextRepair', () => {
+  it('reports no orphans for a clean message list', () => {
+    const { ctx, sent, bc } = makeCtx();
+    handleContextRepair(ctx, FAKE_WS);
+    expect(lastOf(bc, 'context.repaired')).toBeDefined();
+    expect(result(sent)?.message).toContain('no orphan');
+  });
+});
+
+describe('context modes', () => {
+  it('modes.list reports the active id', async () => {
+    const { ctx, sent } = makeCtx();
+    await handleContextModesList(ctx, FAKE_WS);
+    const p = lastOf(sent, 'context.modes.list')?.payload as { activeId: string };
+    expect(p.activeId).toBe(DEFAULT_CONTEXT_WINDOW_MODE_ID);
+  });
+
+  it('mode.switch to a built-in updates meta + broadcasts', async () => {
+    const { ctx, sent, bc, actx } = makeCtx();
+    await handleContextModeSwitch(ctx, FAKE_WS, DEFAULT_CONTEXT_WINDOW_MODE_ID);
+    expect(result(sent)?.success).toBe(true);
+    expect(actx.meta).toMatchObject({ contextWindowMode: DEFAULT_CONTEXT_WINDOW_MODE_ID });
+    expect(lastOf(bc, 'context.mode.changed')).toBeDefined();
+  });
+
+  it('mode.switch rejects an unknown id', async () => {
+    const { ctx, sent } = makeCtx();
+    await handleContextModeSwitch(ctx, FAKE_WS, 'totally-unknown-mode');
+    expect(result(sent)).toMatchObject({ success: false });
+    expect(result(sent)?.message).toContain('Unknown context mode');
+  });
+
+  it('create → update → delete a custom mode (with persistence)', async () => {
+    const t = makeCtx();
+    await handleContextModeCreate(t.ctx, FAKE_WS, {
+      id: 'mine',
+      name: 'Mine',
+      description: 'd',
+      thresholds: { warn: 0.6, soft: 0.75, hard: 0.9 },
+      preserveK: 4,
+      eliseThreshold: 0.5,
+    });
+    expect(result(t.sent)?.success).toBe(true);
+
+    await handleContextModeUpdate(t.ctx, FAKE_WS, { id: 'mine', name: 'Renamed' });
+    expect(t.modeStore._modes[0]?.name).toBe('Renamed');
+
+    await handleContextModeDelete(t.ctx, FAKE_WS, 'mine');
+    expect(t.modeStore._modes).toHaveLength(0);
+    // saved after each successful mutation.
+    expect(t.modeStore._calls.filter((c) => c === 'save').length).toBe(3);
+  });
+
+  it('deleting the active custom mode falls back to default', async () => {
+    const t = makeCtx();
+    t.actx.meta['contextWindowMode'] = 'mine';
+    await handleContextModeCreate(t.ctx, FAKE_WS, {
+      id: 'mine',
+      name: 'Mine',
+      description: 'd',
+      thresholds: { warn: 0.6, soft: 0.75, hard: 0.9 },
+      preserveK: 4,
+      eliseThreshold: 0.5,
+    });
+    await handleContextModeDelete(t.ctx, FAKE_WS, 'mine');
+    expect(t.actx.meta['contextWindowMode']).toBe(DEFAULT_CONTEXT_WINDOW_MODE_ID);
+  });
+});


### PR DESCRIPTION
Continues the ws-handlers extraction with the **context-window** group:
`context.clear`/`debug`/`compact`/`repair` and the custom-context-mode
CRUD (`context.modes.list`, `context.mode.switch`/`create`/`update`/
`delete`) — 9 handlers.

## What moves
- **`ws-handlers/context.ts`** on a `ContextHandlerContext extends
  WsCommon` (`{ agent, buildSessionStart, getCustomModeStore }`). The
  compactor is resolved off the agent container at call time (as before);
  `estimateContextBreakdown` / `repairToolUseAdjacency` /
  `resolveContextWindowPolicy` are static imports.
- **`webui-server.ts`** builds `contextHandlerCtx`; the 9 cases delegate.
  ~230 inline lines removed.

## Tests
New `tests/webui-server/ws-handlers-context.test.ts` (10 cases): clear
wipes+reset, debug breakdown, compact (no-compactor/success), repair
clean-list, modes list/switch(built-in/unknown)/create→update→delete with
persistence + active-mode-delete fallback.

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- full webui-server suite (20 files) **126/126** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)