### PR TITLE
refactor(webui): collapse 9 worklist cases into a shared dispatcher (#31)

### DIFF
--- a/packages/webui/src/server/handlers/index.ts
+++ b/packages/webui/src/server/handlers/index.ts
@@ -18,5 +18,7 @@ export {
   handlePlanGet,
   handlePlanTemplateUse,
   handlePlanItemUpdate,
+  handleWorklistMessage,
   type WorklistContext,
+  type WorklistMessage,
 } from './worklist-handlers.js';

--- a/packages/webui/src/server/handlers/worklist-handlers.ts
+++ b/packages/webui/src/server/handlers/worklist-handlers.ts
@@ -11,6 +11,7 @@
 
 import type { WebSocket } from 'ws';
 import type { TodoItem } from '@wrongstack/core';
+import { validatePlanTemplateUsePayload } from '../ws-payload-validation.js';
 
 // ── Shared result helper ───────────────────────────────────────────────────────
 
@@ -242,5 +243,74 @@ export async function handlePlanItemUpdate(
     ctx.broadcast({ type: 'plan.updated', payload: { plan } });
   } catch (err) {
     sendResult(ws, ctx, false, String(err));
+  }
+}
+
+// ── Dispatcher ──────────────────────────────────────────────────────────────────
+// Single entry point for the nine worklist message types, so the host server's
+// switch delegates one grouped case here instead of repeating the per-type
+// `makeWorklistContext()` boilerplate. Unknown types are a no-op (the caller
+// only routes worklist types to this function).
+
+/** Loosely-typed worklist WS message — payload shapes are narrowed per case. */
+export interface WorklistMessage {
+  type: string;
+  payload?: unknown;
+}
+
+export async function handleWorklistMessage(
+  ctx: WorklistContext,
+  ws: WebSocket,
+  msg: WorklistMessage,
+): Promise<void> {
+  switch (msg.type) {
+    case 'todos.get':
+      handleTodosGet(ctx, ws);
+      return;
+    case 'todos.clear':
+      handleTodosClear(ctx, ws);
+      return;
+    case 'todos.remove':
+      handleTodosRemove(ctx, ws, msg.payload as { id?: string; index?: number } | undefined);
+      return;
+    case 'todo.update':
+      handleTodoUpdate(
+        ctx,
+        ws,
+        msg.payload as { id: string; status?: TodoItem['status']; activeForm?: string },
+      );
+      return;
+    case 'tasks.get':
+      await handleTasksGet(ctx, ws);
+      return;
+    case 'task.update':
+      await handleTaskUpdate(
+        ctx,
+        ws,
+        msg.payload as {
+          id: string;
+          status: 'pending' | 'in_progress' | 'blocked' | 'failed' | 'review' | 'completed';
+        },
+      );
+      return;
+    case 'plan.get':
+      await handlePlanGet(ctx, ws);
+      return;
+    case 'plan.template_use': {
+      const parsed = validatePlanTemplateUsePayload(msg.payload);
+      if (!parsed.ok) {
+        sendResult(ws, ctx, false, parsed.message);
+        return;
+      }
+      await handlePlanTemplateUse(ctx, ws, parsed.value.template);
+      return;
+    }
+    case 'plan.item.update':
+      await handlePlanItemUpdate(
+        ctx,
+        ws,
+        msg.payload as { target: string; status: 'open' | 'in_progress' | 'done' },
+      );
+      return;
   }
 }

--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -1,15 +1,8 @@
 import { expectDefined, GlobalMailbox, projectSlug, getSessionRegistry, AgentStatusTracker, FleetNotifier } from '@wrongstack/core';
 import {
-  handleTodosGet,
-  handleTodosClear,
-  handleTodosRemove,
-  handleTodoUpdate,
-  handleTasksGet,
-  handleTaskUpdate,
-  handlePlanGet,
-  handlePlanTemplateUse,
-  handlePlanItemUpdate,
+  handleWorklistMessage,
   type WorklistContext,
+  type WorklistMessage,
 } from './handlers/index.js';
 import { makeMailboxTool, makeMailSendTool, makeMailInboxTool, mailboxSessionTag } from '@wrongstack/core';
 import { toErrorMessage, wstackGlobalRoot, projectHash, resolveWstackPaths } from '@wrongstack/core/utils';
@@ -40,7 +33,6 @@ import {
   validateMailboxPurgePayload,
   validateModelSwitchPayload,
   validatePrefsUpdatePayload,
-  validatePlanTemplateUsePayload,
   validateShellOpenPayload,
   validateGitDiffPayload,
   validateAutonomySwitchPayload,
@@ -110,7 +102,6 @@ import {
   enhanceUserPrompt,
   recentTextTurns,
   resolveProviderModelList,
-  type TodoItem,
 } from '@wrongstack/core';
 import { ToolExecutor } from '@wrongstack/core/execution';
 import { decryptConfigSecrets, encryptConfigSecrets } from '@wrongstack/core/security';
@@ -1896,54 +1887,19 @@ export async function startWebUI(
         break;
       }
 
-      case 'todos.get': {
-        const ctx = makeWorklistContext();
-        handleTodosGet(ctx, ws);
-        break;
-      }
-      case 'todos.clear': {
-        const ctx = makeWorklistContext();
-        handleTodosClear(ctx, ws);
-        break;
-      }
-      case 'todos.remove': {
-        const ctx = makeWorklistContext();
-        handleTodosRemove(ctx, ws, msg.payload as { id?: string; index?: number } | undefined);
-        break;
-      }
-      case 'tasks.get': {
-        const ctx = makeWorklistContext();
-        await handleTasksGet(ctx, ws);
-        break;
-      }
-      case 'plan.get': {
-        const ctx = makeWorklistContext();
-        await handlePlanGet(ctx, ws);
-        break;
-      }
-      case 'plan.template_use': {
-        const parsed = validatePlanTemplateUsePayload(msg.payload);
-        if (!parsed.ok) {
-          sendResult(ws, false, parsed.message);
-          break;
-        }
-        const ctx = makeWorklistContext();
-        await handlePlanTemplateUse(ctx, ws, parsed.value.template);
-        break;
-      }
-      case 'todo.update': {
-        const ctx = makeWorklistContext();
-        handleTodoUpdate(ctx, ws, msg.payload as { id: string; status?: TodoItem['status']; activeForm?: string });
-        break;
-      }
-      case 'task.update': {
-        const ctx = makeWorklistContext();
-        await handleTaskUpdate(ctx, ws, msg.payload as { id: string; status: 'pending' | 'in_progress' | 'blocked' | 'failed' | 'review' | 'completed' });
-        break;
-      }
+      // ── Worklist (todos / tasks / plan) — delegated to the shared dispatcher ──
+      // The nine worklist message types share one context factory; the dispatcher
+      // in handlers/worklist-handlers.ts narrows each payload and routes it.
+      case 'todos.get':
+      case 'todos.clear':
+      case 'todos.remove':
+      case 'tasks.get':
+      case 'plan.get':
+      case 'plan.template_use':
+      case 'todo.update':
+      case 'task.update':
       case 'plan.item.update': {
-        const ctx = makeWorklistContext();
-        await handlePlanItemUpdate(ctx, ws, msg.payload as { target: string; status: 'open' | 'in_progress' | 'done' });
+        await handleWorklistMessage(makeWorklistContext(), ws, msg as WorklistMessage);
         break;
       }
 

--- a/packages/webui/tests/server/worklist-dispatcher.test.ts
+++ b/packages/webui/tests/server/worklist-dispatcher.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WebSocket } from 'ws';
+import {
+  handleWorklistMessage,
+  type WorklistContext,
+} from '../../src/server/handlers/worklist-handlers.js';
+
+function createMockWs() {
+  const ws = {
+    readyState: 1,
+    sent: [] as Array<{ type: string; payload?: Record<string, unknown>; message?: string }>,
+    send(data: string) {
+      this.sent.push(JSON.parse(data));
+    },
+  } as never as WebSocket & {
+    sent: Array<{ type: string; payload?: Record<string, unknown>; message?: string }>;
+  };
+  return ws;
+}
+
+function makeCtx(): WorklistContext {
+  const ws = createMockWs();
+  return {
+    context: {
+      todos: [{ id: 't1', content: 'do thing', status: 'pending' } as never],
+      meta: {},
+      session: { id: 's1' },
+      state: undefined,
+    },
+    send: (w, m) => (w as never as { send: (d: string) => void }).send(JSON.stringify(m)),
+    broadcast: vi.fn(),
+  };
+}
+
+describe('handleWorklistMessage dispatcher', () => {
+  it('routes todos.get to the todos handler', async () => {
+    const ctx = makeCtx();
+    const ws = createMockWs();
+    await handleWorklistMessage(ctx, ws, { type: 'todos.get' });
+    expect(ws.sent[0]?.type).toBe('todos.updated');
+    expect(ws.sent[0]?.payload?.todos).toHaveLength(1);
+  });
+
+  it('validates plan.template_use payload and rejects bad input', async () => {
+    const ctx = makeCtx();
+    const ws = createMockWs();
+    await handleWorklistMessage(ctx, ws, { type: 'plan.template_use', payload: {} });
+    // Invalid payload → error result, no plan broadcast.
+    expect(ws.sent[0]?.type).toBe('error');
+    expect(ctx.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for an unrelated message type', async () => {
+    const ctx = makeCtx();
+    const ws = createMockWs();
+    await handleWorklistMessage(ctx, ws, { type: 'not.a.worklist.type' });
+    expect(ws.sent).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Continues splitting `webui/src/server/index.ts` (#31).

The nine worklist WS cases — `todos.get/clear/remove`, `todo.update`, `tasks.get`, `task.update`, `plan.get`, `plan.template_use`, `plan.item.update` — each repeated the same `makeWorklistContext()` boilerplate + per-payload cast inline in the `handleMessage` switch (~50 lines).

## Change
Add `handleWorklistMessage(ctx, ws, msg)` to `handlers/worklist-handlers.ts` — the module that already owns these handlers. It narrows each payload and routes it, including the `plan.template_use` validation that previously sat in `index.ts`. The switch now delegates a single grouped case.

The per-type handlers stay exported (the CLI embedded server uses them); only the dispatch + boilerplate moved. Drops the now-unused worklist-handler / `validatePlanTemplateUsePayload` / `TodoItem` imports from `index.ts`.

## Tests
New `worklist-dispatcher.test.ts`: routes `todos.get`, rejects invalid `plan.template_use`, no-ops an unrelated type. webui server suite **601/601**; workspace typecheck clean.

`index.ts`: 2585 → 2541 lines.

Refs #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)