### PR TITLE
fix(lsp): guard tool.executed listener against async tracker failures (#91)

### DIFF
--- a/packages/plug-lsp/src/index.ts
+++ b/packages/plug-lsp/src/index.ts
@@ -58,7 +58,9 @@ const plugin: Plugin = {
         void tracker.forceCloseAll().finally(() => registry.shutdown());
       }),
       api.events.on('tool.executed', (event) => {
-        void tracker.handleToolExecuted(event);
+        void tracker
+          .handleToolExecuted(event)
+          .catch((err) => api.log.debug('LSP tracker failed to handle tool event', err));
       }),
     ];
 

--- a/packages/plug-lsp/tests/unit/runtime.test.ts
+++ b/packages/plug-lsp/tests/unit/runtime.test.ts
@@ -131,6 +131,11 @@ describe('runtime helpers', () => {
     tracker.setCwd(root);
     await tracker.open(path.join(root, 'README.md'));
     await tracker.fileWritten(path.join(root, 'missing.ts'));
+    // #91: a tracked read whose path is missing from the tracker cwd must not
+    // crash the process — handleToolExecuted resolves cleanly instead.
+    await expect(
+      tracker.handleToolExecuted({ name: 'read', ok: true, input: { path: 'missing.ts' } } as never),
+    ).resolves.toBeUndefined();
     await tracker.handleToolExecuted({ name: 'read', ok: true, input: { path: 'a.ts' } } as never);
     expect(opened).toHaveBeenCalledOnce();
     const fresh = path.join(root, 'fresh.ts');


### PR DESCRIPTION
## Problem (#91)
`@wrongstack/plug-lsp` could crash the whole process when a tracked file read fired the document tracker against a path missing from the tracker cwd (worktree / cwd mismatch).

## What's already on main
The primary crash — `DocumentTracker.open()`'s unguarded `fs.readFile` — is **already fixed on current main**: `open()` wraps the read in try/catch and returns early on failure. That landed via an unrelated refactor, which is also why #92 now conflicts.

## Remaining gap (this PR)
The plugin's `tool.executed` listener still fires `void tracker.handleToolExecuted(event)` with no rejection handler — any *other* unexpected throw inside the async hook becomes a fatal unhandled rejection. This wraps it in a `.catch()` that logs at debug.

Adds a regression assertion that a tracked read of a missing path resolves cleanly.

## Tests
`pnpm exec vitest run packages/plug-lsp/tests/unit/runtime.test.ts` → 7/7. Typecheck clean across all packages.

Supersedes #92 (keeps only the still-missing listener guard; drops its already-landed document-tracker hunk). Credit to @Zasetsu for the original report/PR.

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)