### PR TITLE
fix(tui): don't present a steering redirect as a queued backlog item (#87)

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -5925,10 +5925,19 @@ export function App({
       if (autonomyLive === 'auto' && nextStepsAutoSubmitTimerRef.current != null) {
         switchAutonomy?.('off');
       }
-      dispatch({
-        type: 'addEntry',
-        entry: { kind: 'user', text: displayText, queued: true, pasteContent },
-      });
+      // A steering redirect is NOT a backlog item (#87). The Esc-interrupt
+      // already cleared the queue, so this becomes queue[0] and the drainer
+      // runs it the instant the aborting iteration settles — echoing it then as
+      // a clean `↯`-marked user entry (see the drain after runBlocks' finally).
+      // Adding a greyed "queued" entry here would both mislead (it reads as
+      // backlog, not the next thing to run) and double up with that drain echo.
+      // So when steering, enqueue silently and let the drainer surface it.
+      if (!steering) {
+        dispatch({
+          type: 'addEntry',
+          entry: { kind: 'user', text: displayText, queued: true, pasteContent },
+        });
+      }
       dispatch({ type: 'enqueue', item: { displayText, blocks } });
       return;
     }


### PR DESCRIPTION
## Problem (#87)
After `Esc → y` interrupts a run, you type a new direction. If you submit it while the aborting iteration is still settling (`status === 'aborting'` — e.g. during the up-to-1.5s fleet-termination cap), the submit handler's busy branch keys only off `status !== 'idle'` and adds the redirect as a greyed **`queued: true`** entry — as if it were backlog.

But the Esc-interrupt already **cleared the queue**, so this redirect is `queue[0]`, and the drainer runs it the instant the abort settles — echoing it again as a clean `↯`-marked user entry. Net effect: the redirect appears **twice** (once misleadingly "queued", once for real), and reads as a backlog item rather than the next thing to run.

## Fix
In the busy branch, skip the `queued` presentation entry **when steering**: enqueue the blocks silently and let the drainer surface the single clean `↯` entry it already emits. Non-steering busy-time queuing is unchanged.

```diff
   if (autonomyLive === 'auto' && nextStepsAutoSubmitTimerRef.current != null) {
     switchAutonomy?.('off');
   }
-  dispatch({ type: 'addEntry', entry: { kind: 'user', text: displayText, queued: true, pasteContent } });
+  if (!steering) {
+    dispatch({ type: 'addEntry', entry: { kind: 'user', text: displayText, queued: true, pasteContent } });
+  }
   dispatch({ type: 'enqueue', item: { displayText, blocks } });
   return;
```

## Validation
- `tui` typecheck clean; full-workspace typecheck clean (pre-commit gate).
- `reducer.test.ts` + `queue-slash.test.ts` → 66/66.

⚠️ **Needs an interactive confirm before merge.** This lives in the abort/steer/queue state machine in `app.tsx`, which has no end-to-end unit coverage. The logic and types check out, but the exact `aborting`→drain timing is best eyeballed live: trigger a long run, `Esc → y`, immediately type a redirect, and confirm it shows once (clean `↯`) and runs next. Leaving this PR open for that.

Refs #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)