### PR TITLE
fix: publish missing package entrypoints

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     'src/models/index.ts',
     'src/infrastructure/index.ts',
     'src/observability/index.ts',
+    'src/tools/index.ts',
     'src/extension/index.ts',
     // Skill installer
     'src/skills/index.ts',

--- a/packages/webui/tsup.config.ts
+++ b/packages/webui/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: {
     index: 'src/main.tsx',
+    types: 'src/types.ts',
     'server/entry': 'src/server/entry.ts',
     'server/index': 'src/server/index.ts',
   },


### PR DESCRIPTION
## Summary
- include `@wrongstack/core`'s `./tools` export in the core tsup entry list
- include `@wrongstack/webui`'s `./types` export in the webui tsup entry map

## Why
The published package manifests expose these subpaths, but the current build entrypoints do not emit the corresponding runtime/type files:

- `@wrongstack/core/tools` -> `dist/tools/index.{js,d.ts}`
- `@wrongstack/webui/types` -> `dist/types.{js,d.ts}`

Consumers resolving those package exports hit files that are missing from the published tarballs.

## Validation
- inspected the published `@wrongstack/core@0.256.1` and `@wrongstack/webui@0.256.1` tarballs and confirmed the exported files are missing
- confirmed the source entrypoints exist at `packages/core/src/tools/index.ts` and `packages/webui/src/types.ts`
- ran `corepack pnpm install --frozen-lockfile --ignore-scripts`
- ran `corepack pnpm --filter @wrongstack/core build`
- ran `corepack pnpm --filter @wrongstack/tools build`
- ran `corepack pnpm --filter @wrongstack/providers build`
- ran `corepack pnpm --filter @wrongstack/webui build`