### PR TITLE
fix(build): make workspace build runner cross-platform

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -84,15 +84,24 @@ function topoSort(metas) {
 }
 
 function runBuild(pkgDir, script) {
-  const shell = process.env.ComSpec || 'cmd.exe';
+  // Cross-platform: cmd.exe on Windows (ComSpec), POSIX sh elsewhere.
+  // pnpm 11.5.2 + cmd.exe strips the script-shell config that lets `npm
+  // run`-style `; echo "EXIT=$?"` wrappers work, so on Windows we still
+  // shell out to cmd.exe /c which handles `&&` chained scripts correctly
+  // (e.g. `vite build && tsup`). On macOS/Linux we use the user's $SHELL
+  // (or /bin/sh fallback) with `-c`.
+  const isWin = process.platform === 'win32';
+  const shell = isWin ? process.env.ComSpec || 'cmd.exe' : process.env.SHELL || '/bin/sh';
+  const shellArgs = isWin ? ['/c', script] : ['-c', script];
   console.log(`\n> ${pkgDir} > ${script}`);
   // node_modules/.bin must be on PATH so tsup, tsc, etc. resolve when
-  // spawned via cmd.exe — the Node process inherits npm's path resolution
-  // but cmd.exe /c does not. Prepend both the root bin dir and the
-  // package-local bin dir (pnpm isolates bins per-package) to be safe.
+  // spawned via cmd.exe (or sh) — the Node process inherits npm's path
+  // resolution but the spawned shell does not. Prepend both the root bin
+  // dir and the package-local bin dir (pnpm isolates bins per-package) to
+  // be safe.
   const rootBin = join(root, 'node_modules', '.bin');
   const pkgBin = join(root, pkgDir, 'node_modules', '.bin');
-  const pathSep = process.platform === 'win32' ? ';' : ':';
+  const pathSep = isWin ? ';' : ':';
   const envPath = [rootBin, pkgBin, process.env.PATH || process.env.Path || ''].join(pathSep);
   const env = {
     ...process.env,
@@ -100,7 +109,7 @@ function runBuild(pkgDir, script) {
     Path: envPath,
     NODE_OPTIONS: '--max-old-space-size=4096',
   };
-  const result = spawnSync(shell, ['/c', script], {
+  const result = spawnSync(shell, shellArgs, {
     cwd: join(root, pkgDir),
     stdio: 'inherit',
     env,


### PR DESCRIPTION
## Summary

`scripts/build.mjs` hardcoded `cmd.exe` as the spawn shell, which does not exist on macOS or Linux. Running the AGENTS.md one-time `pnpm build` seed instruction on a non-Windows host fails with:

```
> packages/core > tsup

Build failed in packages/core (exit null)
```

`spawnSync('cmd.exe', ...)` returns `status: null` (ENOENT) on POSIX, so the script exits with that misleading message before doing any work.

## Change

Single-file fix to `scripts/build.mjs:runBuild()`:

- **Windows:** unchanged — `process.env.ComSpec || 'cmd.exe'` with `['/c', script]`. pnpm 11.5.2 + cmd.exe still needs `/c` because of the `; echo EXIT=$?` wrapper that cmd.exe handles as literal args (per the existing header comment).
- **POSIX (macOS/Linux):** `process.env.SHELL || '/bin/sh'` with `['-c', script]`.

Both branches preserve the existing PATH prepend (root `node_modules/.bin` + per-package bin) and `NODE_OPTIONS=--max-old-space-size=4096`. The only behavioural change is which shell binary is invoked; script-string handling, env, and cwd are identical.

## Verification

- [x] Clean `pnpm install` on macOS (Apple Silicon, Node 22).
- [x] `node scripts/build.mjs` runs to completion — all 15 workspace packages build (core → providers → tools → ... → cli → webui).
- [x] `pnpm run typecheck` clean across the workspace.
- [x] `pnpm exec biome check scripts/build.mjs` — no new violations in the touched region (the pre-existing `organizeImports` on line 16 is outside this diff and predates it).
- [x] Windows path untouched (no behavioural change for `process.platform === 'win32'`).

## Notes

- This is a prerequisite for any non-Windows contributor running the AGENTS.md "one-time `pnpm build` seed" step; without it the local dist/ never populates and the pre-commit typecheck gate (added in `c71d8237`) cannot run.
- Separate observation (not addressed here, to keep this PR surgical): `.githooks/pre-commit` is installed by `pnpm install` (postinstall runs `git config core.hooksPath .githooks`) but never marked executable, so Git silently ignores it on a fresh clone. Happy to follow up with a tiny `chmod +x` postinstall fix in a separate PR if useful.