### PR TITLE
refactor(webui): extract process.* handlers from server/index.ts (#31)

### DIFF
--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -41,7 +41,6 @@ import {
   validateModelSwitchPayload,
   validatePrefsUpdatePayload,
   validatePlanTemplateUsePayload,
-  validateProcessKillPayload,
   validateShellOpenPayload,
   validateGitDiffPayload,
   validateAutonomySwitchPayload,
@@ -158,6 +157,11 @@ import { send, broadcast, sendResult, errMessage, generateAuthToken } from './ws
 import { createEternalSubscription } from './eternal-iteration-broadcast.js';
 import { handleShellOpen, type ShellOpenRequest, type ShellOpenResult } from './shell-open.js';
 import { handleGitChanges, handleGitDiff, handleGitInfo } from './git-handlers.js';
+import {
+  handleProcessKill,
+  handleProcessKillAll,
+  handleProcessList,
+} from './process-handlers.js';
 // Re-export types — shared message shapes and options used by both the
 // standalone server and the CLI's `--webui` embedded mode.
 export type { WebUIOptions, BackendServices } from './types.js';
@@ -1981,59 +1985,17 @@ export async function startWebUI(
       }
 
       case 'process.list': {
-        // Return tracked process list from the process registry.
-        try {
-          const { getProcessRegistry } = await import('@wrongstack/tools');
-          const procs = getProcessRegistry().list();
-          send(ws, {
-            type: 'process.list',
-            payload: {
-              processes: procs.map((p) => ({
-                pid: p.pid,
-                command: p.command,
-                tool: p.name,
-                startedAt: p.startedAt,
-                status: p.killed ? ('killed' as const) : ('running' as const),
-                protected: p.protected,
-              })),
-            },
-          });
-        } catch {
-          send(ws, { type: 'process.list', payload: { processes: [] } });
-        }
+        await handleProcessList(ws);
         break;
       }
 
       case 'process.kill': {
-        const parsed = validateProcessKillPayload(msg.payload);
-        if (!parsed.ok) {
-          sendResult(ws, false, parsed.message);
-          break;
-        }
-        const { pid } = parsed.value;
-        try {
-          const { getProcessRegistry } = await import('@wrongstack/tools');
-          const proc = getProcessRegistry().get(pid);
-          if (proc?.protected) {
-            sendResult(ws, false, `Cannot kill protected process (PID ${pid})`);
-            break;
-          }
-          getProcessRegistry().kill(pid);
-          sendResult(ws, true, `Killed PID ${pid}`);
-        } catch (err) {
-          sendResult(ws, false, errMessage(err));
-        }
+        await handleProcessKill(ws, msg.payload);
         break;
       }
 
       case 'process.killAll': {
-        try {
-          const { getProcessRegistry } = await import('@wrongstack/tools');
-          getProcessRegistry().killAll();
-          sendResult(ws, true, 'All processes killed');
-        } catch (err) {
-          sendResult(ws, false, errMessage(err));
-        }
+        await handleProcessKillAll(ws);
         break;
       }
 

--- a/packages/webui/src/server/process-handlers.ts
+++ b/packages/webui/src/server/process-handlers.ts
@@ -1,0 +1,72 @@
+/**
+ * Process-registry WebSocket handlers for the WebUI server, extracted from the
+ * `handleMessage` switch in `index.ts` as part of splitting that file (#31).
+ *
+ *   case 'process.list':    return handleProcessList(ws);
+ *   case 'process.kill':    return handleProcessKill(ws, msg.payload);
+ *   case 'process.killAll': return handleProcessKillAll(ws);
+ *
+ * All three reach the registry via a dynamic `@wrongstack/tools` import so the
+ * server starts even when that package is unavailable, and never throw — a
+ * failure is reported back over the socket instead.
+ */
+
+import type { WebSocket } from 'ws';
+import { errMessage, send, sendResult } from './ws-utils.js';
+import { validateProcessKillPayload } from './ws-payload-validation.js';
+
+/** Broadcast the tracked-process list; an empty list on any registry failure. */
+export async function handleProcessList(ws: WebSocket): Promise<void> {
+  try {
+    const { getProcessRegistry } = await import('@wrongstack/tools');
+    const procs = getProcessRegistry().list();
+    send(ws, {
+      type: 'process.list',
+      payload: {
+        processes: procs.map((p) => ({
+          pid: p.pid,
+          command: p.command,
+          tool: p.name,
+          startedAt: p.startedAt,
+          status: p.killed ? ('killed' as const) : ('running' as const),
+          protected: p.protected,
+        })),
+      },
+    });
+  } catch {
+    send(ws, { type: 'process.list', payload: { processes: [] } });
+  }
+}
+
+/** Kill one tracked PID. Rejects invalid payloads and protected processes. */
+export async function handleProcessKill(ws: WebSocket, payload: unknown): Promise<void> {
+  const parsed = validateProcessKillPayload(payload);
+  if (!parsed.ok) {
+    sendResult(ws, false, parsed.message);
+    return;
+  }
+  const { pid } = parsed.value;
+  try {
+    const { getProcessRegistry } = await import('@wrongstack/tools');
+    const proc = getProcessRegistry().get(pid);
+    if (proc?.protected) {
+      sendResult(ws, false, `Cannot kill protected process (PID ${pid})`);
+      return;
+    }
+    getProcessRegistry().kill(pid);
+    sendResult(ws, true, `Killed PID ${pid}`);
+  } catch (err) {
+    sendResult(ws, false, errMessage(err));
+  }
+}
+
+/** Kill every tracked process. */
+export async function handleProcessKillAll(ws: WebSocket): Promise<void> {
+  try {
+    const { getProcessRegistry } = await import('@wrongstack/tools');
+    getProcessRegistry().killAll();
+    sendResult(ws, true, 'All processes killed');
+  } catch (err) {
+    sendResult(ws, false, errMessage(err));
+  }
+}

--- a/packages/webui/tests/server/process-handlers.test.ts
+++ b/packages/webui/tests/server/process-handlers.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WebSocket } from 'ws';
+
+// Mock the registry the handlers reach via dynamic `@wrongstack/tools` import.
+const registry = vi.hoisted(() => ({
+  list: vi.fn(),
+  get: vi.fn(),
+  kill: vi.fn(),
+  killAll: vi.fn(),
+}));
+vi.mock('@wrongstack/tools', () => ({ getProcessRegistry: () => registry }));
+
+const { handleProcessKill, handleProcessKillAll, handleProcessList } = await import(
+  '../../src/server/process-handlers.js'
+);
+
+/** Minimal ws mock that records parsed JSON sends. */
+function createMockWs() {
+  const ws = {
+    readyState: 1,
+    sent: [] as Array<{ type: string; payload: Record<string, unknown> }>,
+    send(data: string) {
+      this.sent.push(JSON.parse(data));
+    },
+  } as never as WebSocket & { sent: Array<{ type: string; payload: Record<string, unknown> }> };
+  return ws;
+}
+
+describe('process WebSocket handlers', () => {
+  afterEach(() => {
+    registry.list.mockReset();
+    registry.get.mockReset();
+    registry.kill.mockReset();
+    registry.killAll.mockReset();
+  });
+
+  describe('handleProcessList', () => {
+    it('projects the registry list into the wire shape', async () => {
+      registry.list.mockReturnValue([
+        { pid: 10, command: 'bash -c x', name: 'bash', startedAt: 5, killed: false, protected: true },
+        { pid: 11, command: 'rg foo', name: 'grep', startedAt: 6, killed: true, protected: false },
+      ]);
+      const ws = createMockWs();
+      await handleProcessList(ws);
+      expect(ws.sent).toHaveLength(1);
+      expect(ws.sent[0]).toEqual({
+        type: 'process.list',
+        payload: {
+          processes: [
+            { pid: 10, command: 'bash -c x', tool: 'bash', startedAt: 5, status: 'running', protected: true },
+            { pid: 11, command: 'rg foo', tool: 'grep', startedAt: 6, status: 'killed', protected: false },
+          ],
+        },
+      });
+    });
+
+    it('sends an empty list if the registry throws', async () => {
+      registry.list.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      const ws = createMockWs();
+      await handleProcessList(ws);
+      expect(ws.sent[0]).toEqual({ type: 'process.list', payload: { processes: [] } });
+    });
+  });
+
+  describe('handleProcessKill', () => {
+    it('rejects an invalid payload without touching the registry', async () => {
+      const ws = createMockWs();
+      await handleProcessKill(ws, { pid: -1 });
+      expect(registry.kill).not.toHaveBeenCalled();
+      expect(ws.sent[0]?.payload.success).toBe(false);
+    });
+
+    it('refuses to kill a protected process', async () => {
+      registry.get.mockReturnValue({ protected: true });
+      const ws = createMockWs();
+      await handleProcessKill(ws, { pid: 42 });
+      expect(registry.kill).not.toHaveBeenCalled();
+      expect(ws.sent[0]?.payload.success).toBe(false);
+      expect(String(ws.sent[0]?.payload.message)).toContain('protected');
+    });
+
+    it('kills an unprotected process', async () => {
+      registry.get.mockReturnValue({ protected: false });
+      const ws = createMockWs();
+      await handleProcessKill(ws, { pid: 42 });
+      expect(registry.kill).toHaveBeenCalledWith(42);
+      expect(ws.sent[0]?.payload.success).toBe(true);
+    });
+  });
+
+  describe('handleProcessKillAll', () => {
+    it('kills all and confirms', async () => {
+      const ws = createMockWs();
+      await handleProcessKillAll(ws);
+      expect(registry.killAll).toHaveBeenCalledOnce();
+      expect(ws.sent[0]?.payload.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Continues the route-handler extraction from #95–#98. Moves the three process-registry WS cases — `process.list` / `process.kill` / `process.killAll` — out of the 2.6k-line `handleMessage` switch in `server/index.ts` into a focused `process-handlers.ts`, matching the existing git / mode / mcp / session handler modules.

## Behavior-preserving
- The switch cases now delegate: `await handleProcessList(ws)` / `handleProcessKill(ws, msg.payload)` / `handleProcessKillAll(ws)`.
- The now-unused `validateProcessKillPayload` import was dropped from `index.ts` (it lives in the handler module now).
- No wire-shape or logic change.

## Tests
New `tests/server/process-handlers.test.ts` (registry mocked): list projection + empty-on-throw, invalid-payload reject, protected-process refusal, kill success, killAll. Full webui server suite **598/598**; workspace typecheck clean.

`index.ts`: 2623 → 2585 lines.

Refs #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)