### PR TITLE
fix(acp): canonical OpenHands docs URL (supersedes #88, no stray CSV)

### DIFF
--- a/packages/acp/src/registry/agents.catalog.ts
+++ b/packages/acp/src/registry/agents.catalog.ts
@@ -160,7 +160,8 @@ export const AGENTS_CATALOG: readonly ACPAgentDescriptor[] = [
       fs: true,
     },
     integration: 'experimental',
-    docs: 'https://github.com/All-Hands-AI/OpenHands',
+    // Canonical repo URL — the org renamed; All-Hands-AI/OpenHands 301-redirects here.
+    docs: 'https://github.com/OpenHands/OpenHands',
   },
 
   // ── Vendor CLIs (native binaries) ───────────────────────────────────


### PR DESCRIPTION
Points the OpenHands agent-catalog `docs` field at the canonical `OpenHands/OpenHands` URL. The org renamed; `All-Hands-AI/OpenHands` now **301-redirects** to it (verified: `301 → 200`).

This applies the single valid change from #88 while **excluding** that PR's `target_set.csv`, which is an eval-harness artifact that doesn't belong in the repo root. Credit to @bugmaker00 for spotting the redirect.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)