### PR TITLE
fix(webui): reconcile WebUI↔CLI WebSocket protocol gaps

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -141,6 +141,10 @@ import {
   handleProviderAdd,
   handleProviderModels,
   handleProviderRemove,
+  handleProviderClearModels,
+  handleProviderUndoClear,
+  handleProviderUpdate,
+  handleProviderProbe,
   handleProvidersList,
   handleProvidersSaved,
   handleSkillsList,
@@ -1474,6 +1478,43 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         break;
       }
 
+      case 'provider.clear_models': {
+        const m = msg as { payload: { providerId: string } };
+        await handleProviderClearModels(wsHandlerCtx, ws, m.payload.providerId);
+        break;
+      }
+
+      case 'provider.undo_clear': {
+        const m = msg as { payload: { providerId: string; previousModels: string[] } };
+        await handleProviderUndoClear(
+          wsHandlerCtx,
+          ws,
+          m.payload.providerId,
+          m.payload.previousModels,
+        );
+        break;
+      }
+
+      case 'provider.update': {
+        const m = msg as {
+          payload: {
+            id: string;
+            family?: string | undefined;
+            baseUrl?: string | undefined;
+            envVars?: string[] | undefined;
+            models?: string[] | undefined;
+          };
+        };
+        await handleProviderUpdate(wsHandlerCtx, ws, m.payload);
+        break;
+      }
+
+      case 'provider.probe': {
+        const m = msg as { payload: { providerId: string; timeoutMs?: number | undefined } };
+        await handleProviderProbe(wsHandlerCtx, ws, m.payload.providerId, m.payload.timeoutMs);
+        break;
+      }
+
       case 'todos.get': {
         handleTodosGet(worklistCtx, ws);
         break;
@@ -1825,11 +1866,16 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }
 
       // Collaboration messages — the CLI webui-server doesn't run a
-      // full collab hub; silently acknowledge and ignore.
+      // full collab hub; silently acknowledge and ignore. request_pause /
+      // resume are included so the CollabPanel's pause/resume buttons don't
+      // trip the "Unhandled message type" warning (the standalone webui
+      // server is the one that wires the real CollaborationWebSocketHandler).
       case 'collab.join':
       case 'collab.leave':
       case 'collab.annotate':
       case 'collab.resolve':
+      case 'collab.request_pause':
+      case 'collab.resume':
         break;
 
       case 'projects.list': {
@@ -2039,6 +2085,52 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
             payload: { error: err instanceof Error ? err.message : String(err) },
           });
         }
+        break;
+      }
+
+      case 'git.info': {
+        // Read git branch, change stats, and sync status from the working
+        // directory. Mirrors the standalone webui server's handler so the
+        // status-bar git widget works under the CLI-hosted webui too.
+        const projectRoot =
+          opts.projectRoot ?? (opts.agent.ctx as { projectRoot?: string }).projectRoot ?? '';
+        const cwd = projectRoot || undefined;
+        const { execFile: ef } = await import('node:child_process');
+        const git = (args: string[]): Promise<string> =>
+          new Promise((resolve) => {
+            ef('git', args, { cwd, timeout: 3000 }, (err: Error | null, stdout: string) => {
+              resolve(err ? '' : stdout.trim());
+            });
+          });
+
+        const [branchRaw, diffRaw, statusRaw, upstreamRaw] = await Promise.all([
+          git(['branch', '--show-current']),
+          git(['diff', '--stat']),
+          git(['status', '--porcelain']),
+          git(['rev-list', '--left-right', '--count', '@{upstream}...HEAD']),
+        ]);
+
+        const branch = branchRaw || '(detached)';
+
+        // `git diff --stat` summary line: "N files changed, X insertions(+), Y deletions(-)"
+        const addMatch = /(\d+)\s+insertion/i.exec(diffRaw);
+        const delMatch = /(\d+)\s+deletion/i.exec(diffRaw);
+        const added = addMatch ? Number(addMatch[1]) : 0;
+        const deleted = delMatch ? Number(delMatch[1]) : 0;
+
+        // Untracked files from `git status --porcelain` (lines starting with "??")
+        const untracked = statusRaw.split('\n').filter((l) => l.startsWith('??')).length;
+
+        // `--left-right --count @{upstream}...HEAD` prints "<behind>\t<ahead>":
+        // left side = commits in upstream not in HEAD (behind), right = ahead.
+        const [behindRaw, aheadRaw] = (upstreamRaw || '0\t0').split('\t');
+        const behind = Number(behindRaw) || 0;
+        const ahead = Number(aheadRaw) || 0;
+
+        send(ws, {
+          type: 'git.info',
+          payload: { branch, added, deleted, untracked, ahead, behind },
+        });
         break;
       }
 

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -112,6 +112,10 @@ export {
   handleProviderAdd,
   handleProviderModels,
   handleProviderRemove,
+  handleProviderClearModels,
+  handleProviderUndoClear,
+  handleProviderUpdate,
+  handleProviderProbe,
   handleProvidersList,
   handleProvidersSaved,
 } from './providers.js';

--- a/packages/cli/src/webui-server/ws-handlers/providers.ts
+++ b/packages/cli/src/webui-server/ws-handlers/providers.ts
@@ -1,4 +1,6 @@
 import type { ProviderConfig } from '@wrongstack/core';
+import { DefaultSecretScrubber } from '@wrongstack/core';
+import { probeLocalLlm } from '@wrongstack/runtime/probe';
 import type { WebSocket } from 'ws';
 import { toErrorMessage } from '@wrongstack/core/utils';
 import {
@@ -27,6 +29,33 @@ import type { WsHandlerContext } from './index.js';
  */
 function sendResult(ctx: WsHandlerContext, ws: WebSocket, success: boolean, message: string): void {
   ctx.send(ws, { type: 'key.operation_result', payload: { success, message } });
+}
+
+/** Shared scrubber for provider health probes — redacts secrets from probe detail. */
+const probeScrubber = new DefaultSecretScrubber();
+
+/**
+ * Re-broadcast the saved-providers projection to every client. Shared by the
+ * mutating provider handlers (add / update / clear / undo) so all surfaces
+ * re-render the same masked snapshot after a change.
+ */
+function broadcastSaved(ctx: WsHandlerContext, providers: Record<string, ProviderConfig>): void {
+  ctx.broadcast({
+    type: 'providers.saved',
+    payload: {
+      providers: Object.entries(providers).map(([id, cfg]) => ({
+        id,
+        family: cfg.family,
+        baseUrl: cfg.baseUrl,
+        apiKeys: normalizeKeys(cfg).map((k) => ({
+          label: k.label,
+          maskedKey: maskedKey(k.apiKey),
+          isActive: k.label === cfg.activeKey,
+          createdAt: k.createdAt,
+        })),
+      })),
+    },
+  });
 }
 
 export async function handleProvidersList(ctx: WsHandlerContext, ws: WebSocket): Promise<void> {
@@ -277,5 +306,120 @@ export async function handleProviderRemove(
     sendResult(ctx, ws, true, `Provider "${providerId}" removed`);
   } catch (err) {
     sendResult(ctx, ws, false, toErrorMessage(err));
+  }
+}
+
+/** Drop a provider's model allowlist (so the full catalog is offered again). */
+export async function handleProviderClearModels(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  providerId: string,
+): Promise<void> {
+  try {
+    const providers = await ctx.providerStore.load();
+    const cfg = providers[providerId];
+    if (!cfg) {
+      sendResult(ctx, ws, false, `Unknown provider "${providerId}"`);
+      return;
+    }
+    delete cfg.models;
+    await ctx.providerStore.save(providers);
+    sendResult(ctx, ws, true, `Cleared model allowlist for ${providerId}`);
+    broadcastSaved(ctx, providers);
+  } catch (err) {
+    sendResult(ctx, ws, false, toErrorMessage(err));
+  }
+}
+
+/** Restore a previously-cleared model allowlist (pairs with clear). */
+export async function handleProviderUndoClear(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  providerId: string,
+  previousModels: string[],
+): Promise<void> {
+  try {
+    const providers = await ctx.providerStore.load();
+    const cfg = providers[providerId];
+    if (!cfg) {
+      sendResult(ctx, ws, false, `Unknown provider "${providerId}"`);
+      return;
+    }
+    cfg.models = [...previousModels];
+    await ctx.providerStore.save(providers);
+    sendResult(ctx, ws, true, `Restored ${previousModels.length} model(s) for ${providerId}`);
+    broadcastSaved(ctx, providers);
+  } catch (err) {
+    sendResult(ctx, ws, false, toErrorMessage(err));
+  }
+}
+
+/** Update a saved provider's wire config (family / baseUrl / envVars / models). */
+export async function handleProviderUpdate(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  payload: {
+    id: string;
+    family?: string | undefined;
+    baseUrl?: string | undefined;
+    envVars?: string[] | undefined;
+    models?: string[] | undefined;
+  },
+): Promise<void> {
+  try {
+    const providers = await ctx.providerStore.load();
+    const cfg = providers[payload.id];
+    if (!cfg) {
+      sendResult(ctx, ws, false, `Unknown provider "${payload.id}"`);
+      return;
+    }
+    if (payload.family !== undefined) cfg.family = payload.family as ProviderConfig['family'];
+    if (payload.baseUrl !== undefined) cfg.baseUrl = payload.baseUrl;
+    if (payload.envVars !== undefined) cfg.envVars = payload.envVars;
+    if (payload.models !== undefined) cfg.models = payload.models;
+    await ctx.providerStore.save(providers);
+    sendResult(ctx, ws, true, `Updated ${payload.id}`);
+    broadcastSaved(ctx, providers);
+  } catch (err) {
+    sendResult(ctx, ws, false, toErrorMessage(err));
+  }
+}
+
+/**
+ * Run a health probe against a saved provider's `/v1/models` and reply with a
+ * `provider.probe` message. Never throws — the probe result carries the
+ * failure mode in its `status`.
+ */
+export async function handleProviderProbe(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  providerId: string,
+  timeoutMs?: number,
+): Promise<void> {
+  const reply = (payload: Record<string, unknown>): void =>
+    ctx.send(ws, { type: 'provider.probe', payload: { providerId, ...payload } });
+  try {
+    const providers = await ctx.providerStore.load();
+    const cfg = providers[providerId];
+    if (!cfg) {
+      reply({ ok: false, status: 'no_provider' });
+      return;
+    }
+    if (!cfg.baseUrl) {
+      reply({ ok: false, status: 'no_base_url' });
+      return;
+    }
+    const keys = normalizeKeys(cfg);
+    const active = keys.find((k) => k.label === cfg.activeKey) ?? keys[0];
+    const result = await probeLocalLlm({
+      baseUrl: cfg.baseUrl,
+      apiKey: active?.apiKey,
+      noAuth: false,
+      scrubber: probeScrubber,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
+    reply(result as unknown as Record<string, unknown>);
+  } catch (err) {
+    reply({ ok: false, status: 'unreachable', detail: toErrorMessage(err) });
   }
 }

--- a/packages/cli/tests/webui-server/ws-handlers-providers.test.ts
+++ b/packages/cli/tests/webui-server/ws-handlers-providers.test.ts
@@ -16,7 +16,11 @@ import {
   handleKeySetActive,
   handleKeyUpsert,
   handleProviderAdd,
+  handleProviderClearModels,
+  handleProviderProbe,
   handleProviderRemove,
+  handleProviderUndoClear,
+  handleProviderUpdate,
   handleProvidersList,
   handleProvidersSaved,
 } from '../../src/webui-server/ws-handlers/index.js';
@@ -178,5 +182,78 @@ describe('ws-handlers/providers (PR 5 of #30)', () => {
     await handleProviderRemove(ctx, FAKE_WS, 'nope');
     expect(lastResult(cap).success).toBe(false);
     expect(lastResult(cap).message).toContain('not found');
+  });
+
+  it('update → clear_models → undo_clear: model allowlist round-trips on disk', async () => {
+    const seed = makeCtx(configPath);
+    await handleProviderAdd(seed.ctx, FAKE_WS, {
+      id: 'acme',
+      family: 'openai-compatible',
+      baseUrl: 'https://a/v1',
+    });
+
+    // Update sets a new baseUrl + model allowlist.
+    const upd = makeCtx(configPath);
+    await handleProviderUpdate(upd.ctx, FAKE_WS, {
+      id: 'acme',
+      baseUrl: 'https://b/v1',
+      models: ['m1', 'm2'],
+    });
+    expect(lastResult(upd.cap).success).toBe(true);
+    expect(upd.cap.broadcasts.some((m) => m.type === 'providers.saved')).toBe(true);
+    let saved = await loadSavedProviders(configPath);
+    expect(saved.acme?.baseUrl).toBe('https://b/v1');
+    expect(saved.acme?.models).toEqual(['m1', 'm2']);
+
+    // Clear drops the allowlist.
+    const clr = makeCtx(configPath);
+    await handleProviderClearModels(clr.ctx, FAKE_WS, 'acme');
+    expect(lastResult(clr.cap).success).toBe(true);
+    saved = await loadSavedProviders(configPath);
+    expect(saved.acme?.models).toBeUndefined();
+
+    // Undo restores it.
+    const undo = makeCtx(configPath);
+    await handleProviderUndoClear(undo.ctx, FAKE_WS, 'acme', ['m1', 'm2']);
+    expect(lastResult(undo.cap).success).toBe(true);
+    saved = await loadSavedProviders(configPath);
+    expect(saved.acme?.models).toEqual(['m1', 'm2']);
+  });
+
+  it('update / clear / undo: error on unknown provider', async () => {
+    const u = makeCtx(configPath);
+    await handleProviderUpdate(u.ctx, FAKE_WS, { id: 'nope', models: [] });
+    expect(lastResult(u.cap).success).toBe(false);
+
+    const c = makeCtx(configPath);
+    await handleProviderClearModels(c.ctx, FAKE_WS, 'nope');
+    expect(lastResult(c.cap).success).toBe(false);
+
+    const un = makeCtx(configPath);
+    await handleProviderUndoClear(un.ctx, FAKE_WS, 'nope', []);
+    expect(lastResult(un.cap).success).toBe(false);
+  });
+
+  it('handleProviderProbe: reports no_provider / no_base_url without a network call', async () => {
+    // Unknown provider — short-circuits before any fetch.
+    const np = makeCtx(configPath);
+    await handleProviderProbe(np.ctx, FAKE_WS, 'ghost');
+    const r1 = np.cap.sent.find((m) => m.type === 'provider.probe')?.payload as {
+      ok: boolean;
+      status: string;
+      providerId: string;
+    };
+    expect(r1).toMatchObject({ ok: false, status: 'no_provider', providerId: 'ghost' });
+
+    // Provider exists but has no baseUrl — also short-circuits.
+    const seed = makeCtx(configPath);
+    await handleProviderAdd(seed.ctx, FAKE_WS, { id: 'nobase', family: 'openai-compatible' });
+    const nb = makeCtx(configPath);
+    await handleProviderProbe(nb.ctx, FAKE_WS, 'nobase');
+    const r2 = nb.cap.sent.find((m) => m.type === 'provider.probe')?.payload as {
+      ok: boolean;
+      status: string;
+    };
+    expect(r2).toMatchObject({ ok: false, status: 'no_base_url' });
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,10 @@
       "types": "./dist/utils/expect-defined.d.ts",
       "import": "./dist/utils/expect-defined.js"
     },
+    "./utils/error": {
+      "types": "./dist/utils/error.d.ts",
+      "import": "./dist/utils/error.js"
+    },
     "./execution": {
       "types": "./dist/execution/index.d.ts",
       "import": "./dist/execution/index.js"

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     'src/defaults/index.ts',
     'src/utils/index.ts',
     'src/utils/expect-defined.ts',
+    'src/utils/error.ts',
     'src/execution/prompt-enhancer.ts',
     // Domain entry points (new as of 0.2.0)
     'src/execution/index.ts',

--- a/packages/webui/src/components/ChatInput.tsx
+++ b/packages/webui/src/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { expectDefined } from '@wrongstack/core';
+import { expectDefined, toErrorMessage } from '@wrongstack/core';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { cn } from '@/lib/utils';
 import { useChatStore, useSessionStore, useUIStore } from '@/stores';
@@ -13,7 +13,6 @@ import { Button } from './ui/button';
 import { type SlashCommandDef, SLASH_COMMANDS, SLASH_CATEGORY_ORDER, matchSlash, detectAtMention } from './ChatInput/slash-commands.js';
 import { autoFenceCode } from './ChatInput/code-detect.js';
 import { RefinePanel } from './RefinePanel.js';
-import { toErrorMessage } from '@wrongstack/core/utils';
 
 export function ChatInput({
   onOpenBreakdown,

--- a/packages/webui/src/lib/core-browser-shim.ts
+++ b/packages/webui/src/lib/core-browser-shim.ts
@@ -17,3 +17,4 @@
  */
 export { expectDefined } from '@wrongstack/core/utils/expect-defined';
 export { normalizedEqual } from '@wrongstack/core/execution/prompt-enhancer';
+export { toErrorMessage } from '@wrongstack/core/utils/error';

--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -62,6 +62,7 @@ import {
   resolveContextWindowPolicy,
   enhanceUserPrompt,
   recentTextTurns,
+  type TodoItem,
 } from '@wrongstack/core';
 import { ToolExecutor } from '@wrongstack/core/execution';
 import { decryptConfigSecrets, encryptConfigSecrets } from '@wrongstack/core/security';
@@ -1440,7 +1441,9 @@ export async function startWebUI(
       case 'collab.join':
       case 'collab.leave':
       case 'collab.annotate':
-      case 'collab.resolve': {
+      case 'collab.resolve':
+      case 'collab.request_pause':
+      case 'collab.resume': {
         collabHandler.handleMessage(ws, msg as { type: string; payload?: unknown | undefined });
         return;
       }
@@ -2355,6 +2358,100 @@ export async function startWebUI(
             type: 'plan.updated',
             payload: { plan },
           });
+        } catch (err) {
+          sendResult(ws, false, errMessage(err));
+        }
+        break;
+      }
+
+      case 'todo.update': {
+        // Update a single todo's status / activeForm in the live agent ctx.
+        // Mirrors the CLI webui-server's worklist handler so both surfaces
+        // can drive the todo list from the UI, not just read it.
+        const payload = (
+          msg as {
+            payload: {
+              id: string;
+              status?: TodoItem['status'] | undefined;
+              activeForm?: string | undefined;
+            };
+          }
+        ).payload;
+        const idx = context.todos.findIndex((t) => t.id === payload.id);
+        if (idx === -1) {
+          sendResult(ws, false, 'Todo not found');
+          break;
+        }
+        const next = [...context.todos];
+        const existing = expectDefined(next[idx]);
+        next[idx] = {
+          ...existing,
+          status: payload.status ?? existing.status,
+          activeForm: payload.activeForm !== undefined ? payload.activeForm : existing.activeForm,
+        };
+        context.state.replaceTodos(next);
+        sendResult(ws, true, `Todo "${existing.content}" updated`);
+        broadcast(clients, { type: 'todos.updated', payload: { todos: next } });
+        break;
+      }
+
+      case 'task.update': {
+        // Mutate the persisted task file at ctx.meta['task.path'].
+        const payload = (
+          msg as {
+            payload: {
+              id: string;
+              status: 'pending' | 'in_progress' | 'blocked' | 'failed' | 'review' | 'completed';
+            };
+          }
+        ).payload;
+        const taskPath = (context.meta as Record<string, unknown>)['task.path'];
+        if (typeof taskPath !== 'string' || !taskPath) {
+          sendResult(ws, false, 'Task storage not configured.');
+          break;
+        }
+        try {
+          const { mutateTasks } = await import('@wrongstack/core');
+          const file = await mutateTasks(taskPath, session.id, async (f) => {
+            const task = f.tasks.find((t) => t.id === payload.id);
+            if (!task) return f;
+            task.status = payload.status;
+            task.updatedAt = new Date().toISOString();
+            return f;
+          });
+          sendResult(ws, true, `Task status updated to "${payload.status}".`);
+          broadcast(clients, { type: 'tasks.updated', payload: { tasks: file.tasks } });
+        } catch (err) {
+          sendResult(ws, false, errMessage(err));
+        }
+        break;
+      }
+
+      case 'plan.item.update': {
+        // Mutate the persisted plan file at ctx.meta['plan.path'].
+        const payload = (
+          msg as { payload: { target: string; status: 'open' | 'in_progress' | 'done' } }
+        ).payload;
+        const planPath = (context.meta as Record<string, unknown>)['plan.path'];
+        if (typeof planPath !== 'string' || !planPath) {
+          sendResult(ws, false, 'Plan storage is not configured for this session.');
+          break;
+        }
+        try {
+          const { mutatePlan, setPlanItemStatus } = await import('@wrongstack/core');
+          let changed = false;
+          const plan = await mutatePlan(planPath, session.id, async (p) => {
+            const before = p.updatedAt;
+            const updated = setPlanItemStatus(p, payload.target, payload.status);
+            changed = updated.updatedAt !== before;
+            return updated;
+          });
+          if (!changed) {
+            sendResult(ws, false, `No plan item matched "${payload.target}".`);
+            break;
+          }
+          sendResult(ws, true, `Plan item status updated to "${payload.status}".`);
+          broadcast(clients, { type: 'plan.updated', payload: { plan } });
         } catch (err) {
           sendResult(ws, false, errMessage(err));
         }

--- a/packages/webui/vite.config.ts
+++ b/packages/webui/vite.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
         find: /^@wrongstack\/core\/execution\/prompt-enhancer$/,
         replacement: path.resolve(__dirname, '../core/src/execution/prompt-enhancer.ts'),
       },
+      {
+        find: /^@wrongstack\/core\/utils\/error$/,
+        replacement: path.resolve(__dirname, '../core/src/utils/error.ts'),
+      },
       // Browser-only: redirect the bare `@wrongstack/core` barrel (which drags
       // in Node built-ins) to a tiny browser-safe shim. Exact match only, so
       // subpath imports like `@wrongstack/core/storage` are left untouched.


### PR DESCRIPTION
## Summary

Closes a cluster of WebSocket protocol mismatches between the WebUI client and the **two** WebUI servers — the CLI-hosted `packages/cli/src/webui-server.ts` (run via `wstack`) and the standalone `packages/webui/src/server/index.ts` (`webui` binary). Symptoms ranged from a hard browser crash to `[WebUI] Unhandled message type` warnings and silently-broken Settings actions.

After this PR, **both servers handle 100% of the `WSClientMessage` union** (verified by diffing the types.ts union against each server's `case` set).

## Fixes

- **Browser `process is not defined`** — `ChatInput` imported `toErrorMessage` from the `@wrongstack/core/utils` barrel, which drags Node built-ins (`fs`, `path`, `process`, …) into the Vite bundle. Routed through the browser shim via a new narrow `@wrongstack/core/utils/error` subpath (new core export + tsup entry + vite alias).
- **CLI `git.info`** — added the handler (status-bar git widget). Also fixed two bugs while mirroring the standalone version: the deleted-count regex required a `+` prefix (always returned 0), and ahead/behind were swapped (`rev-list --left-right --count @{upstream}...HEAD` prints `behind\tahead`).
- **collab pause/resume** — client sends `collab.request_pause`/`collab.resume` but neither server routed them. CLI no-ops collab by design (added to its no-op group); standalone now routes them to the real `CollaborationWebSocketHandler` (which already implemented both).
- **Standalone `todo.update` / `task.update` / `plan.item.update`** — the CLI server had these; the standalone silently dropped them. Re-implemented inline using the standalone's own context primitives.
- **CLI `provider.clear_models` / `undo_clear` / `update` / `probe`** — model-allowlist editing + health probe. The CLI already imported `probeLocalLlm` but never used it; now wired. Mirrors the standalone `provider-handlers.ts`.

## Out of scope (reported, not fixed)

The standalone collab handler broadcasts `collab.event` (observer-mirror activity) and `collab.injection.granted`, but the client has no handler/UI for them — an incomplete-feature gap needing a UI surface, no error, and only via the standalone server (CLI no-ops collab entirely).

## Tests

Adds unit tests for the 4 new CLI provider handlers (update→clear→undo round-trip with on-disk assertions, unknown-provider errors, probe no-network branches).

- Full-repo typecheck ✓
- cli + webui build ✓
- 152 cli webui-server tests + 450 webui tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
