### PR TITLE
fix(tools): guard killWin32Tree against async spawn 'error' crash (#99)

### DIFF
--- a/packages/tools/src/process-registry.ts
+++ b/packages/tools/src/process-registry.ts
@@ -121,10 +121,17 @@ const DEFAULT_GRACE_MS = 2000;
  */
 export function killWin32Tree(pid: number): boolean {
   try {
-    spawn('taskkill', ['/pid', String(pid), '/T', '/F'], {
+    const child = spawn('taskkill', ['/pid', String(pid), '/T', '/F'], {
       stdio: 'ignore',
       windowsHide: true,
-    }).unref();
+    });
+    // spawn() reports a failure to launch (e.g. taskkill not on PATH, blocked by
+    // security software) via an ASYNC 'error' event — the surrounding try/catch
+    // only traps synchronous throws. Without a listener that event is unhandled
+    // and crashes the whole process. Swallow it: this is best-effort tree-kill
+    // and the registry still has the direct child.kill() fallback.
+    child.on('error', () => {});
+    child.unref();
     return true;
   } catch {
     return false;

--- a/packages/tools/tests/process-registry-killtree.test.ts
+++ b/packages/tools/tests/process-registry-killtree.test.ts
@@ -1,0 +1,57 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Mock child_process so we can drive spawn()'s async 'error' event — the failure
+// mode that previously crashed the process (#99 class: an unhandled child
+// 'error' event terminates the runtime).
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, spawn: spawnMock };
+});
+
+const { killWin32Tree } = await import('../src/process-registry.js');
+
+/** A spawn() stand-in that emits 'error' asynchronously, like a missing binary. */
+function erroringChild(): EventEmitter & { unref: () => unknown } {
+  const c = new EventEmitter() as EventEmitter & { unref: () => unknown };
+  c.unref = vi.fn();
+  // Defer so the listener killWin32Tree attaches is in place first.
+  queueMicrotask(() => c.emit('error', new Error('spawn taskkill ENOENT')));
+  return c;
+}
+
+describe('killWin32Tree async-error safety (#99)', () => {
+  afterEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it('swallows an async spawn error instead of crashing', async () => {
+    const child = erroringChild();
+    spawnMock.mockReturnValue(child);
+
+    // Track whether the unhandled 'error' would have escaped to the process.
+    let escaped: unknown;
+    const onUnhandled = (err: unknown) => {
+      escaped = err;
+    };
+    process.once('uncaughtException', onUnhandled);
+    try {
+      expect(killWin32Tree(1234)).toBe(true);
+      // Let the deferred 'error' fire; it must be absorbed by the listener.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(escaped).toBeUndefined();
+      expect(child.listenerCount('error')).toBeGreaterThan(0);
+      expect(child.unref).toHaveBeenCalled();
+    } finally {
+      process.removeListener('uncaughtException', onUnhandled);
+    }
+  });
+
+  it('returns false when spawn throws synchronously', () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error('sync spawn failure');
+    });
+    expect(killWin32Tree(1234)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Context — #99 audit
Issue #99 reports an AbortError / TimeoutError crash from child-process execution. I swept **every** `child_process` spawn across all packages (tools / cli / core / mcp / acp / webui / plug-lsp) that passes a `signal`, and confirmed each one already attaches a synchronous `child.on('error')`. So the **reported** signal/timeout crash path is **not reproducible on current main** — consistent with the earlier triage. That part still needs a reporter repro (version + what was running).

## What the sweep found
One genuinely unguarded spawn, in a different-but-related class: `killWin32Tree` — the win32 `taskkill /T` tree-kill helper (part of the orphan-grandchild OOM fix). It wrapped its spawn in `try/catch` only:

```ts
try { spawn('taskkill', …).unref(); return true; } catch { return false; }
```

`spawn()` reports a *launch* failure (binary not on PATH, blocked by security software) via an **async** `'error'` event. `try/catch` traps only synchronous throws, and there's no global `uncaughtException` net in the CLI boot path — so that event would crash the whole process.

## Fix
Attach a no-op `'error'` listener before `unref()`. Tree-kill is best-effort and the registry retains its direct `child.kill()` fallback, so swallowing is correct.

## Tests
New `process-registry-killtree.test.ts` mocks `child_process` (partial, via `importOriginal`), drives the async `'error'`, and asserts it's absorbed (no `uncaughtException`) plus the synchronous-throw → `false` path. Full `tools` suite: 1149/1149. Typecheck clean across all packages.

Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)