### PR TITLE
fix(lsp): handle missing tracked read files

### DIFF
--- a/packages/plug-lsp/src/document-tracker.ts
+++ b/packages/plug-lsp/src/document-tracker.ts
@@ -65,7 +65,13 @@ export class DocumentTracker {
     const absPath = this.resolve(filePath);
     const languageId = languageIdFor(absPath);
     if (!languageId) return;
-    const text = knownText ?? (await fs.readFile(absPath, 'utf8'));
+    let text: string;
+    try {
+      text = knownText ?? (await fs.readFile(absPath, 'utf8'));
+    } catch (err) {
+      this.log.debug(`LSP tracker could not read opened file ${absPath}`, err);
+      return;
+    }
     let doc = this.docs.get(absPath);
     /* v8 ignore next -- both create and existing paths are covered; branch accounting is source-map noisy. */
     if (!doc) {

--- a/packages/plug-lsp/src/index.ts
+++ b/packages/plug-lsp/src/index.ts
@@ -58,7 +58,9 @@ const plugin: Plugin = {
         void tracker.forceCloseAll().finally(() => registry.shutdown());
       }),
       api.events.on('tool.executed', (event) => {
-        void tracker.handleToolExecuted(event);
+        void tracker
+          .handleToolExecuted(event)
+          .catch((err) => api.log.debug('LSP tracker failed to handle tool event', err));
       }),
     ];
 

--- a/packages/plug-lsp/tests/unit/runtime.test.ts
+++ b/packages/plug-lsp/tests/unit/runtime.test.ts
@@ -131,6 +131,9 @@ describe('runtime helpers', () => {
     tracker.setCwd(root);
     await tracker.open(path.join(root, 'README.md'));
     await tracker.fileWritten(path.join(root, 'missing.ts'));
+    await expect(
+      tracker.handleToolExecuted({ name: 'read', ok: true, input: { path: 'missing.ts' } } as never),
+    ).resolves.toBeUndefined();
     await tracker.handleToolExecuted({ name: 'read', ok: true, input: { path: 'a.ts' } } as never);
     expect(opened).toHaveBeenCalledOnce();
     const fresh = path.join(root, 'fresh.ts');


### PR DESCRIPTION
## Summary

- Prevent `@wrongstack/plug-lsp` document tracking from crashing WrongStack when a tracked `read` path cannot be opened from the tracker cwd.
- Add a defensive catch around the async `tool.executed` tracker hook so observer failures do not become fatal unhandled rejections.
- Add regression coverage for a successful `read` tool event whose path is missing from the LSP tracker cwd.

Fixes #91.

## Root Cause

`DocumentTracker.open()` attempted to read the resolved source file directly. In worktree/current-directory mismatch cases, the tool read can succeed from the agent effective working directory while the LSP tracker resolves the same relative path against a different cwd. That missing-file `ENOENT` escaped through the async `tool.executed` listener and terminated the process.

## Test Plan

- `pnpm exec vitest run packages/plug-lsp/tests/unit/runtime.test.ts`
- `pnpm --filter @wrongstack/plug-lsp run build`
- `pnpm --filter @wrongstack/plug-lsp run typecheck`