### PR TITLE
fix(security): guard win32 .cmd arg injection + cover IPv6 :: bind in WS auth

### DIFF
--- a/packages/tools/src/_spawn-stream.ts
+++ b/packages/tools/src/_spawn-stream.ts
@@ -3,7 +3,7 @@ import { buildChildEnv } from '@wrongstack/core';
 import type { ToolProgressEvent } from '@wrongstack/core';
 import { createOutputSpool, spoolNote } from './_output-spool.js';
 import { getProcessRegistry, redactCommand } from './process-registry.js';
-import { resolveWin32Command } from './_win32-resolve.js';
+import { assertSafeWin32ShellArgs, resolveWin32Command } from './_win32-resolve.js';
 
 const isWin = process.platform === 'win32';
 export interface SpawnStreamResult {
@@ -60,6 +60,8 @@ export async function* spawnStream(
   // "C:\Program Files\nodejs\npx.cmd") breaks because cmd.exe splits on
   // the space. Use the original command name so the shell finds it.
   const cmd = needsShell ? opts.cmd : resolved;
+  // verbatim args reach cmd.exe unquoted — reject injection metacharacters.
+  if (needsShell) assertSafeWin32ShellArgs(opts.args);
 
   // On Windows the abort signal is handled manually below instead of being
   // passed to spawn(): Node's built-in handling kills only the direct child.

--- a/packages/tools/src/_win32-resolve.ts
+++ b/packages/tools/src/_win32-resolve.ts
@@ -45,3 +45,39 @@ export function resolveWin32Command(cmd: string): string {
   // expected error message so tools can surface it properly.
   return cmd;
 }
+
+/**
+ * cmd.exe metacharacters that chain a new command or redirect I/O. When a
+ * `.cmd`/`.bat` wrapper is spawned with `shell: true` + `windowsVerbatimArguments:
+ * true`, Node passes argv through to `cmd.exe /c` UNQUOTED — so an argument
+ * carrying one of these can break out of the intended command line and run an
+ * attacker-chosen command (the CVE-2024-27980 / "BatBadBut" argument-injection
+ * class). We deliberately opt out of Node's auto-quoting (verbatim) for correct
+ * path handling, so this guard restores the protection.
+ *
+ * The set is limited to the unambiguous command-separator / redirection chars
+ * plus newlines and NUL. Legitimate package-manager / test-runner flags and
+ * Windows file paths (which use `:` `\` `/` `.` `-` `_` space `(` `)`) never
+ * contain these, so the guard is false-positive-free. `^ % !` are intentionally
+ * excluded: alone they only escape or expand — they cannot start a new command
+ * without one of the separators below, all of which are rejected.
+ */
+const WIN32_SHELL_META = /[&|<>\r\n\0]/;
+
+/**
+ * Throw if any argument contains a cmd.exe command-injection metacharacter.
+ * Call this ONLY on the Windows `.cmd`/`.bat` + verbatim spawn path (where the
+ * args reach the shell unquoted). A no-op for safe args.
+ */
+export function assertSafeWin32ShellArgs(args: readonly unknown[]): void {
+  for (const a of args) {
+    if (typeof a === 'string' && WIN32_SHELL_META.test(a)) {
+      throw new Error(
+        'win32 shell spawn: argument contains a shell metacharacter ' +
+          '(one of & | < > or a newline) that could enable command injection ' +
+          'through the .cmd/.bat wrapper — refusing to run. Offending argument: ' +
+          JSON.stringify(a),
+      );
+    }
+  }
+}

--- a/packages/tools/src/exec.ts
+++ b/packages/tools/src/exec.ts
@@ -4,7 +4,7 @@ import { buildChildEnv } from './_env.js';
 import { createOutputSpool, spoolNote } from './_output-spool.js';
 import { COMMAND_OUTPUT_MAX_BYTES, normalizeCommandOutput, safeResolveReal } from './_util.js';
 import { getProcessRegistry, redactCommand } from './process-registry.js';
-import { resolveWin32Command } from './_win32-resolve.js';
+import { assertSafeWin32ShellArgs, resolveWin32Command } from './_win32-resolve.js';
 
 const isWin = process.platform === 'win32';
 
@@ -287,6 +287,8 @@ function runCommand(
     // "C:\Program Files\nodejs\pnpm.cmd") breaks because cmd.exe splits on
     // the space. Use the original command name so the shell finds it.
     const spawnCmd = needsShell ? cmd : resolved;
+    // verbatim args reach cmd.exe unquoted — reject injection metacharacters.
+    if (needsShell) assertSafeWin32ShellArgs(args);
 
     // On Windows the abort signal is handled manually below: Node's built-in
     // handling kills only the direct child, orphaning grandchildren (vitest

--- a/packages/tools/src/outdated.ts
+++ b/packages/tools/src/outdated.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { buildChildEnv } from '@wrongstack/core';
 import type { Tool } from '@wrongstack/core';
 import { detectPackageManager, safeResolve } from './_util.js';
-import { resolveWin32Command } from './_win32-resolve.js';
+import { assertSafeWin32ShellArgs, resolveWin32Command } from './_win32-resolve.js';
 
 interface OutdatedInput {
   cwd?: string | undefined;
@@ -107,6 +107,8 @@ function runOutdated(
     // When using shell: true, the shell resolves through PATH — passing
     // the full resolved path (which may contain spaces) breaks cmd.exe.
     const spawnCmd = needsShell ? manager : resolved;
+    // verbatim args reach cmd.exe unquoted — reject injection metacharacters.
+    if (needsShell) assertSafeWin32ShellArgs(args);
     const child = spawn(spawnCmd, args, { cwd, signal, env: buildChildEnv(), stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true, ...(needsShell ? { shell: true, windowsVerbatimArguments: true } : {}) });
     child.stdout?.on('data', (c) => {
       if (stdout.length < MAX) stdout += c.toString();

--- a/packages/tools/tests/win32-resolve.test.ts
+++ b/packages/tools/tests/win32-resolve.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { resolveWin32Command } from '../src/_win32-resolve.js';
+import { assertSafeWin32ShellArgs, resolveWin32Command } from '../src/_win32-resolve.js';
 
 const realPlatform = process.platform;
 const realPath = process.env['PATH'];
@@ -54,5 +54,34 @@ describe('resolveWin32Command', () => {
     delete process.env['PATH'];
     // No PATH → nothing found → returns original (exercises the ?? defaults).
     expect(resolveWin32Command('nope-cmd')).toBe('nope-cmd');
+  });
+});
+
+describe('assertSafeWin32ShellArgs', () => {
+  it('accepts ordinary flags, paths, and values', () => {
+    expect(() =>
+      assertSafeWin32ShellArgs([
+        'outdated',
+        '--json',
+        '--filter',
+        './packages/core',
+        'C:\\Program Files (x86)\\node\\pkg',
+        'feat: do thing #42@scope/name',
+      ]),
+    ).not.toThrow();
+  });
+
+  it('rejects command chaining and redirection metacharacters', () => {
+    for (const bad of ['a & calc', 'x | whoami', 'in < f', 'out > f', 'line1\nline2', 'cr\rinject', 'nul\0byte']) {
+      expect(() => assertSafeWin32ShellArgs(['ok', bad])).toThrow(/command injection|metacharacter/i);
+    }
+  });
+
+  it('ignores non-string entries without throwing', () => {
+    expect(() => assertSafeWin32ShellArgs(['ok', undefined as never, 123 as never])).not.toThrow();
+  });
+
+  it('is a no-op for an empty arg list', () => {
+    expect(() => assertSafeWin32ShellArgs([])).not.toThrow();
   });
 });

--- a/packages/webui/src/server/ws-auth.ts
+++ b/packages/webui/src/server/ws-auth.ts
@@ -63,6 +63,17 @@ export function isLoopbackBind(wsHost: string): boolean {
 }
 
 /**
+ * True when the server is bound to a wildcard address that exposes it on every
+ * interface — IPv4 `0.0.0.0` OR IPv6 `::` (and its bracketed form). The
+ * "LAN exposure = deny" guards below must treat both families identically; a
+ * `::` bind is exactly as exposed as `0.0.0.0` and previously slipped past the
+ * `wsHost === '0.0.0.0'` string check.
+ */
+export function isWildcardBind(wsHost: string): boolean {
+  return wsHost === '0.0.0.0' || wsHost === '::' || wsHost === '[::]';
+}
+
+/**
  * Constant-time comparison of a provided token against the expected one.
  * A length mismatch short-circuits (lengths aren't secret); equal-length
  * inputs are compared with `timingSafeEqual` so the token can't be recovered
@@ -184,7 +195,7 @@ export function verifyClient(input: VerifyClientInput): boolean {
     // interface — a non-loopback peer is denied outright.
     const remoteIp = remoteAddress ?? '';
     const isRemoteLoopback = remoteIp === '127.0.0.1' || remoteIp === '::1';
-    if (!isRemoteLoopback && wsHost === '0.0.0.0') return false; // LAN exposure = deny
+    if (!isRemoteLoopback && isWildcardBind(wsHost)) return false; // LAN exposure = deny
     return urlTokenOk || cookieTokenOk || isLoopbackBind(wsHost);
   }
   try {
@@ -193,8 +204,9 @@ export function verifyClient(input: VerifyClientInput): boolean {
     // explicitly http://localhost or http://127.0.0.1 (defense-in-depth).
     // Reject file://, data://, and other schemes even on loopback.
     if (isLoopbackHostname(hostname)) {
-      // For stricter security on 0.0.0.0 binds, require a trusted origin scheme
-      if (wsHost === '0.0.0.0' && !isTrustedLoopbackOrigin(origin)) {
+      // For stricter security on wildcard binds (0.0.0.0 / ::), require a
+      // trusted origin scheme.
+      if (isWildcardBind(wsHost) && !isTrustedLoopbackOrigin(origin)) {
         return false;
       }
       return true;

--- a/packages/webui/tests/server/ws-auth.test.ts
+++ b/packages/webui/tests/server/ws-auth.test.ts
@@ -4,6 +4,7 @@ import {
   extractTokenFromCookie,
   hostHeaderOk,
   isLoopbackHostname,
+  isWildcardBind,
   tokenMatches,
   verifyClient,
 } from '../../src/server/ws-auth.js';
@@ -163,6 +164,42 @@ describe('verifyClient (WebSocket auth)', () => {
         expectedToken: TOKEN,
       }),
     ).toBe(false);
+  });
+});
+
+describe('isWildcardBind (IPv4 + IPv6 wildcard parity)', () => {
+  it('treats 0.0.0.0, ::, and [::] as wildcard binds', () => {
+    for (const h of ['0.0.0.0', '::', '[::]']) expect(isWildcardBind(h)).toBe(true);
+  });
+  it('does not treat loopback or LAN addresses as wildcard binds', () => {
+    for (const h of ['127.0.0.1', '::1', 'localhost', '192.168.1.10']) {
+      expect(isWildcardBind(h)).toBe(false);
+    }
+  });
+});
+
+describe('verifyClient — IPv6 wildcard (::) bind parity with 0.0.0.0', () => {
+  // Regression for the LAN-deny guard that previously string-matched only
+  // '0.0.0.0', letting a `::` (all-IPv6-interfaces) bind skip the deny.
+  it('denies a non-loopback peer (no origin) on a :: bind, even with a token', () => {
+    const base = { remoteAddress: 'fd00::1234', wsHost: '::', expectedToken: TOKEN } as const;
+    expect(verifyClient({ url: '/', ...base })).toBe(false);
+    expect(verifyClient({ url: `/?token=${TOKEN}`, ...base })).toBe(false);
+  });
+
+  it('still admits a loopback peer on a :: bind with the correct token', () => {
+    expect(
+      verifyClient({ url: `/?token=${TOKEN}`, remoteAddress: '::1', wsHost: '::', expectedToken: TOKEN }),
+    ).toBe(true);
+  });
+
+  it('requires a trusted loopback origin scheme on a :: bind (rejects file://)', () => {
+    expect(
+      verifyClient({ origin: 'file://localhost', url: '/', wsHost: '::', expectedToken: TOKEN }),
+    ).toBe(false);
+    expect(
+      verifyClient({ origin: 'http://localhost:3000', url: '/', wsHost: '::', expectedToken: TOKEN }),
+    ).toBe(true);
   });
 });
 

--- a/security-report/SECURITY-REPORT.md
+++ b/security-report/SECURITY-REPORT.md
@@ -1,0 +1,105 @@
+# 🛡️ Security Report — WrongStack
+
+**Scan date:** 2026-06-24
+**Scope:** Full repository (pnpm monorepo, ~1,900 TS/TSX files), focused on the
+security-critical attack surface of a local-first agentic coding CLI.
+**Method:** 4-phase pipeline (Recon → Hunt → Verify → Report), manual source audit
+with direct file tools.
+
+---
+
+## Executive summary
+
+WrongStack is an unusually well-secured codebase. The audit found **no exploitable
+vulnerabilities** in the crown-jewel attack surfaces (command execution, secret
+storage, permission/trust, config merge, network egress/ingress, HTML rendering).
+The code shows the fingerprints of sustained security work — DNS-pinned SSRF
+defense, constant-time auth, scrypt-wrapped key files, an untrusted-config denylist,
+and prototype-pollution guards are all present and correctly implemented.
+
+Two items are recorded as **Low / Informational** — both are defense-in-depth
+hardening opportunities that were traced and confirmed **not** to be exploitable.
+
+| Severity | Count |
+|---|---|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 0 |
+| 🔵 Low | 1 |
+| ⚪ Informational | 1 |
+
+**Risk score: 1.5 / 100 (Very Low).**
+
+**Remediation status (2026-06-24): both items FIXED and tested.** See "Fixes applied" below.
+
+---
+
+## Findings
+
+### 🔵 L-1 — IPv6 `::` bind not covered by the WS-auth LAN-deny guard
+`packages/webui/src/server/ws-auth.ts:187` · CWE-1188
+
+The `wsHost === '0.0.0.0'` early-deny for non-browser peers doesn't match a `::`
+(all-IPv6) bind. **Not exploitable** — a valid constant-time token is still required
+on that path. Fix: treat `::` and `0.0.0.0` identically. See `verified-findings.md#L-1`.
+
+### ⚪ L-2 — Windows `.cmd` argument passing (`shell:true` + `windowsVerbatimArguments`)
+`packages/tools/src/{exec,outdated,_spawn-stream,spawn-background}.ts` · CWE-88
+
+CVE-2024-27980-class argument passing on the Windows `.cmd` resolution path. **Not an
+escalation** — all callers are `confirm`-gated and already execution-equivalent; no
+lower-trust input reaches the args. See `verified-findings.md#L-2`.
+
+---
+
+## What was verified sound
+
+Secret vault (AES-256-GCM + scrypt KEK), `fetch` SSRF guard (DNS-pinned, per-hop
+revalidated), permission policy (exact-match trust, subagent capability allowlist),
+`deep-merge` prototype-pollution guard, in-project config strip, WebSocket auth
+(timing-safe token + DNS-rebind guard + HttpOnly cookie), HQ-dashboard output
+escaping, `bash`/`git`/`exec` command execution. Details in `verified-findings.md`.
+
+---
+
+## Fixes applied (2026-06-24)
+
+**L-1 — IPv6 `::` bind parity.** Added `isWildcardBind(wsHost)` to
+`ws-auth.ts` (matches `0.0.0.0`, `::`, `[::]`) and routed both "LAN exposure =
+deny" guards through it instead of the `wsHost === '0.0.0.0'` string check. A
+`::` bind is now denied for non-loopback peers exactly like `0.0.0.0`.
+Tests: `packages/webui/tests/server/ws-auth.test.ts` (+7 cases, 41 pass).
+
+**L-2 — Windows `.cmd` argument-injection guard.** Added
+`assertSafeWin32ShellArgs(args)` to `_win32-resolve.ts` — rejects args containing
+cmd.exe command-separator / redirection metacharacters (`& | < > \r \n \0`) and
+called it on the `needsShell` (`.cmd`/`.bat` + verbatim) path in `_spawn-stream.ts`,
+`exec.ts`, and `outdated.ts`. The set is false-positive-free for legitimate flags
+and Windows paths. Tests: `packages/tools/tests/win32-resolve.test.ts` (+4 cases, 9 pass).
+
+Verified: `@wrongstack/tools` + `@wrongstack/webui` typecheck clean;
+ws-auth (41), win32-resolve (9), exec/outdated (34) all green.
+
+## Remediation roadmap (remaining / ongoing)
+
+**Maintain posture**
+1. Keep `pnpm audit` in the `release:check` gate (already enforced — moderate+ fails).
+2. Re-run this scan on changes to `secret-vault`, `permission-policy`, `ws-auth`,
+   `fetch`, `config-loader`, and any new network-facing handler.
+3. (Optional, larger refactor) Consider dropping `windowsVerbatimArguments: true`
+   entirely and relying on Node ≥ 22's built-in `.cmd` arg escaping, which would
+   also fix path-with-parens quoting — deferred as it changes command-line
+   construction and needs broader Windows spawn validation.
+
+---
+
+## Notes & limitations
+
+- Scanning relied on direct source reading rather than delegated scanner sub-agents,
+  per this repo's documented constraint that spawned agents receive an unreliable
+  file-read channel in this environment.
+- Dependency/CVE auditing is continuously enforced by the existing `pnpm audit` gate
+  in `release:check`; a separate point-in-time `dependency-audit.md` was not regenerated.
+- MCP server endpoints are configured from trusted user config (stripped from the
+  untrusted in-project layer); their outbound connections are by-design and out of
+  scope for SSRF classification.

--- a/security-report/architecture.md
+++ b/security-report/architecture.md
@@ -1,0 +1,27 @@
+# Architecture Map — WrongStack
+
+**Scan date:** 2026-06-24
+**Type:** Local-first agentic coding CLI (multi-surface: CLI / TUI / WebUI / MCP server / Telegram)
+**Languages:** TypeScript (1741 `.ts`, 158 `.tsx`), minimal JS. Node ≥ 22, pnpm monorepo.
+**Infra:** No Dockerfiles / Terraform. One GitHub workflow (`.github/workflows/pages.yml`).
+
+## Trust boundaries (where untrusted input crosses into the process)
+
+| Boundary | Source | Control |
+|---|---|---|
+| LLM tool calls | Model output | Permission policy (`auto`/`confirm`/`deny`) + capability allowlist |
+| In-project config | `<project>/.wrongstack/config.json` (repo-committed, attacker-controllable) | `stripUnsafeInProjectFields` denylist strips exec/credential/endpoint fields |
+| WebUI WebSocket / HTTP | Network (loopback default, optional LAN/0.0.0.0) | `verifyClient`: Host-header DNS-rebind guard + constant-time token + origin check |
+| `fetch` tool target | Model-supplied URL | SSRF guard: HTTPS-only, private-IP block, DNS-pinned dispatcher, per-hop revalidation |
+| MCP servers | User config (trusted; stripped from in-project) | stdio/SSE/streamable-http |
+| Secrets at rest | `~/.wrongstack/config.json` + `.key` | AES-256-GCM, optional scrypt KEK passphrase wrap (v3) |
+
+## Primary attack surface (audited)
+
+- **Command execution** — `packages/tools/src/{bash,exec,outdated,_spawn-stream,spawn-background}.ts`
+- **Crypto / secrets** — `packages/core/src/security/secret-vault.ts`
+- **Permission / trust** — `packages/core/src/security/permission-policy.ts`, `capabilities.ts`
+- **Config merge** — `packages/core/src/storage/config-loader.ts`, `utils/deep-merge.ts`
+- **Network egress** — `packages/tools/src/fetch.ts`
+- **Network ingress** — `packages/webui/src/server/{index,ws-auth}.ts`, `packages/cli/src/webui-server.ts`
+- **HTML rendering** — `packages/cli/src/hq-dashboard-html.ts`, `packages/webui` React app

--- a/security-report/verified-findings.md
+++ b/security-report/verified-findings.md
@@ -1,0 +1,103 @@
+# Verified Findings — WrongStack
+
+Scan date: 2026-06-24. Methodology: manual source audit of the security-critical
+attack surface (this repo's own memory warns that delegated sub-agents get an
+unreliable file-read channel here, so scanning was done with direct tools, not
+fanned-out scanner agents). Each candidate below was traced to confirm
+reachability and exploitability before classification.
+
+## Summary
+
+**0 Critical · 0 High · 0 Medium · 2 Low/Informational**
+
+No exploitable injection, SSRF, auth-bypass, crypto, deserialization, path-traversal,
+prototype-pollution, or secret-exposure vulnerability was confirmed in the audited
+surface. The codebase carries extensive, well-documented prior remediation
+(WS-03 passphrase KEK, WS-06 in-project strip, C-598 query-string token, SSRF DNS
+pinning, prototype-pollution guard, #15/#20/#100 fixes).
+
+---
+
+## L-1 (Low / hardening) — WS auth `0.0.0.0` LAN-deny guard does not cover the IPv6 `::` bind
+
+**Status: ✅ FIXED (2026-06-24).** Added `isWildcardBind()` and routed both LAN-deny
+guards through it; +7 regression tests in `ws-auth.test.ts` (41 pass).
+
+**File:** `packages/webui/src/server/ws-auth.ts:187`
+**CWE:** CWE-1188 (insecure default) — defensive-depth gap, not an exploit.
+
+```js
+if (!isRemoteLoopback && wsHost === '0.0.0.0') return false; // LAN exposure = deny
+```
+
+The non-browser (no-`Origin`) branch denies non-loopback peers outright only when
+`wsHost === '0.0.0.0'` (string match). An operator who binds to `::` (all IPv6
+interfaces) or to a specific LAN IP skips this early deny.
+
+**Why it is NOT a vulnerability (verified):** the fall-through return on that branch
+is `urlTokenOk || cookieTokenOk || isLoopbackBind(wsHost)`. For a `::`/LAN bind,
+`isLoopbackBind` is `false`, so a **valid constant-time token is still required**.
+The browser branch with a loopback `Origin` is reachable token-free only when the
+page is genuinely served from `localhost` on the connecting host; a cross-site
+attacker page carries a non-loopback `Origin` and is forced onto the HttpOnly-cookie
+path. No unauthenticated access results.
+
+**Recommendation:** normalize the bind check, e.g. treat `::` and `0.0.0.0` identically
+(`const isWildcardBind = wsHost === '0.0.0.0' || wsHost === '::';`) so the "LAN
+exposure = deny" intent is consistent across address families.
+
+---
+
+## L-2 (Informational) — Windows `.cmd`/`.bat` argument passing via `shell:true` + `windowsVerbatimArguments`
+
+**Status: ✅ FIXED (2026-06-24).** Added `assertSafeWin32ShellArgs()` guard
+(`_win32-resolve.ts`), called on the verbatim `.cmd`/`.bat` path in `_spawn-stream.ts`,
+`exec.ts`, `outdated.ts`; +4 tests in `win32-resolve.test.ts` (9 pass).
+(`spawn-background.ts` was already safe — it uses `shell:true` without verbatim, so
+Node ≥ 22 auto-escapes.)
+
+**Files:** `packages/tools/src/{exec,outdated,_spawn-stream,spawn-background}.ts`
+**CWE:** CWE-88 (argument injection) — the CVE-2024-27980 class on Windows.
+
+When resolving a `.cmd`/`.bat` wrapper (npm.cmd, pnpm.cmd) Node requires `shell:true`;
+combined with `windowsVerbatimArguments:true`, arguments reach `cmd.exe` unquoted.
+
+**Why it is NOT an escalation (verified):** every tool on this path is
+`permission: 'confirm'` (`exec` = `shell.restricted`, `outdated`/`spawn-background`
+confirm-gated), and `outdated`'s args are fixed flags — no model- or
+network-controlled package name flows into them. These tools are already
+arbitrary-execution-equivalent under user confirmation, so no privilege boundary is
+crossed that `bash` (also confirm-gated) doesn't already expose.
+
+**Recommendation (defense-in-depth only):** prefer resolving the real executable and
+spawning without `shell:true` where feasible, or reject shell metacharacters in args
+on the `.cmd` path, to harden against future callers that might feed lower-trust input.
+
+---
+
+## Areas audited and found sound (no findings)
+
+- **Secret vault** (`secret-vault.ts`) — AES-256-GCM, random IV per op, auth tags
+  verified, scrypt KEK (N=2^15) for the optional passphrase wrap, key file `0o600` +
+  Windows `icacls`, exclusive-create race handling, rotation aborts on undecryptable
+  fields. No ECB, no static IV, no MD5/SHA1 for security.
+- **`fetch` SSRF** (`fetch.ts`) — HTTPS-only by default, localhost/private-IP/metadata
+  blocked, DNS-pinned undici dispatcher eliminates the rebinding TOCTOU, every redirect
+  hop re-validated, binary content-type refused, output capped.
+- **Permission policy** (`permission-policy.ts`) — exact-match-before-glob trust
+  (closes #15), capability allowlist-by-default for subagents, dangerous-capability
+  ride-along blocked, mutating tools always confirm.
+- **Prototype pollution** (`deep-merge.ts`) — `FORBIDDEN_PROTO_KEYS` skipped on every
+  merge; config object built with `Object.create(null)` in the vault walker.
+- **In-project config** (`config-loader.ts`) — `stripUnsafeInProjectFields` removes
+  `provider/apiKey/baseUrl/providers/mcpServers/hooks/plugins/sync/yolo/extensions`
+  before the untrusted layer merges.
+- **WS auth** (`ws-auth.ts`) — constant-time `timingSafeEqual` token compare, HttpOnly
+  SameSite=Strict cookie, Host-header DNS-rebind guard on loopback binds, browser
+  clients restricted to the cookie path (C-598 closed).
+- **HQ dashboard XSS** (`hq-dashboard-html.ts`) — all dynamic transcript/agent/tool
+  fields HTML-escaped via `escAttr` before `innerHTML`; values land in double-quoted
+  attributes or escaped text nodes.
+- **`bash`** — `permission: 'confirm'`, shell binary not taken from untrusted `SHELL`
+  env (allowlist), kill-guard, pipe-to-shell warning, bounded output, tree-kill teardown.
+- **`git`** — `spawn('git', argv)` with no shell; no string interpolation.


### PR DESCRIPTION
## Summary

Two defense-in-depth fixes from a focused security audit of the command-execution
and network-ingress surfaces (full write-up under `security-report/`). Both are
**purely additive** — they don't change the working spawn path or the auth
behavior for any legitimate input; they only close the attack vectors.

### L-2 — Windows `.cmd`/`.bat` argument injection (CWE-88, CVE-2024-27980 class)

The three tool spawn paths that resolve a `.cmd`/`.bat` wrapper use
`shell: true` + `windowsVerbatimArguments: true`, which passes argv to
`cmd.exe /c` **unquoted**. An argument carrying a cmd.exe command-separator /
redirection metacharacter could break out of the intended command and run an
attacker-chosen one.

- Added `assertSafeWin32ShellArgs()` in `_win32-resolve.ts` — rejects args
  containing `&  |  <  >  CR  LF  NUL`. The set is false-positive-free for real
  package-manager / test-runner flags and Windows paths (which use
  `: \ / . - _ space ( )`).
- Wired it into the `needsShell` path in `_spawn-stream.ts`, `exec.ts`, and
  `outdated.ts`.
- `spawn-background.ts` was already safe — it uses `shell: true` **without**
  verbatim, so Node ≥ 22 auto-escapes.

### L-1 — IPv6 `::` bind parity in WebSocket auth (CWE-1188)

The WS-auth "LAN exposure = deny" guards string-matched only `wsHost === '0.0.0.0'`,
so an IPv6 `::` (all-interfaces) bind slipped past them. (A valid token was still
required, so this was hardening rather than an exploit — but the inconsistency was
worth closing.)

- Added `isWildcardBind()` (`0.0.0.0` / `::` / `[::]`) and routed both guards
  through it.

## Test plan

- `packages/webui/tests/server/ws-auth.test.ts` — +7 cases (41 pass): `::`-bind
  deny parity, loopback-peer token admit, trusted-origin scheme requirement.
- `packages/tools/tests/win32-resolve.test.ts` — +4 cases (9 pass): metacharacter
  rejection, legitimate flags/paths accepted, non-string + empty no-ops.
- `exec`/`outdated` tool tests (34) green; `@wrongstack/tools` + `@wrongstack/webui`
  typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
