### PR TITLE
refactor(cli): extract session ws-handlers (PR 5j of #30)

### DIFF
--- a/docs/refactor-next.md
+++ b/docs/refactor-next.md
@@ -25,7 +25,8 @@ refactor). Update this before switching context, handing off, or resuming.
 | 5g | ws-handlers/ — **projects** (list/select/add/working_dir) | ✅ merged | #67 |
 | 5h | ws-handlers/ — **context** (clear/debug/compact/repair/modes) | ✅ merged | #68 |
 | 5i | ws-handlers/ — **process** (list/kill/killAll) | ✅ merged | #69 |
-| 5j | ws-handlers/ — **sessions** + handleUserMessage | 🔴 in progress | — |
+| 5j | ws-handlers/ — **sessions** (goal.get/sessions.list/session.*) | ✅ merged | #70 |
+| 5k | ws-handlers/ — **handleUserMessage** + connection cases | 🔴 in progress | — |
 
 `webui-server.ts` is ~3000 lines (down from ~3250). The self-contained
 concerns now live under `packages/cli/src/webui-server/`:
@@ -49,6 +50,7 @@ webui-server/
     projects.ts         — projects.list/select/add, working_dir (PR 5g)
     context.ts          — context.clear/debug/compact/repair/modes (PR 5h)
     process.ts          — process.list/kill/killAll           (PR 5i)
+    sessions.ts         — goal.get/sessions.list/session.*     (PR 5j)
 ```
 
 Per-group contexts now extend a small `WsCommon` base (`send`/`broadcast`/
@@ -61,24 +63,23 @@ A module-map doc comment at the top of `webui-server.ts` points to each.
 
 ---
 
-## PR 5j — remaining ws-handler groups (🔴 in progress)
+## PR 5k — remaining ws-handler work (🔴 in progress)
 
 Extracted so far: **providers** (5), **brain** (5b), **introspection**
 (5c), **worklist** (5d), **agent-config** (5e), **prefs** (5f),
-**projects** (5g), **context** (5h), **process** (5i) — each fully
-unit-tested, threaded via a per-group context extending `WsCommon`.
-Current reality:
+**projects** (5g), **context** (5h), **process** (5i), **sessions** (5j)
+— each fully unit-tested, threaded via a per-group context extending
+`WsCommon`. Current reality:
 
 - **Already delegated** — `memory.*`, `files.*`, `mailbox.*`, `shell.open`
   cases already call the shared `@wrongstack/webui/server` handlers. No
   CLI-local extraction to do.
-- **Still inline** — the `handleMessage` switch cases for
-  `sessions` / `session.*`, plus
-  `handleUserMessage`. These
-  are coupled to run-loop state (the abort controllers, client map,
-  custom-mode store, session writer/store, the session.start payload
-  builder, the prefs-snapshot/persist closures) — extract test-first, one
-  group at a time, growing each group's context.
+- **Still inline** — only `handleUserMessage` (the agent-run entry) and
+  the connection-level cases (`user_message` / `abort` / `ping` /
+  `tool.confirm_result`). This is the riskiest remaining extraction: it
+  drives the live run loop, owns the abort controllers + pending-confirm
+  map, and bridges agent events back to the socket. Extract test-first,
+  growing its context with the run-loop state it needs.
 
 **Why deferred (not "forgotten"):** these cases are coupled to ~25 pieces
 of run-loop state (`abortController` + `abortControllers`, `clients`,

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -66,7 +66,6 @@ import {
   decryptConfigSecrets,
   encryptConfigSecrets,
 } from '@wrongstack/core/security';
-import { DefaultSessionStore } from '@wrongstack/core/storage';
 import {
   AutoPhaseWebSocketHandler,
   type CustomModeStore,
@@ -97,6 +96,7 @@ import {
   type IntrospectionContext,
   type PrefsContext,
   type ProjectsContext,
+  type SessionsContext,
   type WorklistContext,
   type WsCommon,
   type WsHandlerContext,
@@ -141,6 +141,14 @@ import {
   handleProcessKill,
   handleProcessKillAll,
   handleProcessList,
+  handleGoalGet,
+  handleSessionCheckpoints,
+  handleSessionDelete,
+  handleSessionNew,
+  handleSessionResume,
+  handleSessionRewind,
+  handleSessionSave,
+  handleSessionsList,
   handleTodoUpdate,
   handleTodosClear,
   handleTodosGet,
@@ -1108,6 +1116,16 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
 
   // Bare messaging surface for handler groups that need no run-loop state.
   const wsCommon: WsCommon = { send, broadcast, log: (m) => console.log(m) };
+
+  // `opts` is passed by reference so the session handlers read live
+  // agent.ctx.session / opts.sessionStore at call time.
+  const sessionsCtx: SessionsContext = {
+    opts,
+    buildSessionStart: (overrides) => buildSessionStartPayload(overrides),
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
   return new Promise<void>((resolve) => {
     wss.on('listening', () => {
       console.log(`[WebUI] WebSocket server running on ws://${host}:${port}`);
@@ -1459,107 +1477,21 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'goal.get': {
-        // Read goal.json from disk and broadcast to all connected clients.
-        // The frontend polls this periodically; we serve the latest snapshot.
-        const projectRoot = opts.projectRoot ?? opts.agent.ctx.projectRoot;
-        try {
-          const goalPath = path.join(projectRoot, '.wrongstack', 'goal.json');
-          const raw = await fs.readFile(goalPath, 'utf8');
-          const goal = JSON.parse(raw);
-          broadcast({ type: 'goal.updated', payload: goal });
-        } catch {
-          broadcast({ type: 'goal.updated', payload: null });
-        }
+        await handleGoalGet(sessionsCtx, ws);
         break;
       }
 
       case 'sessions.list': {
-        // Prefer the wired SessionStore (the real ~/.wrongstack/projects/<hash>/
-        // sessions location). The transient store at <projectRoot>/.wrongstack/
-        // sessions is a legacy fallback only — real sessions never live there.
-        const limit = (msg as { payload?: { limit?: number | undefined } }).payload?.limit ?? 50;
-        try {
-          const store =
-            opts.sessionStore ??
-            new DefaultSessionStore({
-              dir: path.join(
-                opts.projectRoot ?? opts.agent.ctx.projectRoot,
-                '.wrongstack',
-                'sessions',
-              ),
-            });
-          const list = await store.list(limit);
-          const currentId = opts.agent.ctx.session?.id ?? opts.session.id;
-          send(ws, {
-            type: 'sessions.list',
-            payload: {
-              sessions: list.map((s) => ({
-                id: s.id,
-                title: s.title,
-                startedAt: s.startedAt,
-                model: s.model,
-                provider: s.provider,
-                tokenTotal: s.tokenTotal,
-                isCurrent: s.id === currentId,
-              })),
-            },
-          });
-        } catch (err) {
-          send(ws, {
-            type: 'sessions.list',
-            payload: { sessions: [], error: err instanceof Error ? err.message : String(err) },
-          });
-        }
+        await handleSessionsList(
+          sessionsCtx,
+          ws,
+          (msg as { payload?: { limit?: number | undefined } }).payload?.limit ?? 50,
+        );
         break;
       }
 
       case 'session.new': {
-        // Full new session when the SessionStore is wired (the normal case):
-        // finalize the current writer (session_end + close → summary sidecar)
-        // and swap in a fresh on-disk session, exactly like the standalone
-        // server. Previously this only wiped in-memory state — the "new"
-        // conversation kept appending to the OLD session's JSONL.
-        const ctx = opts.agent.ctx;
-        const oldId = ctx.session?.id ?? opts.session.id;
-        if (opts.sessionStore) {
-          try {
-            const oldWriter = ctx.session;
-            const oldUsage = ctx.tokenCounter.total();
-            if (oldWriter) {
-              void (async () => {
-                await oldWriter
-                  .append({ type: 'session_end', ts: new Date().toISOString(), usage: oldUsage })
-                  .catch(() => undefined);
-                await oldWriter.close().catch(() => undefined);
-              })();
-            }
-            const fresh = await opts.sessionStore.create({
-              id: '',
-              title: '',
-              model: ctx.model,
-              provider: (ctx.provider as { id?: string }).id ?? '',
-            });
-            ctx.session = fresh;
-            opts.onSessionSwapped?.(fresh.id);
-            ctx.tokenCounter.reset();
-          } catch (err) {
-            // Store failure degrades to the in-memory reset below.
-            console.warn(
-              JSON.stringify({
-                level: 'warn',
-                event: 'webui.session_new_store_failed',
-                message: err instanceof Error ? err.message : String(err),
-                timestamp: new Date().toISOString(),
-              }),
-            );
-          }
-        }
-        ctx.state.replaceMessages([]);
-        ctx.state.replaceTodos([]);
-        ctx.readFiles.clear();
-        ctx.fileMtimes.clear();
-        const sessNewP = await buildSessionStartPayload({ reset: true, clearedSessionId: oldId });
-        broadcast({ type: 'session.start', payload: sessNewP });
+        await handleSessionNew(sessionsCtx, ws);
         break;
       }
 
@@ -1631,50 +1563,16 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'session.checkpoints': {
-        const projectRoot = opts.projectRoot ?? opts.agent.ctx.projectRoot;
-        try {
-          const { DefaultSessionRewinder } = await import('@wrongstack/core');
-          const rewinder = new DefaultSessionRewinder(
-            opts.sessionsDir ?? path.join(projectRoot, '.wrongstack', 'sessions'),
-            projectRoot,
-          );
-          // Use the LIVE writer's id — after an in-app resume the active
-          // session is agent.ctx.session, not the startup one.
-          const liveId = opts.agent.ctx.session?.id ?? opts.session.id;
-          const checkpoints = await rewinder.listCheckpoints(liveId);
-          send(ws, {
-            type: 'session.checkpoints',
-            payload: { checkpoints },
-          });
-        } catch {
-          send(ws, {
-            type: 'session.checkpoints',
-            payload: { checkpoints: [] },
-          });
-        }
+        await handleSessionCheckpoints(sessionsCtx, ws);
         break;
       }
 
       case 'session.rewind': {
-        const { checkpointIndex } = (msg as { payload: { checkpointIndex: number } }).payload;
-        const projectRoot = opts.projectRoot ?? opts.agent.ctx.projectRoot;
-        try {
-          const { DefaultSessionRewinder } = await import('@wrongstack/core');
-          const rewinder = new DefaultSessionRewinder(
-            opts.sessionsDir ?? path.join(projectRoot, '.wrongstack', 'sessions'),
-            projectRoot,
-          );
-          // Rewind the LIVE session — both the file reverts (rewinder) and
-          // the JSONL truncation (writer) must target the same session.
-          const liveSession = opts.agent.ctx.session ?? opts.session;
-          await rewinder.rewindToCheckpoint(liveSession.id, checkpointIndex);
-          await liveSession.truncateToCheckpoint(checkpointIndex);
-          sendResult(ws, true, `Rewound to checkpoint ${checkpointIndex}`);
-          const rewindP = await buildSessionStartPayload({ reset: true });
-          broadcast({ type: 'session.start', payload: rewindP });
-        } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
-        }
+        await handleSessionRewind(
+          sessionsCtx,
+          ws,
+          (msg as { payload: { checkpointIndex: number } }).payload.checkpointIndex,
+        );
         break;
       }
 
@@ -1700,36 +1598,12 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'session.delete': {
-        const { id } = (msg as { payload: { id: string } }).payload;
-        // Guard against the CURRENT writer — after an in-app resume the
-        // active session is agent.ctx.session, not the startup one.
-        if (id === (opts.agent.ctx.session?.id ?? opts.session.id)) {
-          sendResult(ws, false, 'Cannot delete the active session');
-          break;
-        }
-        try {
-          // Prefer the wired SessionStore (real sessions location); the
-          // transient <projectRoot>/.wrongstack/sessions store is legacy-only.
-          const store =
-            opts.sessionStore ??
-            new DefaultSessionStore({
-              dir: path.join(
-                opts.projectRoot ?? opts.agent.ctx.projectRoot,
-                '.wrongstack',
-                'sessions',
-              ),
-            });
-          await store.delete(id);
-          sendResult(ws, true, `Session ${id} deleted`);
-        } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
-        }
+        await handleSessionDelete(sessionsCtx, ws, (msg as { payload: { id: string } }).payload.id);
         break;
       }
 
       case 'session.save':
-        // SessionWriter auto-flushes — confirm for UI habit parity.
-        sendResult(ws, true, `Session ${opts.session.id} is auto-saved`);
+        handleSessionSave(sessionsCtx, ws);
         break;
 
       case 'plan.get': {
@@ -1806,61 +1680,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       case 'session.resume': {
-        if (!opts.sessionStore) {
-          sendResult(ws, false, 'Session store not available');
-          break;
-        }
-        const { id } = (msg as { payload: { id: string } }).payload;
-        try {
-          // Compare against the CURRENT writer — after a prior in-app resume
-          // the active session is agent.ctx.session, not the startup one.
-          const ctx = opts.agent.ctx;
-          if (id === (ctx.session?.id ?? opts.session.id)) {
-            sendResult(ws, false, 'Session is already active');
-            break;
-          }
-          const resumed = await opts.sessionStore.resume(id);
-          // Finalize the writer we are leaving (session_end + flush + summary
-          // sidecar), then swap the context to the resumed writer so all new
-          // events land in the resumed session's JSONL. Without the swap,
-          // the conversation kept recording into the old session's log and
-          // the resumed writer leaked an open file handle.
-          const oldWriter = ctx.session;
-          if (oldWriter && oldWriter !== resumed.writer) {
-            const oldUsage = ctx.tokenCounter.total();
-            void (async () => {
-              await oldWriter
-                .append({
-                  type: 'session_end',
-                  ts: new Date().toISOString(),
-                  usage: oldUsage,
-                })
-                .catch(() => undefined);
-              await oldWriter.close().catch(() => undefined);
-            })();
-          }
-          ctx.session = resumed.writer;
-          // Let the host re-point crash-recovery state (active.json) at the
-          // session that is now actually being written.
-          opts.onSessionSwapped?.(resumed.writer.id);
-          // Hydrate the context with the old session's messages.
-          ctx.state.replaceMessages(resumed.data.messages);
-          ctx.state.replaceTodos([]);
-          ctx.readFiles.clear();
-          ctx.fileMtimes.clear();
-          ctx.tokenCounter.reset();
-          // Replay usage so the topbar shows accurate totals.
-          ctx.tokenCounter.account(resumed.data.usage, ctx.model);
-          const resumeP = await buildSessionStartPayload({
-            reset: true,
-            replayMessages: resumed.data.messages,
-            replayUsage: resumed.data.usage,
-          });
-          broadcast({ type: 'session.start', payload: resumeP });
-          sendResult(ws, true, `Resumed session ${id}`);
-        } catch (err) {
-          sendResult(ws, false, err instanceof Error ? err.message : String(err));
-        }
+        await handleSessionResume(sessionsCtx, ws, (msg as { payload: { id: string } }).payload.id);
         break;
       }
 

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -107,6 +107,18 @@ export {
   handleProvidersSaved,
 } from './providers.js';
 export {
+  handleGoalGet,
+  handleSessionCheckpoints,
+  handleSessionDelete,
+  handleSessionNew,
+  handleSessionResume,
+  handleSessionRewind,
+  handleSessionSave,
+  handleSessionsList,
+  type SessionsContext,
+  type SessionsOptions,
+} from './sessions.js';
+export {
   handlePlanGet,
   handlePlanItemUpdate,
   handlePlanTemplateUse,

--- a/packages/cli/src/webui-server/ws-handlers/sessions.ts
+++ b/packages/cli/src/webui-server/ws-handlers/sessions.ts
@@ -1,0 +1,256 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  type Agent,
+  DefaultSessionRewinder,
+  type SessionStore,
+  type SessionWriter,
+} from '@wrongstack/core';
+import { DefaultSessionStore } from '@wrongstack/core/storage';
+import type { WebSocket } from 'ws';
+import type { WsCommon } from './index.js';
+
+/**
+ * PR 5j of Issue #30: session-management WebSocket handlers — `goal.get`,
+ * `sessions.list`, `session.new`/`delete`/`save`, `session.checkpoints`/
+ * `rewind`/`resume`.
+ *
+ * The session-swapping handlers (new/resume) and the rewinder mutate the
+ * LIVE session writer on `agent.ctx.session` and reset the token counter,
+ * exactly as the inline cases did. `opts` is read-only here (no field is
+ * reassigned — unlike projects.select), so `SessionsOptions` is just the
+ * subset these handlers read, passed by reference so they see live
+ * `agent.ctx.session` / `opts.sessionStore` at call time.
+ */
+
+export interface SessionsOptions {
+  projectRoot?: string | undefined;
+  agent: Agent;
+  session: SessionWriter;
+  sessionStore?: SessionStore | undefined;
+  sessionsDir?: string | undefined;
+  onSessionSwapped?: ((newSessionId: string) => void) | undefined;
+}
+
+export interface SessionsContext extends WsCommon {
+  opts: SessionsOptions;
+  /** Build the reset session.start payload (runWebUI closure). */
+  buildSessionStart: (overrides?: Record<string, unknown>) => Promise<unknown>;
+}
+
+function sendResult(ctx: WsCommon, ws: WebSocket, success: boolean, message: string): void {
+  ctx.send(ws, { type: 'key.operation_result', payload: { success, message } });
+}
+
+/** The session store to use: the wired one, else a transient legacy fallback. */
+function storeFor(opts: SessionsOptions): SessionStore {
+  return (
+    opts.sessionStore ??
+    new DefaultSessionStore({
+      dir: path.join(opts.projectRoot ?? opts.agent.ctx.projectRoot, '.wrongstack', 'sessions'),
+    })
+  );
+}
+
+export async function handleGoalGet(ctx: SessionsContext, _ws: WebSocket): Promise<void> {
+  // Read goal.json from disk and broadcast the latest snapshot.
+  const projectRoot = ctx.opts.projectRoot ?? ctx.opts.agent.ctx.projectRoot;
+  try {
+    const goalPath = path.join(projectRoot, '.wrongstack', 'goal.json');
+    const raw = await fs.readFile(goalPath, 'utf8');
+    ctx.broadcast({ type: 'goal.updated', payload: JSON.parse(raw) });
+  } catch {
+    ctx.broadcast({ type: 'goal.updated', payload: null });
+  }
+}
+
+export async function handleSessionsList(
+  ctx: SessionsContext,
+  ws: WebSocket,
+  limit: number,
+): Promise<void> {
+  try {
+    const list = await storeFor(ctx.opts).list(limit);
+    const currentId = ctx.opts.agent.ctx.session?.id ?? ctx.opts.session.id;
+    ctx.send(ws, {
+      type: 'sessions.list',
+      payload: {
+        sessions: list.map((s) => ({
+          id: s.id,
+          title: s.title,
+          startedAt: s.startedAt,
+          model: s.model,
+          provider: s.provider,
+          tokenTotal: s.tokenTotal,
+          isCurrent: s.id === currentId,
+        })),
+      },
+    });
+  } catch (err) {
+    ctx.send(ws, {
+      type: 'sessions.list',
+      payload: { sessions: [], error: err instanceof Error ? err.message : String(err) },
+    });
+  }
+}
+
+export async function handleSessionNew(ctx: SessionsContext, _ws: WebSocket): Promise<void> {
+  const { opts } = ctx;
+  const actx = opts.agent.ctx;
+  const oldId = actx.session?.id ?? opts.session.id;
+  if (opts.sessionStore) {
+    try {
+      const oldWriter = actx.session;
+      const oldUsage = actx.tokenCounter.total();
+      if (oldWriter) {
+        void (async () => {
+          await oldWriter
+            .append({ type: 'session_end', ts: new Date().toISOString(), usage: oldUsage })
+            .catch(() => undefined);
+          await oldWriter.close().catch(() => undefined);
+        })();
+      }
+      const fresh = await opts.sessionStore.create({
+        id: '',
+        title: '',
+        model: actx.model,
+        provider: (actx.provider as { id?: string }).id ?? '',
+      });
+      actx.session = fresh;
+      opts.onSessionSwapped?.(fresh.id);
+      actx.tokenCounter.reset();
+    } catch (err) {
+      // Store failure degrades to the in-memory reset below.
+      ctx.log(
+        JSON.stringify({
+          level: 'warn',
+          event: 'webui.session_new_store_failed',
+          message: err instanceof Error ? err.message : String(err),
+          timestamp: new Date().toISOString(),
+        }),
+      );
+    }
+  }
+  actx.state.replaceMessages([]);
+  actx.state.replaceTodos([]);
+  actx.readFiles.clear();
+  actx.fileMtimes.clear();
+  const payload = await ctx.buildSessionStart({ reset: true, clearedSessionId: oldId });
+  ctx.broadcast({ type: 'session.start', payload });
+}
+
+function rewinderFor(opts: SessionsOptions): DefaultSessionRewinder {
+  const projectRoot = opts.projectRoot ?? opts.agent.ctx.projectRoot;
+  return new DefaultSessionRewinder(
+    opts.sessionsDir ?? path.join(projectRoot, '.wrongstack', 'sessions'),
+    projectRoot,
+  );
+}
+
+export async function handleSessionCheckpoints(ctx: SessionsContext, ws: WebSocket): Promise<void> {
+  try {
+    const rewinder = rewinderFor(ctx.opts);
+    // Use the LIVE writer's id — after an in-app resume the active session
+    // is agent.ctx.session, not the startup one.
+    const liveId = ctx.opts.agent.ctx.session?.id ?? ctx.opts.session.id;
+    const checkpoints = await rewinder.listCheckpoints(liveId);
+    ctx.send(ws, { type: 'session.checkpoints', payload: { checkpoints } });
+  } catch {
+    ctx.send(ws, { type: 'session.checkpoints', payload: { checkpoints: [] } });
+  }
+}
+
+export async function handleSessionRewind(
+  ctx: SessionsContext,
+  ws: WebSocket,
+  checkpointIndex: number,
+): Promise<void> {
+  try {
+    const rewinder = rewinderFor(ctx.opts);
+    // Rewind the LIVE session — both the file (rewinder) and the JSONL
+    // truncation (writer) must target the same session.
+    const liveSession = ctx.opts.agent.ctx.session ?? ctx.opts.session;
+    await rewinder.rewindToCheckpoint(liveSession.id, checkpointIndex);
+    await liveSession.truncateToCheckpoint(checkpointIndex);
+    sendResult(ctx, ws, true, `Rewound to checkpoint ${checkpointIndex}`);
+    const payload = await ctx.buildSessionStart({ reset: true });
+    ctx.broadcast({ type: 'session.start', payload });
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function handleSessionDelete(
+  ctx: SessionsContext,
+  ws: WebSocket,
+  id: string,
+): Promise<void> {
+  // Guard against the CURRENT writer — after an in-app resume the active
+  // session is agent.ctx.session, not the startup one.
+  if (id === (ctx.opts.agent.ctx.session?.id ?? ctx.opts.session.id)) {
+    sendResult(ctx, ws, false, 'Cannot delete the active session');
+    return;
+  }
+  try {
+    await storeFor(ctx.opts).delete(id);
+    sendResult(ctx, ws, true, `Session ${id} deleted`);
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export function handleSessionSave(ctx: SessionsContext, ws: WebSocket): void {
+  // SessionWriter auto-flushes — confirm for UI habit parity.
+  sendResult(ctx, ws, true, `Session ${ctx.opts.session.id} is auto-saved`);
+}
+
+export async function handleSessionResume(
+  ctx: SessionsContext,
+  ws: WebSocket,
+  id: string,
+): Promise<void> {
+  const { opts } = ctx;
+  if (!opts.sessionStore) {
+    sendResult(ctx, ws, false, 'Session store not available');
+    return;
+  }
+  try {
+    const actx = opts.agent.ctx;
+    if (id === (actx.session?.id ?? opts.session.id)) {
+      sendResult(ctx, ws, false, 'Session is already active');
+      return;
+    }
+    const resumed = await opts.sessionStore.resume(id);
+    // Finalize the writer we are leaving, then swap the context to the
+    // resumed writer so all new events land in the resumed session's JSONL.
+    const oldWriter = actx.session;
+    if (oldWriter && oldWriter !== resumed.writer) {
+      const oldUsage = actx.tokenCounter.total();
+      void (async () => {
+        await oldWriter
+          .append({ type: 'session_end', ts: new Date().toISOString(), usage: oldUsage })
+          .catch(() => undefined);
+        await oldWriter.close().catch(() => undefined);
+      })();
+    }
+    actx.session = resumed.writer;
+    opts.onSessionSwapped?.(resumed.writer.id);
+    // Hydrate the context with the old session's messages.
+    actx.state.replaceMessages(resumed.data.messages);
+    actx.state.replaceTodos([]);
+    actx.readFiles.clear();
+    actx.fileMtimes.clear();
+    actx.tokenCounter.reset();
+    // Replay usage so the topbar shows accurate totals.
+    actx.tokenCounter.account(resumed.data.usage, actx.model);
+    const payload = await ctx.buildSessionStart({
+      reset: true,
+      replayMessages: resumed.data.messages,
+      replayUsage: resumed.data.usage,
+    });
+    ctx.broadcast({ type: 'session.start', payload });
+    sendResult(ctx, ws, true, `Resumed session ${id}`);
+  } catch (err) {
+    sendResult(ctx, ws, false, err instanceof Error ? err.message : String(err));
+  }
+}

--- a/packages/cli/tests/webui-server/ws-handlers-sessions.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-sessions.test.ts
@@ -1,0 +1,217 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import type { WsServerMessage } from '../../src/webui-server/ws-handlers/index.js';
+import {
+  handleGoalGet,
+  handleSessionDelete,
+  handleSessionNew,
+  handleSessionResume,
+  handleSessionSave,
+  handleSessionsList,
+} from '../../src/webui-server/ws-handlers/index.js';
+import type {
+  SessionsContext,
+  SessionsOptions,
+} from '../../src/webui-server/ws-handlers/sessions.js';
+
+/**
+ * PR 5j of Issue #30: session ws-handler unit tests. A stub session store
+ * + fake agent ctx drive the swapping handlers; goal.get round-trips
+ * through a temp project dir. The disk-backed rewinder paths
+ * (checkpoints/rewind) are covered by the runWebUI integration test.
+ */
+
+const FAKE_WS = {} as WebSocket;
+
+let tmpDir = '';
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wstack-pr5j-'));
+});
+afterEach(async () => {
+  if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+  tmpDir = '';
+});
+
+function makeWriter(id: string) {
+  return {
+    id,
+    append: async () => {},
+    close: async () => {},
+    truncateToCheckpoint: async () => {},
+  };
+}
+
+function makeAgentCtx(sessionId: string) {
+  const ctx = {
+    projectRoot: tmpDir,
+    model: 'm',
+    provider: { id: 'anthropic' },
+    session: makeWriter(sessionId),
+    tokenCounter: { total: () => ({ input: 0, output: 0 }), reset: () => {}, account: () => {} },
+    readFiles: new Set<string>(['x']),
+    fileMtimes: new Map<string, number>([['x', 1]]),
+    state: {
+      replaceMessages: (m: unknown[]) => {
+        ctx.messages = m;
+      },
+      replaceTodos: () => {},
+    },
+    messages: [] as unknown[],
+  };
+  return ctx;
+}
+
+function makeCtx(over: Partial<SessionsOptions> = {}): {
+  ctx: SessionsContext;
+  sent: WsServerMessage[];
+  bc: WsServerMessage[];
+  swapped: string[];
+  opts: SessionsOptions;
+  agentCtx: ReturnType<typeof makeAgentCtx>;
+} {
+  const sent: WsServerMessage[] = [];
+  const bc: WsServerMessage[] = [];
+  const swapped: string[] = [];
+  const agentCtx = makeAgentCtx('startup');
+  const opts: SessionsOptions = {
+    projectRoot: tmpDir,
+    agent: { ctx: agentCtx } as never,
+    session: { id: 'startup' } as never,
+    sessionStore: undefined,
+    sessionsDir: undefined,
+    onSessionSwapped: (id) => swapped.push(id),
+    ...over,
+  };
+  const ctx: SessionsContext = {
+    opts,
+    buildSessionStart: async () => ({ sessionStart: true }),
+    send: (_ws, m) => sent.push(m),
+    broadcast: (m) => bc.push(m),
+    log: () => {},
+  };
+  return { ctx, sent, bc, swapped, opts, agentCtx };
+}
+
+const lastOf = (msgs: WsServerMessage[], type: string) =>
+  msgs.filter((m) => m.type === type).at(-1);
+const result = (sent: WsServerMessage[]) =>
+  sent.filter((m) => m.type === 'key.operation_result').at(-1)?.payload as
+    | { success: boolean; message: string }
+    | undefined;
+
+describe('handleGoalGet', () => {
+  it('broadcasts null when no goal.json exists', async () => {
+    const { ctx, bc } = makeCtx();
+    await handleGoalGet(ctx, FAKE_WS);
+    expect(lastOf(bc, 'goal.updated')?.payload).toBeNull();
+  });
+
+  it('broadcasts the parsed goal when present', async () => {
+    await fs.mkdir(path.join(tmpDir, '.wrongstack'));
+    await fs.writeFile(
+      path.join(tmpDir, '.wrongstack', 'goal.json'),
+      JSON.stringify({ mission: 'ship' }),
+    );
+    const { ctx, bc } = makeCtx();
+    await handleGoalGet(ctx, FAKE_WS);
+    expect(lastOf(bc, 'goal.updated')?.payload).toEqual({ mission: 'ship' });
+  });
+});
+
+describe('handleSessionsList', () => {
+  it('marks the current session and maps the wire shape', async () => {
+    const store = {
+      list: async () => [
+        { id: 'startup', title: 'a', startedAt: 1, model: 'm', provider: 'p', tokenTotal: 5 },
+        { id: 'other', title: 'b', startedAt: 2, model: 'm', provider: 'p', tokenTotal: 9 },
+      ],
+    };
+    const { ctx, sent } = makeCtx({ sessionStore: store as never });
+    await handleSessionsList(ctx, FAKE_WS, 50);
+    const list = (
+      lastOf(sent, 'sessions.list')?.payload as {
+        sessions: Array<{ id: string; isCurrent: boolean }>;
+      }
+    ).sessions;
+    expect(list.find((s) => s.id === 'startup')?.isCurrent).toBe(true);
+    expect(list.find((s) => s.id === 'other')?.isCurrent).toBe(false);
+  });
+});
+
+describe('handleSessionNew', () => {
+  it('swaps in a fresh writer, resets, and broadcasts session.start', async () => {
+    const store = { create: async () => makeWriter('fresh') };
+    const t = makeCtx({ sessionStore: store as never });
+    await handleSessionNew(t.ctx, FAKE_WS);
+    expect(t.agentCtx.session.id).toBe('fresh');
+    expect(t.swapped).toEqual(['fresh']);
+    expect(t.agentCtx.messages).toEqual([]);
+    expect(lastOf(t.bc, 'session.start')).toBeDefined();
+  });
+});
+
+describe('handleSessionDelete', () => {
+  it('refuses to delete the active session', async () => {
+    const { ctx, sent } = makeCtx();
+    await handleSessionDelete(ctx, FAKE_WS, 'startup');
+    expect(result(sent)).toMatchObject({ success: false });
+    expect(result(sent)?.message).toContain('active session');
+  });
+
+  it('deletes a non-active session via the store', async () => {
+    const deleted: string[] = [];
+    const store = { delete: async (id: string) => void deleted.push(id) };
+    const { ctx, sent } = makeCtx({ sessionStore: store as never });
+    await handleSessionDelete(ctx, FAKE_WS, 'other');
+    expect(deleted).toEqual(['other']);
+    expect(result(sent)?.success).toBe(true);
+  });
+});
+
+describe('handleSessionSave', () => {
+  it('confirms auto-save', () => {
+    const { ctx, sent } = makeCtx();
+    handleSessionSave(ctx, FAKE_WS);
+    expect(result(sent)).toMatchObject({
+      success: true,
+      message: expect.stringContaining('auto-saved'),
+    });
+  });
+});
+
+describe('handleSessionResume', () => {
+  it('errors when no session store is wired', async () => {
+    const { ctx, sent } = makeCtx({ sessionStore: undefined });
+    await handleSessionResume(ctx, FAKE_WS, 'x');
+    expect(result(sent)).toMatchObject({ success: false, message: 'Session store not available' });
+  });
+
+  it('refuses to resume the already-active session', async () => {
+    const store = {
+      resume: async () => ({ writer: makeWriter('startup'), data: { messages: [], usage: {} } }),
+    };
+    const { ctx, sent } = makeCtx({ sessionStore: store as never });
+    await handleSessionResume(ctx, FAKE_WS, 'startup');
+    expect(result(sent)?.message).toContain('already active');
+  });
+
+  it('swaps to the resumed writer and hydrates messages', async () => {
+    const messages = [{ role: 'user' }, { role: 'assistant' }];
+    const store = {
+      resume: async () => ({
+        writer: makeWriter('resumed'),
+        data: { messages, usage: { input: 3, output: 1 } },
+      }),
+    };
+    const t = makeCtx({ sessionStore: store as never });
+    await handleSessionResume(t.ctx, FAKE_WS, 'resumed');
+    expect(t.agentCtx.session.id).toBe('resumed');
+    expect(t.swapped).toEqual(['resumed']);
+    expect(t.agentCtx.messages).toEqual(messages);
+    expect(result(t.sent)?.success).toBe(true);
+    expect(lastOf(t.bc, 'session.start')).toBeDefined();
+  });
+});


### PR DESCRIPTION
Part of #30 (webui-server 8-PR refactor). Continues the ws-handlers/ extraction (PRs 5–5i).

## What
Move the inline `handleMessage` switch cases for `goal.get`, `sessions.list`, and `session.new`/`checkpoints`/`rewind`/`delete`/`save`/`resume` out of `runWebUI` into `packages/cli/src/webui-server/ws-handlers/sessions.ts` (8 `ctx`-threaded functions).

## How
- `SessionsOptions` is the read-only subset these handlers need (`agent`, `session`, `sessionStore`, `sessionsDir`, `onSessionSwapped`), passed **by reference** so the swapping handlers observe live `agent.ctx.session` at call time.
- The swapping handlers (new/resume) + rewinder still mutate the LIVE writer and reset the token counter exactly as the inline cases did.
- Reset `session.start` payload built via a `buildSessionStart` callback wrapping the existing `buildSessionStartPayload` closure.

## Net
−180 lines in `webui-server.ts`.

## Tests
- New `ws-handlers-sessions.test.ts` (10 tests): stub store + fake agent ctx drive the swapping handlers; `goal.get` round-trips a temp project dir. Disk-backed checkpoints/rewind stay covered by the runWebUI integration test.
- Full webui-server suite: **141 passed across 22 files**. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)