### PR TITLE
refactor(webui): extract goal.get handler from server/index.ts (#31)

### DIFF
--- a/packages/webui/src/server/goal-handlers.ts
+++ b/packages/webui/src/server/goal-handlers.ts
@@ -1,0 +1,34 @@
+/**
+ * Goal-state WebSocket handler for the WebUI server, extracted from the
+ * `handleMessage` switch in `index.ts` as part of splitting that file (#31).
+ *
+ *   case 'goal.get': return handleGoalGet(projectRoot, (m) => broadcast(clients, m));
+ *
+ * Reads the canonical goal.json and broadcasts it to every connected client so
+ * all browser tabs share one goal snapshot. Never throws — a missing or
+ * unparseable file broadcasts `null` so clients clear stale goal state.
+ */
+
+import { resolveWstackPaths } from '@wrongstack/core/utils';
+
+/**
+ * Read `goal.json` for `projectRoot` and broadcast a `goal.updated` message.
+ * The path must match /goal, the autonomy engines, and TUI F9, which all
+ * resolve via `resolveWstackPaths().projectGoal`
+ * (`~/.wrongstack/projects/<slug>/goal.json`) — NOT the repo-local
+ * `.wrongstack/goal.json`.
+ */
+export async function handleGoalGet(
+  projectRoot: string,
+  broadcast: (msg: object) => void,
+): Promise<void> {
+  try {
+    const goalPath = resolveWstackPaths({ projectRoot }).projectGoal;
+    const { readFile } = await import('node:fs/promises');
+    const raw = await readFile(goalPath, 'utf8');
+    const goal = JSON.parse(raw);
+    broadcast({ type: 'goal.updated', payload: goal });
+  } catch {
+    broadcast({ type: 'goal.updated', payload: null });
+  }
+}

--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -5,7 +5,7 @@ import {
   type WorklistMessage,
 } from './handlers/index.js';
 import { makeMailboxTool, makeMailSendTool, makeMailInboxTool, mailboxSessionTag } from '@wrongstack/core';
-import { toErrorMessage, wstackGlobalRoot, projectHash, resolveWstackPaths } from '@wrongstack/core/utils';
+import { toErrorMessage, wstackGlobalRoot, projectHash } from '@wrongstack/core/utils';
 import { SkillInstaller } from '@wrongstack/core/skills';
 import {
   BrainMonitor,
@@ -153,6 +153,7 @@ import {
   handleProcessKillAll,
   handleProcessList,
 } from './process-handlers.js';
+import { handleGoalGet } from './goal-handlers.js';
 // Re-export types — shared message shapes and options used by both the
 // standalone server and the CLI's `--webui` embedded mode.
 export type { WebUIOptions, BackendServices } from './types.js';
@@ -1966,23 +1967,7 @@ export async function startWebUI(
       }
 
       case 'goal.get': {
-        // Read goal.json from disk and broadcast to all clients so every
-        // connected browser sees the same goal state. The file is polled
-        // by the frontend every 10s — we serve the latest snapshot here.
-        try {
-          // Canonical goal path — must match /goal, the autonomy engines, and
-          // TUI F9, which all resolve via resolveWstackPaths().projectGoal
-          // (~/.wrongstack/projects/<slug>/goal.json), NOT the repo-local
-          // .wrongstack/goal.json.
-          const goalPath = resolveWstackPaths({ projectRoot }).projectGoal;
-          const raw = await fs.readFile(goalPath, 'utf8');
-          const goal = JSON.parse(raw);
-          broadcast(clients, { type: 'goal.updated', payload: goal });
-        } catch {
-          // No goal file yet or parse error — broadcast null so the
-          // frontend clears any stale goal state.
-          broadcast(clients, { type: 'goal.updated', payload: null });
-        }
+        await handleGoalGet(projectRoot, (m) => broadcast(clients, m));
         break;
       }
 

--- a/packages/webui/tests/server/goal-handlers.test.ts
+++ b/packages/webui/tests/server/goal-handlers.test.ts
@@ -1,0 +1,52 @@
+import { randomBytes } from 'node:crypto';
+import * as fsSync from 'node:fs';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Point goal resolution at a temp project root by mocking resolveWstackPaths.
+const tmpGoal = vi.hoisted(() => ({ path: '' }));
+vi.mock('@wrongstack/core/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wrongstack/core/utils')>();
+  return { ...actual, resolveWstackPaths: () => ({ projectGoal: tmpGoal.path }) };
+});
+
+const { handleGoalGet } = await import('../../src/server/goal-handlers.js');
+
+describe('handleGoalGet', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = path.join(process.env.TEMP || '/tmp', `goaltest-${randomBytes(4).toString('hex')}`);
+    fsSync.mkdirSync(dir, { recursive: true });
+    tmpGoal.path = path.join(dir, 'goal.json');
+  });
+
+  afterEach(() => {
+    try {
+      fsSync.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('broadcasts the parsed goal when the file exists', async () => {
+    const goal = { mission: 'ship it', goalState: 'active' };
+    fsSync.writeFileSync(tmpGoal.path, JSON.stringify(goal));
+    const sent: object[] = [];
+    await handleGoalGet('/proj', (m) => sent.push(m));
+    expect(sent).toEqual([{ type: 'goal.updated', payload: goal }]);
+  });
+
+  it('broadcasts null when the goal file is missing', async () => {
+    const sent: Array<{ type: string; payload: unknown }> = [];
+    await handleGoalGet('/proj', (m) => sent.push(m as never));
+    expect(sent[0]).toEqual({ type: 'goal.updated', payload: null });
+  });
+
+  it('broadcasts null when the goal file is malformed', async () => {
+    fsSync.writeFileSync(tmpGoal.path, '{ not json');
+    const sent: Array<{ type: string; payload: unknown }> = [];
+    await handleGoalGet('/proj', (m) => sent.push(m as never));
+    expect(sent[0]).toEqual({ type: 'goal.updated', payload: null });
+  });
+});


### PR DESCRIPTION
Continues splitting `webui/src/server/index.ts` (#31).

Moves the `goal.get` WS case out of the `handleMessage` switch into `goal-handlers.ts`, matching the git / process / mode handler modules. The handler reads the canonical `goal.json` (via `resolveWstackPaths().projectGoal`) and broadcasts `goal.updated` — the parsed goal, or `null` on a missing/malformed file. Behavior unchanged; the switch case delegates. Drops the now-unused `resolveWstackPaths` import from `index.ts`.

## Tests
New `goal-handlers.test.ts` (resolveWstackPaths mocked to a temp dir): present / missing / malformed file. webui server suite **604/604**; webui typecheck clean.

`index.ts`: 2541 → 2526 lines.

Refs #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)