### PR TITLE
feat(providers): propagate minimal/xhigh/max reasoning effort to compatible servers (#14)

### DIFF
--- a/packages/providers/src/openai-compatible.ts
+++ b/packages/providers/src/openai-compatible.ts
@@ -1,5 +1,5 @@
 import type { Request } from '@wrongstack/core';
-import type { Capabilities } from '@wrongstack/core';
+import type { Capabilities, ReasoningEffort } from '@wrongstack/core';
 import { capabilitiesForFamily } from './family-capabilities.js';
 import { OpenAIProvider } from './openai.js';
 import type { WireAdapterStreamOptions } from './wire-adapter.js';
@@ -103,6 +103,11 @@ export class OpenAICompatibleProvider extends OpenAIProvider {
   protected override buildBody(req: Request): Record<string, unknown> {
     const body = super.buildBody(req);
     applyThinkingParams(body, req, this.opts.quirks?.thinkingParam);
+    // #14: the base builder only emits `reasoning_effort` for the values real
+    // OpenAI accepts (none/low/medium/high); the broader internal levels —
+    // `minimal`, `xhigh`, `max` — were silently dropped, so picking `max` on a
+    // generic compatible model (MiniMax, DeepSeek, …) sent no effort at all.
+    applyGenericReasoningEffort(body, req, this.opts.quirks?.thinkingParam);
     // Many OpenAI-compatible servers (Together, Fireworks, DeepSeek, etc.)
     // accept the `top_k` parameter even though real OpenAI rejects it.
     if (req.topK !== undefined) body['top_k'] = req.topK;
@@ -151,5 +156,44 @@ function mapZaiReasoningEffort(effort: NonNullable<Request['reasoning']>['effort
       return 'max';
     default:
       return effort;
+  }
+}
+
+/**
+ * Fill in the reasoning effort levels the base OpenAI body builder drops (#14).
+ * It emits `reasoning_effort` only for none/low/medium/high; `minimal`, `xhigh`,
+ * and `max` fall through and never reach the wire. Map those onto the accepted
+ * `low | high` extremes and set them — but never override a value the base or a
+ * more specific quirk (`zai-glm`) already wrote, and never when reasoning was
+ * explicitly disabled.
+ */
+function applyGenericReasoningEffort(
+  body: Record<string, unknown>,
+  req: Request,
+  mode: CompatibilityQuirks['thinkingParam'],
+): void {
+  if (mode === 'zai-glm') return; // already mapped effort → reasoning_effort
+  const effort = req.reasoning?.effort;
+  if (!effort) return;
+  if (req.reasoning?.enabled === false) return;
+  if (body['reasoning_effort'] !== undefined) return;
+  const mapped = mapGenericReasoningEffort(effort);
+  if (mapped) body['reasoning_effort'] = mapped;
+}
+
+/**
+ * Collapse the internal levels the base builder rejects onto the values OpenAI's
+ * `reasoning_effort` accepts. none/low/medium/high are already handled upstream,
+ * so they return undefined here (no double-write).
+ */
+function mapGenericReasoningEffort(effort: ReasoningEffort): 'low' | 'high' | undefined {
+  switch (effort) {
+    case 'minimal':
+      return 'low';
+    case 'xhigh':
+    case 'max':
+      return 'high';
+    default:
+      return undefined;
   }
 }

--- a/packages/providers/tests/openai-compatible.test.ts
+++ b/packages/providers/tests/openai-compatible.test.ts
@@ -150,6 +150,61 @@ describe('OpenAICompatibleProvider', () => {
     expect(captured?.['thinking']).toBeUndefined();
   });
 
+  it('maps the effort levels the base builder drops onto reasoning_effort (#14)', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const spy = vi.fn(async (_url: unknown, init: { body?: string } = {}) => {
+      captured = JSON.parse(init.body ?? '{}');
+      return { ok: true, status: 200, json: async () => ({ model: 'm', choices: [], usage: {} }), text: async () => '' };
+    }) as never as typeof fetch;
+    const p = new OpenAICompatibleProvider({
+      id: 'deepseek',
+      apiKey: 'k',
+      baseUrl: 'https://api.deepseek.com/v1',
+      fetchImpl: spy,
+    });
+    // `max` is outside OpenAI's accepted set, so the base builder dropped it
+    // entirely before this fix; it now collapses onto `high`.
+    await p.complete(
+      { model: 'm', messages: [{ role: 'user', content: 'hi' }], maxTokens: 1, reasoning: { effort: 'max' } },
+      { signal: new AbortController().signal },
+    );
+    expect(captured?.['reasoning_effort']).toBe('high');
+
+    // `minimal` collapses onto `low`.
+    await p.complete(
+      { model: 'm', messages: [{ role: 'user', content: 'hi' }], maxTokens: 1, reasoning: { effort: 'minimal' } },
+      { signal: new AbortController().signal },
+    );
+    expect(captured?.['reasoning_effort']).toBe('low');
+  });
+
+  it('leaves base-handled efforts untouched and skips when reasoning is disabled (#14)', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const spy = vi.fn(async (_url: unknown, init: { body?: string } = {}) => {
+      captured = JSON.parse(init.body ?? '{}');
+      return { ok: true, status: 200, json: async () => ({ model: 'm', choices: [], usage: {} }), text: async () => '' };
+    }) as never as typeof fetch;
+    const p = new OpenAICompatibleProvider({
+      id: 'deepseek',
+      apiKey: 'k',
+      baseUrl: 'https://api.deepseek.com/v1',
+      fetchImpl: spy,
+    });
+    // medium is in OpenAI's set — emitted verbatim by the base builder, not remapped.
+    await p.complete(
+      { model: 'm', messages: [{ role: 'user', content: 'hi' }], maxTokens: 1, reasoning: { effort: 'medium' } },
+      { signal: new AbortController().signal },
+    );
+    expect(captured?.['reasoning_effort']).toBe('medium');
+
+    // An out-of-set effort with reasoning explicitly disabled is not injected.
+    await p.complete(
+      { model: 'm', messages: [{ role: 'user', content: 'hi' }], maxTokens: 1, reasoning: { enabled: false, effort: 'max' } },
+      { signal: new AbortController().signal },
+    );
+    expect(captured?.['reasoning_effort']).toBeUndefined();
+  });
+
   it('works without custom headers', async () => {
     const spy = mockFetchSpy();
     const p = new OpenAICompatibleProvider({


### PR DESCRIPTION
## Problem (#14)
A user can set reasoning effort via `/settings reasoning-effort <level>`, but on generic OpenAI-compatible providers (MiniMax, DeepSeek, OpenRouter, …) some levels never reached the wire.

## What already works on main
The recent #100 fix (commit `057bd04d`) added `reasoning_effort` to the base OpenAI body builder — but only for the values **real OpenAI accepts**: `none/low/medium/high` (guarded by `isOpenAIEffort`). So those four already propagate to compatible servers today.

## Remaining gap (this PR)
The three broader WrongStack-internal levels — `minimal`, `xhigh`, `max` — fall outside that set and were silently dropped. Picking `max` on a generic compatible model sent **no** effort at all.

`OpenAICompatibleProvider.buildBody` now fills them, mapped onto OpenAI's accepted scale:
- `minimal → low`
- `xhigh | max → high`

It is strictly additive: it never overrides a value the base builder or the `zai-glm` quirk already wrote (`reasoning_effort === undefined` guard), and it respects an explicit `reasoning.enabled === false`. No change to OpenAI / Anthropic / Google / codex providers.

## Tests
`pnpm exec vitest run packages/providers` → 369/369. New cases cover the propagated levels, base-handled passthrough (`medium` verbatim), and the disabled-reasoning skip. Typecheck clean across all packages.

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)