### PR TITLE
refactor(webui): extract modeRoutes to mode-handlers.ts

### DIFF
--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -39,7 +39,6 @@ import {
   validateMailboxAgentsPayload,
   validateMailboxMessagesPayload,
   validateMailboxPurgePayload,
-  validateModeSwitchPayload,
   validateModelSwitchPayload,
   validatePrefsUpdatePayload,
   validatePlanTemplateUsePayload,
@@ -150,6 +149,7 @@ import { findFreePort } from './port-utils.js';
 import { openBrowser } from './open-browser.js';
 import { computeUsageCost, getCostRates } from './usage-cost.js';
 import { createProviderHandlers } from './provider-handlers.js';
+import { createModeHandlers } from './mode-handlers.js';
 import { handleProviderRoute, type ProviderRouteHandlers } from './provider-routes.js';
 import { handleSessionRoute, type SessionRouteHandlers } from './session-routes.js';
 import { handleProjectRoute, type ProjectRouteHandlers } from './project-routes.js';
@@ -2947,76 +2947,21 @@ export async function startWebUI(
     },
   };
 
-  modeRoutes = {
-    listModes: async (ws) => {
-      try {
-        const modes = await modeStore.listModes();
-        const active = await modeStore.getActiveMode();
-        send(ws, {
-          type: 'modes.list',
-          payload: {
-            modes: modes.map((m) => ({
-              id: m.id,
-              name: m.name,
-              description: m.description,
-              isActive: m.id === (active?.id ?? 'default'),
-            })),
-            activeId: active?.id ?? 'default',
-          },
-        });
-      } catch (err) {
-        send(ws, {
-          type: 'modes.list',
-          payload: {
-            modes: [],
-            activeId: 'default',
-            error: errMessage(err),
-          },
-        });
-      }
+  modeRoutes = createModeHandlers({
+    modeStore,
+    memoryStore,
+    skillLoader,
+    modelCapabilities,
+    context,
+    toolRegistry,
+    config,
+    projectRoot,
+    clients,
+    setModeId: (id) => {
+      modeId = id;
     },
-    switchMode: async (ws, msg) => {
-      const parsed = validateModeSwitchPayload(msg.payload);
-      if (!parsed.ok) {
-        sendResult(ws, false, parsed.message);
-        return;
-      }
-      const { id } = parsed.value;
-      try {
-        if (id === 'default') {
-          await modeStore.setActiveMode(null);
-        } else {
-          const found = await modeStore.getMode(id);
-          if (!found) throw new Error(`Unknown mode "${id}"`);
-          await modeStore.setActiveMode(id);
-        }
-        modeId = id;
-        const modePrompt = id === 'default' ? '' : ((await modeStore.getMode(id))?.prompt ?? '');
-        const freshBuilder = new DefaultSystemPromptBuilder({
-          memoryStore,
-          skillLoader,
-          modeStore,
-          modeId: id,
-          modePrompt,
-          modelCapabilities,
-        });
-        context.systemPrompt = await freshBuilder.build({
-          cwd: projectRoot,
-          projectRoot,
-          tools: toolRegistry.list(),
-          provider: config.provider,
-          model: config.model,
-        });
-        sendResult(ws, true, `Switched to mode "${id}"`);
-        broadcast(clients, {
-          type: 'session.start',
-          payload: { ...(await sessionStartPayload()) },
-        });
-      } catch (err) {
-        sendResult(ws, false, errMessage(err));
-      }
-    },
-  };
+    sessionStartPayload,
+  });
 
   shellGitRoutes = {
     gitInfo: async (ws) => {

--- a/packages/webui/src/server/mode-handlers.ts
+++ b/packages/webui/src/server/mode-handlers.ts
@@ -1,0 +1,129 @@
+/**
+ * Mode route handlers — extracted from the startWebUI closure in index.ts.
+ * Mirrors createProviderHandlers: a factory that closes the handler bodies over
+ * an explicit context object instead of the giant startWebUI scope. The one
+ * piece of outer mutable state (the `modeId` let) is threaded in as a setter so
+ * the factory stays a pure function of its context.
+ */
+import type { WebSocket } from 'ws';
+import {
+  type Context,
+  DefaultSystemPromptBuilder,
+  type DefaultMemoryStore,
+  type DefaultModeStore,
+  type SkillLoader,
+  type ToolRegistry,
+} from '@wrongstack/core';
+import type { ConnectedClient } from './types.js';
+import type { ModeRouteHandlers } from './mode-routes.js';
+import { broadcast, errMessage, send, sendResult } from './ws-utils.js';
+import { validateModeSwitchPayload } from './ws-payload-validation.js';
+
+/** The rich payload startWebUI's sessionStartPayload() resolves to. Matches the
+ *  WSSessionStart wire shape; broadcast() accepts it for a 'session.start' msg. */
+type SessionStartPayload = {
+  sessionId: string;
+  model: string;
+  provider: string;
+  maxContext: number;
+  inputCost: number;
+  outputCost: number;
+  cacheReadCost: number;
+  projectName: string;
+  projectRoot: string;
+  cwd: string;
+  mode: string;
+  contextMode: string;
+};
+type ModelCapabilities = NonNullable<
+  ConstructorParameters<typeof DefaultSystemPromptBuilder>[0]
+>['modelCapabilities'];
+
+export interface ModeHandlersContext {
+  modeStore: DefaultModeStore;
+  memoryStore: DefaultMemoryStore;
+  skillLoader: SkillLoader | undefined;
+  modelCapabilities: ModelCapabilities;
+  context: Context;
+  toolRegistry: ToolRegistry;
+  config: { provider: string; model: string };
+  projectRoot: string;
+  clients: Map<WebSocket, ConnectedClient>;
+  /** Update the outer `modeId` binding on a successful switch. */
+  setModeId: (id: string) => void;
+  /** Rebuilds the rich session.start payload broadcast after a mode switch. */
+  sessionStartPayload: () => Promise<SessionStartPayload>;
+}
+
+export function createModeHandlers(ctx: ModeHandlersContext): ModeRouteHandlers {
+  return {
+    listModes: async (ws) => {
+      try {
+        const modes = await ctx.modeStore.listModes();
+        const active = await ctx.modeStore.getActiveMode();
+        send(ws, {
+          type: 'modes.list',
+          payload: {
+            modes: modes.map((m) => ({
+              id: m.id,
+              name: m.name,
+              description: m.description,
+              isActive: m.id === (active?.id ?? 'default'),
+            })),
+            activeId: active?.id ?? 'default',
+          },
+        });
+      } catch (err) {
+        send(ws, {
+          type: 'modes.list',
+          payload: {
+            modes: [],
+            activeId: 'default',
+            error: errMessage(err),
+          },
+        });
+      }
+    },
+    switchMode: async (ws, msg) => {
+      const parsed = validateModeSwitchPayload(msg.payload);
+      if (!parsed.ok) {
+        sendResult(ws, false, parsed.message);
+        return;
+      }
+      const { id } = parsed.value;
+      try {
+        if (id === 'default') {
+          await ctx.modeStore.setActiveMode(null);
+        } else {
+          const found = await ctx.modeStore.getMode(id);
+          if (!found) throw new Error(`Unknown mode "${id}"`);
+          await ctx.modeStore.setActiveMode(id);
+        }
+        ctx.setModeId(id);
+        const modePrompt = id === 'default' ? '' : ((await ctx.modeStore.getMode(id))?.prompt ?? '');
+        const freshBuilder = new DefaultSystemPromptBuilder({
+          memoryStore: ctx.memoryStore,
+          skillLoader: ctx.skillLoader,
+          modeStore: ctx.modeStore,
+          modeId: id,
+          modePrompt,
+          modelCapabilities: ctx.modelCapabilities,
+        });
+        ctx.context.systemPrompt = await freshBuilder.build({
+          cwd: ctx.projectRoot,
+          projectRoot: ctx.projectRoot,
+          tools: ctx.toolRegistry.list(),
+          provider: ctx.config.provider,
+          model: ctx.config.model,
+        });
+        sendResult(ws, true, `Switched to mode "${id}"`);
+        broadcast(ctx.clients, {
+          type: 'session.start',
+          payload: { ...(await ctx.sessionStartPayload()) },
+        });
+      } catch (err) {
+        sendResult(ws, false, errMessage(err));
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Second slice of the `server/index.ts` split. Extracts the inline `modeRoutes` object literal into a `createModeHandlers(ctx)` factory in `mode-handlers.ts`, mirroring the existing `createProviderHandlers` pattern.

The one piece of outer mutable state the handlers touched (the `modeId` let) is threaded in as a `setModeId` setter, so the factory stays a pure function of its context.

## Why
- Continues shrinking `server/index.ts` (3215 → 3160).
- Establishes the setter-injected context-object pattern for the remaining route-object builders.

## Testing
Verbatim lift (same logic, `ctx.*` references); behaviour unchanged. Full webui suite green (**1596 passing**), typecheck + build clean.

## Notes
- Net diff: `index.ts` + new `mode-handlers.ts`.
- Remaining route builders (`projectRoutes`, `sessionRoutes`) are the heavier pieces — `selectProject` alone mutates 6 outer `let` bindings across the session-switch path — and will follow as separate verified slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)