### PR TITLE
refactor(cli): extract process ws-handlers into ws-handlers/process.ts (PR 5i of #30)

### DIFF
--- a/docs/refactor-next.md
+++ b/docs/refactor-next.md
@@ -24,7 +24,8 @@ refactor). Update this before switching context, handing off, or resuming.
 | 5f | ws-handlers/ — **prefs** (prefs/autonomy.switch) | ✅ merged | #66 |
 | 5g | ws-handlers/ — **projects** (list/select/add/working_dir) | ✅ merged | #67 |
 | 5h | ws-handlers/ — **context** (clear/debug/compact/repair/modes) | ✅ merged | #68 |
-| 5i | ws-handlers/ — **remaining groups** | 🔴 in progress | — |
+| 5i | ws-handlers/ — **process** (list/kill/killAll) | ✅ merged | #69 |
+| 5j | ws-handlers/ — **sessions** + handleUserMessage | 🔴 in progress | — |
 
 `webui-server.ts` is ~3000 lines (down from ~3250). The self-contained
 concerns now live under `packages/cli/src/webui-server/`:
@@ -47,6 +48,7 @@ webui-server/
     prefs.ts            — prefs.get/update, autonomy.switch   (PR 5f)
     projects.ts         — projects.list/select/add, working_dir (PR 5g)
     context.ts          — context.clear/debug/compact/repair/modes (PR 5h)
+    process.ts          — process.list/kill/killAll           (PR 5i)
 ```
 
 Per-group contexts now extend a small `WsCommon` base (`send`/`broadcast`/
@@ -59,18 +61,19 @@ A module-map doc comment at the top of `webui-server.ts` points to each.
 
 ---
 
-## PR 5i — remaining ws-handler groups (🔴 in progress)
+## PR 5j — remaining ws-handler groups (🔴 in progress)
 
 Extracted so far: **providers** (5), **brain** (5b), **introspection**
 (5c), **worklist** (5d), **agent-config** (5e), **prefs** (5f),
-**projects** (5g), **context** (5h) — each fully unit-tested, threaded via
-a per-group context extending `WsCommon`. Current reality:
+**projects** (5g), **context** (5h), **process** (5i) — each fully
+unit-tested, threaded via a per-group context extending `WsCommon`.
+Current reality:
 
 - **Already delegated** — `memory.*`, `files.*`, `mailbox.*`, `shell.open`
   cases already call the shared `@wrongstack/webui/server` handlers. No
   CLI-local extraction to do.
 - **Still inline** — the `handleMessage` switch cases for
-  `sessions` / `session.*`, `process.*`, plus
+  `sessions` / `session.*`, plus
   `handleUserMessage`. These
   are coupled to run-loop state (the abort controllers, client map,
   custom-mode store, session writer/store, the session.start payload

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -98,6 +98,7 @@ import {
   type PrefsContext,
   type ProjectsContext,
   type WorklistContext,
+  type WsCommon,
   type WsHandlerContext,
   handleAutonomySwitch,
   handleBrainAsk,
@@ -137,6 +138,9 @@ import {
   handleStatsGet,
   handleTaskUpdate,
   handleTasksGet,
+  handleProcessKill,
+  handleProcessKillAll,
+  handleProcessList,
   handleTodoUpdate,
   handleTodosClear,
   handleTodosGet,
@@ -1101,6 +1105,9 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     broadcast,
     log: (m) => console.log(m),
   };
+
+  // Bare messaging surface for handler groups that need no run-loop state.
+  const wsCommon: WsCommon = { send, broadcast, log: (m) => console.log(m) };
   return new Promise<void>((resolve) => {
     wss.on('listening', () => {
       console.log(`[WebUI] WebSocket server running on ws://${host}:${port}`);
@@ -1589,53 +1596,17 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'process.list': {
-        try {
-          const { getProcessRegistry } = await import('@wrongstack/tools');
-          const procs = getProcessRegistry().list();
-          send(ws, {
-            type: 'process.list',
-            payload: {
-              processes: procs.map((p) => ({
-                pid: p.pid,
-                command: p.command,
-                tool: p.name,
-                startedAt: p.startedAt,
-                status: p.killed ? ('killed' as const) : ('running' as const),
-                protected: p.protected,
-              })),
-            },
-          });
-        } catch {
-          send(ws, { type: 'process.list', payload: { processes: [] } });
-        }
+        handleProcessList(wsCommon, ws);
         break;
       }
 
       case 'process.kill': {
-        const { pid } = (msg as { payload: { pid: number } }).payload;
-        try {
-          const { getProcessRegistry } = await import('@wrongstack/tools');
-          const proc = getProcessRegistry().get(pid);
-          if (proc?.protected) {
-            sendResult(ws, false, `Cannot kill protected process (PID ${pid})`);
-            break;
-          }
-          getProcessRegistry().kill(pid);
-          sendResult(ws, true, `Killed PID ${pid}`);
-        } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
-        }
+        handleProcessKill(wsCommon, ws, (msg as { payload: { pid: number } }).payload.pid);
         break;
       }
 
       case 'process.killAll': {
-        try {
-          const { getProcessRegistry } = await import('@wrongstack/tools');
-          getProcessRegistry().killAll();
-          sendResult(ws, true, 'All processes killed');
-        } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
-        }
+        handleProcessKillAll(wsCommon, ws);
         break;
       }
 

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -57,6 +57,12 @@ export {
   handleModesList,
 } from './agent-config.js';
 export {
+  type BrainHandlerContext,
+  handleBrainAsk,
+  handleBrainRisk,
+  handleBrainStatus,
+} from './brain.js';
+export {
   type ContextHandlerContext,
   handleContextClear,
   handleContextCompact,
@@ -64,16 +70,10 @@ export {
   handleContextModeCreate,
   handleContextModeDelete,
   handleContextModeSwitch,
-  handleContextModeUpdate,
   handleContextModesList,
+  handleContextModeUpdate,
   handleContextRepair,
 } from './context.js';
-export {
-  type BrainHandlerContext,
-  handleBrainAsk,
-  handleBrainRisk,
-  handleBrainStatus,
-} from './brain.js';
 export {
   handleDiagGet,
   handleSkillsList,
@@ -87,6 +87,7 @@ export {
   handlePrefsUpdate,
   type PrefsContext,
 } from './prefs.js';
+export { handleProcessKill, handleProcessKillAll, handleProcessList } from './process.js';
 export {
   handleProjectsAdd,
   handleProjectsList,

--- a/packages/cli/src/webui-server/ws-handlers/process.ts
+++ b/packages/cli/src/webui-server/ws-handlers/process.ts
@@ -1,0 +1,61 @@
+import { getProcessRegistry } from '@wrongstack/tools';
+import type { WebSocket } from 'ws';
+import type { WsCommon } from './index.js';
+
+/**
+ * PR 5i of Issue #30: background-process WebSocket handlers —
+ * `process.list`, `process.kill`, `process.killAll`.
+ *
+ * These only touch the global process registry (from `@wrongstack/tools`)
+ * — no run-loop state — so they take the bare `WsCommon` messaging
+ * surface. The registry import is now static (the switch loaded it
+ * lazily per-case).
+ */
+
+function sendResult(ctx: WsCommon, ws: WebSocket, success: boolean, message: string): void {
+  ctx.send(ws, { type: 'key.operation_result', payload: { success, message } });
+}
+
+export function handleProcessList(ctx: WsCommon, ws: WebSocket): void {
+  try {
+    const procs = getProcessRegistry().list();
+    ctx.send(ws, {
+      type: 'process.list',
+      payload: {
+        processes: procs.map((p) => ({
+          pid: p.pid,
+          command: p.command,
+          tool: p.name,
+          startedAt: p.startedAt,
+          status: p.killed ? ('killed' as const) : ('running' as const),
+          protected: p.protected,
+        })),
+      },
+    });
+  } catch {
+    ctx.send(ws, { type: 'process.list', payload: { processes: [] } });
+  }
+}
+
+export function handleProcessKill(ctx: WsCommon, ws: WebSocket, pid: number): void {
+  try {
+    const proc = getProcessRegistry().get(pid);
+    if (proc?.protected) {
+      sendResult(ctx, ws, false, `Cannot kill protected process (PID ${pid})`);
+      return;
+    }
+    getProcessRegistry().kill(pid);
+    sendResult(ctx, ws, true, `Killed PID ${pid}`);
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export function handleProcessKillAll(ctx: WsCommon, ws: WebSocket): void {
+  try {
+    getProcessRegistry().killAll();
+    sendResult(ctx, ws, true, 'All processes killed');
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}

--- a/packages/cli/tests/webui-server/ws-handlers-process.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-process.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WebSocket } from 'ws';
+
+// Mock the tools registry before importing the handlers.
+const registry = {
+  list: vi.fn(() => [] as Array<Record<string, unknown>>),
+  get: vi.fn((_pid: number) => undefined as Record<string, unknown> | undefined),
+  kill: vi.fn(),
+  killAll: vi.fn(),
+};
+vi.mock('@wrongstack/tools', () => ({ getProcessRegistry: () => registry }));
+
+const { handleProcessKill, handleProcessKillAll, handleProcessList } = await import(
+  '../../src/webui-server/ws-handlers/index.js'
+);
+type WsServerMessage = import('../../src/webui-server/ws-handlers/index.js').WsServerMessage;
+
+/**
+ * PR 5i of Issue #30: process ws-handler unit tests. The global process
+ * registry is mocked so no real children are spawned or killed.
+ */
+
+const FAKE_WS = {} as WebSocket;
+
+function makeCtx() {
+  const sent: WsServerMessage[] = [];
+  return {
+    ctx: {
+      send: (_ws: WebSocket, m: WsServerMessage) => sent.push(m),
+      broadcast: () => {},
+      log: () => {},
+    },
+    sent,
+  };
+}
+const lastOf = (msgs: WsServerMessage[], type: string) =>
+  msgs.filter((m) => m.type === type).at(-1);
+const result = (sent: WsServerMessage[]) =>
+  sent.filter((m) => m.type === 'key.operation_result').at(-1)?.payload as
+    | { success: boolean; message: string }
+    | undefined;
+
+afterEach(() => {
+  vi.clearAllMocks();
+  registry.list.mockReturnValue([]);
+  registry.get.mockReturnValue(undefined);
+});
+
+describe('handleProcessList', () => {
+  it('maps the registry entries to the wire shape', () => {
+    registry.list.mockReturnValue([
+      { pid: 7, command: 'sleep 1', name: 'bash', startedAt: 1, killed: false, protected: false },
+      { pid: 8, command: 'serve', name: 'bash', startedAt: 2, killed: true, protected: true },
+    ]);
+    const { ctx, sent } = makeCtx();
+    handleProcessList(ctx, FAKE_WS);
+    const procs = (
+      lastOf(sent, 'process.list')?.payload as { processes: Array<Record<string, unknown>> }
+    ).processes;
+    expect(procs).toEqual([
+      {
+        pid: 7,
+        command: 'sleep 1',
+        tool: 'bash',
+        startedAt: 1,
+        status: 'running',
+        protected: false,
+      },
+      { pid: 8, command: 'serve', tool: 'bash', startedAt: 2, status: 'killed', protected: true },
+    ]);
+  });
+
+  it('degrades to an empty list when the registry throws', () => {
+    registry.list.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const { ctx, sent } = makeCtx();
+    handleProcessList(ctx, FAKE_WS);
+    expect((lastOf(sent, 'process.list')?.payload as { processes: unknown[] }).processes).toEqual(
+      [],
+    );
+  });
+});
+
+describe('handleProcessKill', () => {
+  it('kills a normal process', () => {
+    registry.get.mockReturnValue({ protected: false });
+    const { ctx, sent } = makeCtx();
+    handleProcessKill(ctx, FAKE_WS, 42);
+    expect(registry.kill).toHaveBeenCalledWith(42);
+    expect(result(sent)).toMatchObject({ success: true });
+  });
+
+  it('refuses to kill a protected process', () => {
+    registry.get.mockReturnValue({ protected: true });
+    const { ctx, sent } = makeCtx();
+    handleProcessKill(ctx, FAKE_WS, 9);
+    expect(registry.kill).not.toHaveBeenCalled();
+    expect(result(sent)).toMatchObject({ success: false });
+    expect(result(sent)?.message).toContain('protected');
+  });
+});
+
+describe('handleProcessKillAll', () => {
+  it('kills all and reports success', () => {
+    const { ctx, sent } = makeCtx();
+    handleProcessKillAll(ctx, FAKE_WS);
+    expect(registry.killAll).toHaveBeenCalledTimes(1);
+    expect(result(sent)).toMatchObject({ success: true, message: 'All processes killed' });
+  });
+});


### PR DESCRIPTION
Continues the ws-handlers extraction with the **background-process** group:
`process.list` / `process.kill` / `process.killAll` — 3 handlers.

## What moves
- **`ws-handlers/process.ts`** — these only touch the global process
  registry (`@wrongstack/tools`), so they take the bare `WsCommon`
  messaging surface (no run-loop state). The registry import is now static.
- **`webui-server.ts`** adds a small `wsCommon` const (send/broadcast/log)
  for groups that need no run-loop state; the 3 cases delegate.

## Tests
New `tests/webui-server/ws-handlers-process.test.ts` (5 cases): list maps
the wire shape + degrades on error, kill normal/protected, killAll — with
the registry **mocked** (no real children spawned/killed).

## Verification
- `pnpm --filter @wrongstack/cli typecheck` ✅
- full webui-server suite (21 files) **131/131** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)