### PR TITLE
refactor(cli): extract connection ws-handlers — completes #30

### DIFF
--- a/docs/refactor-next.md
+++ b/docs/refactor-next.md
@@ -1,7 +1,10 @@
-# webui-server Refactor — Status & Remaining Work
+# webui-server Refactor — Status (Issue #30 COMPLETE ✅)
 
 Checkpoint for Issue #30 (the `packages/cli/src/webui-server.ts` N-PR
-refactor). Update this before switching context, handing off, or resuming.
+refactor). **All planned PRs are merged** — every self-contained concern,
+and every `handleMessage` ws-handler group, now lives in a focused
+`webui-server/*` module. `handleMessage` is a pure router. This doc is kept
+as the historical map; there is no remaining extraction work.
 
 ## Completed status
 
@@ -26,9 +29,9 @@ refactor). Update this before switching context, handing off, or resuming.
 | 5h | ws-handlers/ — **context** (clear/debug/compact/repair/modes) | ✅ merged | #68 |
 | 5i | ws-handlers/ — **process** (list/kill/killAll) | ✅ merged | #69 |
 | 5j | ws-handlers/ — **sessions** (goal.get/sessions.list/session.*) | ✅ merged | #70 |
-| 5k | ws-handlers/ — **handleUserMessage** + connection cases | 🔴 in progress | — |
+| 5k | ws-handlers/ — **connection** (user_message/abort/ping/tool.confirm_result) | ✅ merged | #71 |
 
-`webui-server.ts` is ~3000 lines (down from ~3250). The self-contained
+`webui-server.ts` is ~2070 lines (down from ~3250). The self-contained
 concerns now live under `packages/cli/src/webui-server/`:
 
 ```
@@ -51,6 +54,7 @@ webui-server/
     context.ts          — context.clear/debug/compact/repair/modes (PR 5h)
     process.ts          — process.list/kill/killAll           (PR 5i)
     sessions.ts         — goal.get/sessions.list/session.*     (PR 5j)
+    connection.ts       — user_message/abort/ping/tool.confirm_result (PR 5k)
 ```
 
 Per-group contexts now extend a small `WsCommon` base (`send`/`broadcast`/
@@ -63,44 +67,32 @@ A module-map doc comment at the top of `webui-server.ts` points to each.
 
 ---
 
-## PR 5k — remaining ws-handler work (🔴 in progress)
+## ws-handlers extraction — COMPLETE
 
-Extracted so far: **providers** (5), **brain** (5b), **introspection**
-(5c), **worklist** (5d), **agent-config** (5e), **prefs** (5f),
-**projects** (5g), **context** (5h), **process** (5i), **sessions** (5j)
-— each fully unit-tested, threaded via a per-group context extending
-`WsCommon`. Current reality:
+All eleven groups are extracted, each fully unit-tested and threaded via a
+per-group context extending `WsCommon`: **providers** (5), **brain** (5b),
+**introspection** (5c), **worklist** (5d), **agent-config** (5e), **prefs**
+(5f), **projects** (5g), **context** (5h), **process** (5i), **sessions**
+(5j), **connection** (5k).
 
-- **Already delegated** — `memory.*`, `files.*`, `mailbox.*`, `shell.open`
-  cases already call the shared `@wrongstack/webui/server` handlers. No
-  CLI-local extraction to do.
-- **Still inline** — only `handleUserMessage` (the agent-run entry) and
-  the connection-level cases (`user_message` / `abort` / `ping` /
-  `tool.confirm_result`). This is the riskiest remaining extraction: it
-  drives the live run loop, owns the abort controllers + pending-confirm
-  map, and bridges agent events back to the socket. Extract test-first,
-  growing its context with the run-loop state it needs.
+- **Delegated, not extracted** — `memory.*`, `files.*`, `mailbox.*`,
+  `shell.open` call the shared `@wrongstack/webui/server` handlers directly.
+  There was never CLI-local code to move for these.
+- **`connection` (5k)** was the last and was expected to be the riskiest
+  (it owns the per-socket abort controllers + the pending-confirm map and
+  drives `agent.run`). In practice the four cases only touch
+  `abortControllers`, `pendingConfirms`, and `opts.agent` — so they moved
+  cleanly behind a `ConnectionContext` that shares those two maps by
+  reference with the connection/close handlers, plus `opts` by reference so
+  `user_message` runs the live (post-project-switch) agent. 10 unit tests
+  cover overlap-rejection, result/error mapping, per-socket abort scoping,
+  ping, and confirm-resolve.
 
-**Why deferred (not "forgotten"):** these cases are coupled to ~25 pieces
-of run-loop state (`abortController` + `abortControllers`, `clients`,
-`pendingConfirms`, `eventUnsubscribers`, `autoPhaseHandler`,
-`getCustomModeStore`, `opts.agent`/`events`/`session`/`sessionStore`,
-the event bridge, `broadcast`, …) and have **no standalone unit
-coverage**. Moving them safely means first growing `WsHandlerContext` to
-carry that state explicitly, then extracting one group at a time behind
-characterization tests — a dedicated test-first effort, not an
-opportunistic move bundled into another PR.
-
-**Suggested approach when picked up:**
-1. Pick one cohesive group (sessions is a good first — it's large and
-   relatively self-contained around `sessionStore`/`session`).
-2. Add a handler-level test that drives the current inline behaviour
-   through a real (or faithfully faked) context — lock in the contract.
-3. Add the group's dependencies to `WsHandlerContext`.
-4. Move the cases into `webui-server/ws-handlers/<group>.ts` as
-   `ctx`-threaded functions; the switch case calls them.
-5. Repeat. The `WsHandlerContext` + provider group from PR 5 are the
-   template.
+`handleMessage` is now a pure router: every case unpacks its payload and
+calls a `handleXxx(ctx, …)`. The per-group contexts are all built before
+the WS connection handler is wired (TDZ-safe). The template to follow for
+any future ws message is: add the handler to its topic file, export it
+through `ws-handlers/index.ts`, add a router case.
 
 ---
 

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -17,19 +17,23 @@
  *                                        ProviderConfigStore facade
  *                                        (PR 4 + follow-up)
  *   webui-server/static-serve.ts       — dist discovery + HTTP bring-up (PR 6)
- *   webui-server/ws-handlers/          — provider/model/key WS handlers,
- *                                        threaded via WsHandlerContext (PR 5)
  *   webui-server/lifecycle.ts          — instance registry, ready banner +
  *                                        open-browser, SIGINT/SIGTERM
  *                                        graceful shutdown (PR 7)
+ *   webui-server/ws-handlers/          — every `handleMessage` case, one
+ *                                        topic file per group, each threaded
+ *                                        through a per-group context that
+ *                                        extends the small `WsCommon` base
+ *                                        (PR 5 + 5b–5k):
+ *       providers · brain · introspection · worklist · agent-config ·
+ *       prefs · projects · context · process · sessions · connection
  *
- * The remaining `handleMessage` switch (sessions, todos, context, brain,
- * tasks, projects, plan, skills, modes, model, …) is still inline here:
- * those cases are coupled to ~25 pieces of run-loop state and have no
- * standalone unit coverage, so they await a dedicated test-first
- * extraction rather than being moved opportunistically. The file/memory/
- * mailbox/shell cases already delegate to the shared
- * `@wrongstack/webui/server` handlers.
+ * `handleMessage` now only routes: each case unpacks the payload and calls
+ * the matching `handleXxx(ctx, …)`. The per-group contexts are all built
+ * once (before the WS connection handler is wired, so a fast client message
+ * can't reach a handler before its context initializes). The file/memory/
+ * mailbox/shell cases delegate to the shared `@wrongstack/webui/server`
+ * handlers.
  *
  * Public surface: `runWebUI` plus the `WSServerMessage` / `WSClientMessage`
  * message shapes. Everything else is internal to the run.
@@ -92,6 +96,7 @@ import { startStaticServe } from './webui-server/static-serve.js';
 import {
   type AgentConfigContext,
   type BrainHandlerContext,
+  type ConnectionContext,
   type ContextHandlerContext,
   type IntrospectionContext,
   type PrefsContext,
@@ -100,10 +105,14 @@ import {
   type WorklistContext,
   type WsCommon,
   type WsHandlerContext,
+  handleAbort,
   handleAutonomySwitch,
   handleBrainAsk,
   handleBrainRisk,
   handleBrainStatus,
+  handlePing,
+  handleToolConfirmResult,
+  handleUserMessage,
   handleContextClear,
   handleContextCompact,
   handleContextDebug,
@@ -1126,6 +1135,18 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     broadcast,
     log: (m) => console.log(m),
   };
+
+  // Connection-level cases (user_message/abort/ping/tool.confirm_result).
+  // `opts` is by reference so `user_message` runs the live agent; the two
+  // maps are the SAME instances the connection/close handlers mutate.
+  const connectionCtx: ConnectionContext = {
+    opts,
+    abortControllers,
+    pendingConfirms,
+    send,
+    broadcast,
+    log: (m) => console.log(m),
+  };
   return new Promise<void>((resolve) => {
     wss.on('listening', () => {
       console.log(`[WebUI] WebSocket server running on ws://${host}:${port}`);
@@ -1372,48 +1393,31 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
 
   async function handleMessage(
     ws: WebSocket,
-    client: ConnectedClient,
+    _client: ConnectedClient,
     msg: WSClientMessage,
   ): Promise<void> {
     switch (msg.type) {
       case 'user_message':
         await handleUserMessage(
+          connectionCtx,
           ws,
-          client,
           (msg as { payload: { content: string } }).payload.content,
         );
         break;
 
       case 'abort':
-        // Scope the abort to the requesting socket. The legacy module-scope
-        // `abortController` (project-switch path) is left alone — a
-        // `case 'abort'` from one client should not interfere with another
-        // client's in-flight run. The error message is sent only to the
-        // requesting socket (was `broadcast({...})` previously), which is
-        // correct: other clients have no idea what just happened.
-        {
-          const wsController = abortControllers.get(ws);
-          wsController?.abort();
-        }
-        send(ws, {
-          type: 'error',
-          payload: { phase: 'abort', message: 'User aborted' },
-        });
+        handleAbort(connectionCtx, ws);
         break;
 
       case 'ping':
-        send(ws, { type: 'pong', payload: {} });
+        handlePing(connectionCtx, ws);
         break;
 
       case 'tool.confirm_result': {
         const { id, decision } = (
           msg as { payload: { id: string; decision: 'yes' | 'no' | 'always' | 'deny' } }
         ).payload;
-        const resolve = pendingConfirms.get(id);
-        if (resolve) {
-          pendingConfirms.delete(id);
-          resolve(decision);
-        }
+        handleToolConfirmResult(connectionCtx, id, decision);
         break;
       }
 
@@ -2030,64 +2034,6 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         }
         break;
       }
-    }
-  }
-
-  async function handleUserMessage(
-    ws: WebSocket,
-    _client: ConnectedClient,
-    content: string,
-  ): Promise<void> {
-    // Guard against overlapping runs on the same Agent instance. Two
-    // rapid user messages would otherwise start a second agent.run()
-    // before the first one's cleanup settles, corrupting context state.
-    // Scoped to the requesting socket via `abortControllers` — a second
-    // tab's `user_message` is allowed to start its own run; only an
-    // overlapping message from the SAME tab is rejected.
-    if (abortControllers.has(ws)) {
-      send(ws, {
-        type: 'error',
-        payload: { phase: 'agent.run', message: 'A run is already in progress. Abort it first.' },
-      });
-      return;
-    }
-
-    // Abort any existing run (safety net; the guard above makes this
-    // unreachable in the overlapping case, but direct abort requests
-    // from the client still need the controller reference).
-    const wsAbort = new AbortController();
-    abortControllers.set(ws, wsAbort);
-
-    try {
-      const result = await opts.agent.run(content, {
-        signal: wsAbort.signal,
-      });
-
-      send(ws, {
-        type: 'run.result',
-        payload: {
-          status: result.status,
-          iterations: result.iterations,
-          finalText: result.finalText,
-          error: result.error
-            ? {
-                code: result.error.code,
-                message: result.error.message,
-                recoverable: result.error.recoverable,
-              }
-            : undefined,
-        },
-      });
-    } catch (err) {
-      send(ws, {
-        type: 'error',
-        payload: {
-          phase: 'agent.run',
-          message: err instanceof Error ? err.message : String(err),
-        },
-      });
-    } finally {
-      abortControllers.delete(ws);
     }
   }
 

--- a/packages/cli/src/webui-server/ws-handlers/connection.ts
+++ b/packages/cli/src/webui-server/ws-handlers/connection.ts
@@ -1,0 +1,126 @@
+import type { Agent } from '@wrongstack/core';
+import type { WebSocket } from 'ws';
+import type { WsCommon } from './index.js';
+
+/**
+ * PR 5k of Issue #30: the connection-level WebSocket handlers —
+ * `user_message` (the agent-run entry), `abort`, `ping`, and
+ * `tool.confirm_result`.
+ *
+ * These are the last cases that lived inline in `runWebUI`'s
+ * `handleMessage` switch. Unlike the topic groups, they own per-socket
+ * run-loop state: `abortControllers` (one in-flight `AbortController`
+ * per socket) and `pendingConfirms` (tool-permission resolvers keyed by
+ * confirm id). Both maps are *owned* by `runWebUI` and shared with the
+ * connection/close handlers, so they're passed by reference on the
+ * context rather than copied — the close handler still aborts/clears the
+ * same maps these handlers mutate.
+ *
+ * `opts` is threaded by reference (read-only here) so `handleUserMessage`
+ * calls the live `opts.agent` — after a project switch reassigns it, the
+ * next `user_message` runs the new agent.
+ */
+
+/** The tool-confirmation decision the client can send back. */
+export type ConfirmDecision = 'yes' | 'no' | 'always' | 'deny';
+
+export interface ConnectionOptions {
+  agent: Agent;
+}
+
+export interface ConnectionContext extends WsCommon {
+  opts: ConnectionOptions;
+  /** One in-flight run controller per socket; owned by runWebUI. */
+  abortControllers: Map<WebSocket, AbortController>;
+  /** Pending tool-permission resolvers keyed by confirm id; owned by runWebUI. */
+  pendingConfirms: Map<string, (decision: ConfirmDecision) => void>;
+}
+
+export async function handleUserMessage(
+  ctx: ConnectionContext,
+  ws: WebSocket,
+  content: string,
+): Promise<void> {
+  // Guard against overlapping runs on the same Agent instance. Two
+  // rapid user messages would otherwise start a second agent.run()
+  // before the first one's cleanup settles, corrupting context state.
+  // Scoped to the requesting socket via `abortControllers` — a second
+  // tab's `user_message` is allowed to start its own run; only an
+  // overlapping message from the SAME tab is rejected.
+  if (ctx.abortControllers.has(ws)) {
+    ctx.send(ws, {
+      type: 'error',
+      payload: { phase: 'agent.run', message: 'A run is already in progress. Abort it first.' },
+    });
+    return;
+  }
+
+  // Abort any existing run (safety net; the guard above makes this
+  // unreachable in the overlapping case, but direct abort requests
+  // from the client still need the controller reference).
+  const wsAbort = new AbortController();
+  ctx.abortControllers.set(ws, wsAbort);
+
+  try {
+    const result = await ctx.opts.agent.run(content, {
+      signal: wsAbort.signal,
+    });
+
+    ctx.send(ws, {
+      type: 'run.result',
+      payload: {
+        status: result.status,
+        iterations: result.iterations,
+        finalText: result.finalText,
+        error: result.error
+          ? {
+              code: result.error.code,
+              message: result.error.message,
+              recoverable: result.error.recoverable,
+            }
+          : undefined,
+      },
+    });
+  } catch (err) {
+    ctx.send(ws, {
+      type: 'error',
+      payload: {
+        phase: 'agent.run',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    });
+  } finally {
+    ctx.abortControllers.delete(ws);
+  }
+}
+
+export function handleAbort(ctx: ConnectionContext, ws: WebSocket): void {
+  // Scope the abort to the requesting socket. The legacy module-scope
+  // `abortController` (project-switch path) is left alone — a
+  // `case 'abort'` from one client should not interfere with another
+  // client's in-flight run. The error message is sent only to the
+  // requesting socket (not broadcast), which is correct: other clients
+  // have no idea what just happened.
+  const wsController = ctx.abortControllers.get(ws);
+  wsController?.abort();
+  ctx.send(ws, {
+    type: 'error',
+    payload: { phase: 'abort', message: 'User aborted' },
+  });
+}
+
+export function handlePing(ctx: ConnectionContext, ws: WebSocket): void {
+  ctx.send(ws, { type: 'pong', payload: {} });
+}
+
+export function handleToolConfirmResult(
+  ctx: ConnectionContext,
+  id: string,
+  decision: ConfirmDecision,
+): void {
+  const resolve = ctx.pendingConfirms.get(id);
+  if (resolve) {
+    ctx.pendingConfirms.delete(id);
+    resolve(decision);
+  }
+}

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -63,6 +63,15 @@ export {
   handleBrainStatus,
 } from './brain.js';
 export {
+  type ConfirmDecision,
+  type ConnectionContext,
+  type ConnectionOptions,
+  handleAbort,
+  handlePing,
+  handleToolConfirmResult,
+  handleUserMessage,
+} from './connection.js';
+export {
   type ContextHandlerContext,
   handleContextClear,
   handleContextCompact,

--- a/packages/cli/tests/webui-server/ws-handlers-connection.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-connection.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import {
+  type ConfirmDecision,
+  type ConnectionContext,
+  handleAbort,
+  handlePing,
+  handleToolConfirmResult,
+  handleUserMessage,
+} from '../../src/webui-server/ws-handlers/connection.js';
+import type { WsServerMessage } from '../../src/webui-server/ws-handlers/index.js';
+
+/**
+ * PR 5k of Issue #30: connection-level ws-handler unit tests
+ * (user_message / abort / ping / tool.confirm_result). A fake agent
+ * drives the run path; the abort/confirm maps are real Maps so the
+ * per-socket scoping and the finally-block cleanup are exercised
+ * directly.
+ */
+
+const WS_A = { id: 'a' } as unknown as WebSocket;
+const WS_B = { id: 'b' } as unknown as WebSocket;
+
+type RunResult = {
+  status: string;
+  iterations: number;
+  finalText: string;
+  error?: { code: string; message: string; recoverable: boolean };
+};
+
+function makeCtx(run?: (content: string, opts: { signal: AbortSignal }) => Promise<RunResult>): {
+  ctx: ConnectionContext;
+  sent: Array<{ ws: WebSocket; msg: WsServerMessage }>;
+  abortControllers: Map<WebSocket, AbortController>;
+  pendingConfirms: Map<string, (d: ConfirmDecision) => void>;
+} {
+  const sent: Array<{ ws: WebSocket; msg: WsServerMessage }> = [];
+  const abortControllers = new Map<WebSocket, AbortController>();
+  const pendingConfirms = new Map<string, (d: ConfirmDecision) => void>();
+  const ctx: ConnectionContext = {
+    opts: {
+      agent: {
+        run: run ?? (async () => ({ status: 'completed', iterations: 1, finalText: 'ok' })),
+      } as never,
+    },
+    abortControllers,
+    pendingConfirms,
+    send: (ws, msg) => sent.push({ ws, msg }),
+    broadcast: () => {},
+    log: () => {},
+  };
+  return { ctx, sent, abortControllers, pendingConfirms };
+}
+
+const lastFor = (
+  sent: Array<{ ws: WebSocket; msg: WsServerMessage }>,
+  ws: WebSocket,
+  type: string,
+) => sent.filter((s) => s.ws === ws && s.msg.type === type).at(-1)?.msg;
+
+describe('handleUserMessage', () => {
+  it('rejects an overlapping run on the same socket without calling the agent', async () => {
+    let ran = false;
+    const t = makeCtx(async () => {
+      ran = true;
+      return { status: 'completed', iterations: 1, finalText: 'ok' };
+    });
+    // Simulate an in-flight run for WS_A.
+    t.abortControllers.set(WS_A, new AbortController());
+    await handleUserMessage(t.ctx, WS_A, 'hi');
+    expect(ran).toBe(false);
+    expect(lastFor(t.sent, WS_A, 'error')?.payload).toMatchObject({
+      phase: 'agent.run',
+      message: expect.stringContaining('already in progress'),
+    });
+  });
+
+  it('runs the agent, maps the result, and clears the controller', async () => {
+    let seenSignal: AbortSignal | undefined;
+    const t = makeCtx(async (_content, opts) => {
+      seenSignal = opts.signal;
+      // The controller must be registered for the duration of the run.
+      expect(t.abortControllers.has(WS_A)).toBe(true);
+      return { status: 'completed', iterations: 3, finalText: 'done' };
+    });
+    await handleUserMessage(t.ctx, WS_A, 'hello');
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+    expect(lastFor(t.sent, WS_A, 'run.result')?.payload).toEqual({
+      status: 'completed',
+      iterations: 3,
+      finalText: 'done',
+      error: undefined,
+    });
+    // Cleared in the finally block.
+    expect(t.abortControllers.has(WS_A)).toBe(false);
+  });
+
+  it('maps a structured run error', async () => {
+    const t = makeCtx(async () => ({
+      status: 'error',
+      iterations: 2,
+      finalText: '',
+      error: { code: 'E_X', message: 'boom', recoverable: true },
+    }));
+    await handleUserMessage(t.ctx, WS_A, 'go');
+    expect(lastFor(t.sent, WS_A, 'run.result')?.payload).toMatchObject({
+      status: 'error',
+      error: { code: 'E_X', message: 'boom', recoverable: true },
+    });
+  });
+
+  it('reports a thrown run error and still clears the controller', async () => {
+    const t = makeCtx(async () => {
+      throw new Error('kaboom');
+    });
+    await handleUserMessage(t.ctx, WS_A, 'go');
+    expect(lastFor(t.sent, WS_A, 'error')?.payload).toMatchObject({
+      phase: 'agent.run',
+      message: 'kaboom',
+    });
+    expect(t.abortControllers.has(WS_A)).toBe(false);
+  });
+
+  it('lets a second socket start its own run concurrently', async () => {
+    const t = makeCtx();
+    t.abortControllers.set(WS_A, new AbortController()); // A is busy
+    await handleUserMessage(t.ctx, WS_B, 'hi from B');
+    // B was not rejected — it produced a run.result.
+    expect(lastFor(t.sent, WS_B, 'run.result')).toBeDefined();
+    expect(lastFor(t.sent, WS_B, 'error')).toBeUndefined();
+  });
+});
+
+describe('handleAbort', () => {
+  it('aborts only the requesting socket and notifies it', () => {
+    const t = makeCtx();
+    const ctrlA = new AbortController();
+    const ctrlB = new AbortController();
+    t.abortControllers.set(WS_A, ctrlA);
+    t.abortControllers.set(WS_B, ctrlB);
+    handleAbort(t.ctx, WS_A);
+    expect(ctrlA.signal.aborted).toBe(true);
+    expect(ctrlB.signal.aborted).toBe(false);
+    expect(lastFor(t.sent, WS_A, 'error')?.payload).toMatchObject({
+      phase: 'abort',
+      message: 'User aborted',
+    });
+  });
+
+  it('is a no-op on the controller when none is in flight, but still notifies', () => {
+    const t = makeCtx();
+    expect(() => handleAbort(t.ctx, WS_A)).not.toThrow();
+    expect(lastFor(t.sent, WS_A, 'error')?.payload).toMatchObject({ phase: 'abort' });
+  });
+});
+
+describe('handlePing', () => {
+  it('replies with pong', () => {
+    const t = makeCtx();
+    handlePing(t.ctx, WS_A);
+    expect(lastFor(t.sent, WS_A, 'pong')).toBeDefined();
+  });
+});
+
+describe('handleToolConfirmResult', () => {
+  it('resolves and removes the pending confirm', () => {
+    const t = makeCtx();
+    let got: ConfirmDecision | undefined;
+    t.pendingConfirms.set('c1', (d) => {
+      got = d;
+    });
+    handleToolConfirmResult(t.ctx, 'c1', 'always');
+    expect(got).toBe('always');
+    expect(t.pendingConfirms.has('c1')).toBe(false);
+  });
+
+  it('ignores an unknown confirm id', () => {
+    const t = makeCtx();
+    expect(() => handleToolConfirmResult(t.ctx, 'missing', 'yes')).not.toThrow();
+  });
+});


### PR DESCRIPTION
Final PR of #30 (webui-server N-PR refactor). Completes the ws-handlers/ extraction.

## What
Move the last inline `handleMessage` cases — `user_message` (agent-run entry), `abort`, `ping`, `tool.confirm_result` — into `packages/cli/src/webui-server/ws-handlers/connection.ts` (4 `ctx`-threaded functions). `handleMessage` is now a pure router.

## How
- `ConnectionContext` shares `abortControllers` and `pendingConfirms` **by reference** with the connection/close handlers (the close handler still aborts/clears the same maps).
- `opts` threaded by reference so `user_message` runs the live `opts.agent` after a project switch reassigns it.
- Behaviour unchanged: per-socket overlap rejection, structured result/error mapping, abort scoped to the requesting socket, ping/pong, confirm-resolve.

These were billed as the riskiest cases (they own the run-loop's abort + pending-confirm state), but each only touches `abortControllers` / `pendingConfirms` / `opts.agent` — so they moved cleanly.

## Net
−54 lines in `webui-server.ts` (now ~2070, down from ~3250 at the start of #30).

## Tests
- New `ws-handlers-connection.test.ts` (10 tests): fake agent drives the run path; real Maps exercise per-socket scoping + finally-block cleanup.
- Full webui-server suite: **151 passed across 23 files**. Typecheck clean.

## Docs
- Refreshes the module-map header in `webui-server.ts`.
- Marks Issue #30 **complete** in `docs/refactor-next.md` (all eleven ws-handler groups extracted: providers · brain · introspection · worklist · agent-config · prefs · projects · context · process · sessions · connection).

Closes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)