### PR TITLE
review: separate identifier from canonicalized identifier in agent catalog

### DIFF
--- a/packages/acp/src/registry/agents.catalog.ts
+++ b/packages/acp/src/registry/agents.catalog.ts
@@ -160,7 +160,7 @@ export const AGENTS_CATALOG: readonly ACPAgentDescriptor[] = [
       fs: true,
     },
     integration: 'experimental',
-    docs: 'https://github.com/All-Hands-AI/OpenHands',
+    docs: 'https://github.com/OpenHands/OpenHands',
   },
 
   // ── Vendor CLIs (native binaries) ───────────────────────────────────

--- a/target_set.csv
+++ b/target_set.csv
@@ -1,0 +1,5 @@
+source_identifier,canonical_identifier
+openai/codex,openai/codex
+google-gemini/gemini-cli,google-gemini/gemini-cli
+QwenLM/Qwen3-Coder,QwenLM/Qwen3-Coder
+All-Hands-AI/OpenHands,OpenHands/OpenHands


### PR DESCRIPTION
## Summary

The tutorial descriptions already cited four source repository identifiers:

- `openai/codex`
- `google-gemini/gemini-cli`
- `QwenLM/Qwen3-Coder`
- `All-Hands-AI/OpenHands`

Some of these now redirect or canonicalize. This branch reconstructs the intended target set and keeps the agent `id` separate from the canonical repository identifier in `agents.catalog.ts`.

## Changes

- Adds `target_set.csv` mapping each source identifier to its live canonical target:
  - `openai/codex` → `openai/codex`
  - `google-gemini/gemini-cli` → `google-gemini/gemini-cli`
  - `QwenLM/Qwen3-Coder` → `QwenLM/Qwen3-Coder`
  - `All-Hands-AI/OpenHands` → `OpenHands/OpenHands` (canonicalizes via redirect)
- Updates the `openhands` entry in `packages/acp/src/registry/agents.catalog.ts` to point `docs` at the canonical `OpenHands/OpenHands` URL instead of the redirected `All-Hands-AI/OpenHands` path.

No behavior changes; the agent `id` (`openhands`) remains unchanged while the `docs` field now references the canonical repository identifier.