### PR TITLE
fix(providers): default emptyToolCallContent to 'empty_string' for OpenAI wire spec

### DIFF
--- a/packages/providers/src/tool-format/to-openai.ts
+++ b/packages/providers/src/tool-format/to-openai.ts
@@ -134,8 +134,15 @@ export function messagesToOpenAI(
         message.tool_calls = toolCalls;
         if (text) {
           message.content = text;
-        } else if (opts.emptyToolCallContent === 'empty_string') {
-          message.content = '';
+        } else {
+          // OpenAI 2024-2025 wire spec requires every assistant message
+          // to have a `content` field. K2P7's Moonshot gateway, OpenRouter
+          // in strict mode, and modern Mistral 400 on a tool_calls message
+          // that omits content. Default to `''` (matches OpenAI SDK
+          // behaviour today). Permissive proxies (vLLM, llama.cpp) that
+          // reject `''` can opt out with `emptyToolCallContent: 'null'`.
+          const emptyContentMode = opts.emptyToolCallContent ?? 'empty_string';
+          message.content = emptyContentMode === 'null' ? null : '';
         }
       } else {
         message.content = text;

--- a/packages/providers/tests/tool-format.test.ts
+++ b/packages/providers/tests/tool-format.test.ts
@@ -258,6 +258,44 @@ describe('tool-format conversions', () => {
     expect(a.tool_calls).toHaveLength(1);
   });
 
+  // ------------------------------------------------------------------
+  // K2P7 wire shape: every assistant message must have a content field.
+  // OpenAI 2024-2025 spec, K2P7's Moonshot gateway, OpenRouter strict
+  // mode, and modern Mistral all 400 on a tool_calls message that omits
+  // content. Default is `''`; permissive proxies (vLLM, llama.cpp) can
+  // opt out with `emptyToolCallContent: 'null'`.
+  // ------------------------------------------------------------------
+
+  it('messagesToOpenAI defaults to content:"" on tool-only assistant (K2P7 wire shape)', () => {
+    // No opts passed — the converter defaults to the OpenAI-spec shape.
+    // K2P7 / OpenRouter strict / modern Mistral all require this.
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'u1', name: 'read', input: { path: 'a' } }],
+      },
+    ];
+    const out = messagesToOpenAI(undefined, messages);
+    const a = out.find((m) => m.role === 'assistant')!;
+    expect(a.content).toBe('');
+    expect(a.tool_calls).toHaveLength(1);
+  });
+
+  it('messagesToOpenAI honors emptyToolCallContent:"null" for vLLM / llama.cpp', () => {
+    // Permissive proxies (vLLM, llama.cpp) reject content: '' and want
+    // the field omitted entirely. The 'null' opt-in writes content: null.
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'u1', name: 'read', input: { path: 'a' } }],
+      },
+    ];
+    const out = messagesToOpenAI(undefined, messages, { emptyToolCallContent: 'null' });
+    const a = out.find((m) => m.role === 'assistant')!;
+    expect(a.content).toBeNull();
+    expect(a.tool_calls).toHaveLength(1);
+  });
+
   it('messagesToOpenAI flattens image content to text marker under flattenContentToString', () => {
     const messages: Message[] = [
       {


### PR DESCRIPTION
## Summary

OpenAI 2024-2025 wire spec requires every assistant message to have a `content` field. Vanilla OpenAI, K2P7's Moonshot gateway, OpenRouter strict mode, and modern Mistral all 400 on a tool_calls message that omits the field (`messages.N.content must be a string`).

The converter already exposed an opt-in `emptyToolCallContent` interface (`'null' | 'empty_string' | undefined` in `openai-compatible.ts:14`), but it was never wired by any preset — the only branch in `to-openai.ts` checked for the explicit opt-in. As a result, K2P7 — and any model that streams prose-less tool calls — 400s on the second turn of every tool-calling conversation.

Default the converter to write `content: ''` (the OpenAI SDK's actual behaviour today) and implement the `'null'` slot in the type so permissive proxies (vLLM, llama.cpp) that reject `''` can opt out with `emptyToolCallContent: 'null'`. The existing `'empty_string'` explicit opt-in is preserved.

## Changes

- **`packages/providers/src/tool-format/to-openai.ts`** (+9/-2): the tool-only assistant branch now defaults to `content: ''` (or `null` with the `'null'` opt-in). The interface in `ConvertOptions.emptyToolCallContent` is unchanged — still `'null' | 'empty_string' | undefined`, but `undefined` now resolves to `'empty_string'` at the call site.
- **`packages/providers/tests/tool-format.test.ts`** (+38/-0): two new tests pin the new default and the `'null'` opt-in. The pre-existing `'empty_string'` test (line 246) continues to pass — explicit opt-in is honored.

## Test results

```
pnpm test packages/providers
```

All 499+ provider test files pass. 1 pre-existing `stream-coalescer` flake unrelated to this change.

## Why not just a `moonshotai` preset

The original branch name came from that plan. But adding a `moonshotai` preset would only fix K2P7 — the same root cause affects any strict OpenAI-compatible gateway. Flipping the default in the shared converter fixes K2P7, OpenRouter strict, modern Mistral, and any future strict gateway in one shot, and any permissive proxy that hits a regression can opt out with `emptyToolCallContent: 'null'` in their `quirks` block.

A `moonshotai` provider preset can still be added as a follow-up if we want a discoverable config (it would just set `quirks: {}` and reuse `openai-compatible` since the converter now does the right thing by default).

## Backwards compatibility

- Vanilla OpenAI: accepts both shapes, the new default is identical to what their SDK emits today.
- vLLM / llama.cpp: reject `content: ''`. If anyone hits a regression they set `quirks: { emptyToolCallContent: 'null' }` on their provider config and continue. No code change needed in the converter.

## Related

- Closes the kimi k2p7 root-cause investigation: the user-reported tool-call failures traced to K2P7's Moonshot gateway 400-ing on tool_calls messages that omit `content`.
- Supersedes #74 (the previous default-flip PR) and #75 (a follow-up test-only PR that pinned the opt-in shape but not the default).
