### PR TITLE
refactor(webui): extract prefs.* into 12th sibling route handler (#31)

### DIFF
--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -142,6 +142,7 @@ import { handleProviderRoute, type ProviderRouteHandlers } from './provider-rout
 import { handleSessionRoute, type SessionRouteHandlers } from './session-routes.js';
 import { handleProjectRoute, type ProjectRouteHandlers } from './project-routes.js';
 import { handleModeRoute, type ModeRouteHandlers } from './mode-routes.js';
+import { handlePrefsRoute, type PrefsRouteHandlers } from './prefs-routes.js';
 import { handleShellGitRoute, type ShellGitRouteHandlers } from './shell-git-routes.js';
 import { handleMailboxRoute, type MailboxRouteHandlers } from './mailbox-routes.js';
 import { handleBrainRoute, type BrainRouteHandlers } from './brain-routes.js';
@@ -1793,6 +1794,7 @@ export async function startWebUI(
   let sessionRoutes: SessionRouteHandlers;
   let projectRoutes: ProjectRouteHandlers;
   let modeRoutes: ModeRouteHandlers;
+  let prefsRoutes: PrefsRouteHandlers;
   let shellGitRoutes: ShellGitRouteHandlers;
   let mailboxRoutes: MailboxRouteHandlers;
   let brainRoutes: BrainRouteHandlers;
@@ -1810,6 +1812,7 @@ export async function startWebUI(
     if (await handleSessionRoute(ws, msg, sessionRoutes)) return;
     if (await handleProjectRoute(ws, msg, projectRoutes)) return;
     if (await handleModeRoute(ws, msg, modeRoutes)) return;
+    if (await handlePrefsRoute(ws, msg, prefsRoutes)) return;
     if (await handleShellGitRoute(ws, msg, shellGitRoutes)) return;
     if (await handleMailboxRoute(ws, msg, mailboxRoutes)) return;
     if (await handleBrainRoute(ws, msg, brainRoutes)) return;
@@ -2147,87 +2150,18 @@ export async function startWebUI(
       }
 
       case 'prefs.update': {
-        // Batch preference update from the webui. Merges arbitrary key/value
-        // pairs into context.meta so the runtime can read them immediately,
-        // broadcasts the full pref snapshot to every connected client so all
-        // browser tabs stay in sync, and persists the durable keys to
-        // config.json (same keys the TUI settings picker writes).
-        const parsed = validatePrefsUpdatePayload(msg.payload);
-        if (!parsed.ok) {
-          sendResult(ws, false, parsed.message);
-          break;
-        }
-        const payload = parsed.value.prefs;
-        // Write each pref into context.meta
-        for (const [key, val] of Object.entries(payload)) {
-          context.meta[key] = val;
-        }
-        void persistPrefsToConfig(payload);
-        // YOLO mode: toggle the permission policy so tool confirmations
-        // are auto-approved instead of prompting the user. Uses the live
-        // reference resolved from the container at startup.
-        if (typeof payload['yolo'] === 'boolean') {
-          permissionPolicy.setYolo?.(payload['yolo']);
-        }
-        // Also update config.features for feature flags that affect tool/skill
-        // initialisation (these were read at startup but can be changed at runtime
-        // by the agent's permission middleware or tool guards).
-        if (typeof payload['featureMcp'] === 'boolean')
-          config.features.mcp = payload['featureMcp'];
-        if (typeof payload['featurePlugins'] === 'boolean')
-          config.features.plugins = payload['featurePlugins'];
-        if (typeof payload['featureMemory'] === 'boolean')
-          config.features.memory = payload['featureMemory'];
-        if (typeof payload['featureSkills'] === 'boolean')
-          config.features.skills = payload['featureSkills'];
-        if (typeof payload['featureModelsRegistry'] === 'boolean')
-          config.features.modelsRegistry = payload['featureModelsRegistry'];
-
-        // Global fallback chain: mutate the live config so the leader's fallback
-        // extension (which reads config each turn) honours it without a restart.
-        if (Array.isArray(payload['fallbackModels']))
-          config.fallbackModels = payload['fallbackModels'] as string[];
-        if (typeof payload['fallbackAuto'] === 'boolean')
-          config.fallbackAuto = payload['fallbackAuto'];
-
-        // Runtime effects: apply prefs that change server behaviour immediately.
-
-        // contextAutoCompact — toggle AutoCompactionMiddleware in/out of the
-        // contextWindow pipeline. When off, the pipeline skips the compaction
-        // step entirely (zero overhead). When on, re-adds the middleware.
-        if (typeof payload['contextAutoCompact'] === 'boolean') {
-          if (payload['contextAutoCompact'] && autoCompactor) {
-            // Re-add: remove first (idempotent via optional), then insert.
-            pipelines.contextWindow.remove('AutoCompaction', { optional: true });
-            pipelines.contextWindow.use({ name: 'AutoCompaction', handler: autoCompactor.handler() });
-          } else {
-            pipelines.contextWindow.remove('AutoCompaction', { optional: true });
-          }
-        }
-
-        // logLevel — the DefaultLogger.level property is a public mutable
-        // field. Setting it at runtime changes the log threshold immediately
-        // (the log() method checks LEVEL_RANK on every call).
-        if (typeof payload['logLevel'] === 'string') {
-          const valid = ['debug', 'info', 'warn', 'error'] as const;
-          if ((valid as readonly string[]).includes(payload['logLevel'])) {
-            logger.level = payload['logLevel'] as typeof valid[number];
-          }
-        }
-
-        // auditLevel — stored in context.meta by the generic loop above.
-        // Consumed by the session audit log system at session-close time.
-
-        // Broadcast the full current prefs snapshot to ALL clients.
-        broadcast(clients, { type: 'prefs.updated', payload: prefSnapshot() });
-        break;
+        // Routed via handlePrefsRoute (see prefsRoutes = { ... } below) —
+        // the actual handler is `updatePrefs`. This case is unreachable but
+        // left as a tripwire for any future regression where the route
+        // chain stops claiming 'prefs.*'. If you see this fire, fix the
+        // dispatch order in the handleMessage chain above.
+        void ws;
+        throw new Error('handlePrefsRoute did not claim prefs.update — check chain order');
       }
 
       case 'prefs.get': {
-        // Return the current pref snapshot so a freshly-connected client
-        // can seed its local-prefs store from the server's truth.
-        send(ws, { type: 'prefs.updated', payload: prefSnapshot() });
-        break;
+        // Routed via handlePrefsRoute (see prefsRoutes = { ... } below).
+        throw new Error('handlePrefsRoute did not claim prefs.get — check chain order');
       }
 
       default:
@@ -2486,6 +2420,97 @@ export async function startWebUI(
     },
     sessionStartPayload,
   });
+
+  // ---- Prefs route (handlePrefsRoute) ----
+  // The standalone server's pref surface is richer than the CLI's embedded
+  // prefs.ts (issue #31 follow-on to #94–#110). We own the full set of
+  // runtime effects: YOLO toggle on permissionPolicy, feature-flag mutation
+  // on config.features, fallback chain update on config, AutoCompaction
+  // pipeline add/remove, logger.level mutation, and config.json persistence.
+  // Closure-captured dependencies stay here in index.ts; the dispatch layer
+  // (prefs-routes.ts) just calls these two functions.
+  prefsRoutes = {
+    getPrefs: async (ws) => {
+      // Return the current pref snapshot so a freshly-connected client
+      // can seed its local-prefs store from the server's truth.
+      send(ws, { type: 'prefs.updated', payload: prefSnapshot() });
+    },
+    updatePrefs: async (ws, msgPayload) => {
+      // Batch preference update from the webui. Merges arbitrary key/value
+      // pairs into context.meta so the runtime can read them immediately,
+      // broadcasts the full pref snapshot to every connected client so all
+      // browser tabs stay in sync, and persists the durable keys to
+      // config.json (same keys the TUI settings picker writes).
+      const parsed = validatePrefsUpdatePayload(msgPayload);
+      if (!parsed.ok) {
+        sendResult(ws, false, parsed.message);
+        return;
+      }
+      const payload = parsed.value.prefs;
+      // Write each pref into context.meta
+      for (const [key, val] of Object.entries(payload)) {
+        context.meta[key] = val;
+      }
+      void persistPrefsToConfig(payload);
+      // YOLO mode: toggle the permission policy so tool confirmations
+      // are auto-approved instead of prompting the user. Uses the live
+      // reference resolved from the container at startup.
+      if (typeof payload['yolo'] === 'boolean') {
+        permissionPolicy.setYolo?.(payload['yolo']);
+      }
+      // Also update config.features for feature flags that affect tool/skill
+      // initialisation (these were read at startup but can be changed at runtime
+      // by the agent's permission middleware or tool guards).
+      if (typeof payload['featureMcp'] === 'boolean')
+        config.features.mcp = payload['featureMcp'];
+      if (typeof payload['featurePlugins'] === 'boolean')
+        config.features.plugins = payload['featurePlugins'];
+      if (typeof payload['featureMemory'] === 'boolean')
+        config.features.memory = payload['featureMemory'];
+      if (typeof payload['featureSkills'] === 'boolean')
+        config.features.skills = payload['featureSkills'];
+      if (typeof payload['featureModelsRegistry'] === 'boolean')
+        config.features.modelsRegistry = payload['featureModelsRegistry'];
+
+      // Global fallback chain: mutate the live config so the leader's fallback
+      // extension (which reads config each turn) honours it without a restart.
+      if (Array.isArray(payload['fallbackModels']))
+        config.fallbackModels = payload['fallbackModels'] as string[];
+      if (typeof payload['fallbackAuto'] === 'boolean')
+        config.fallbackAuto = payload['fallbackAuto'];
+
+      // Runtime effects: apply prefs that change server behaviour immediately.
+
+      // contextAutoCompact — toggle AutoCompactionMiddleware in/out of the
+      // contextWindow pipeline. When off, the pipeline skips the compaction
+      // step entirely (zero overhead). When on, re-adds the middleware.
+      if (typeof payload['contextAutoCompact'] === 'boolean') {
+        if (payload['contextAutoCompact'] && autoCompactor) {
+          // Re-add: remove first (idempotent via optional), then insert.
+          pipelines.contextWindow.remove('AutoCompaction', { optional: true });
+          pipelines.contextWindow.use({ name: 'AutoCompaction', handler: autoCompactor.handler() });
+        } else {
+          pipelines.contextWindow.remove('AutoCompaction', { optional: true });
+        }
+      }
+
+      // logLevel — the DefaultLogger.level property is a public mutable
+      // field. Setting it at runtime changes the log threshold immediately
+      // (the log() method checks LEVEL_RANK on every call).
+      if (typeof payload['logLevel'] === 'string') {
+        const valid = ['debug', 'info', 'warn', 'error'] as const;
+        if ((valid as readonly string[]).includes(payload['logLevel'])) {
+          logger.level = payload['logLevel'] as typeof valid[number];
+        }
+      }
+
+      // auditLevel — stored in context.meta by the generic loop above.
+      // Consumed by the session audit log system at session-close time.
+
+      // Broadcast the full current prefs snapshot to ALL clients.
+      broadcast(clients, { type: 'prefs.updated', payload: prefSnapshot() });
+    },
+  };
 
   shellGitRoutes = {
     gitInfo: async (ws) => {

--- a/packages/webui/src/server/prefs-routes.ts
+++ b/packages/webui/src/server/prefs-routes.ts
@@ -1,0 +1,62 @@
+// Prefs WS-message routing — extracted from packages/webui/src/server/index.ts
+// (issue #31, follow-on to PRs #94–#110). The standalone server owns a richer
+// pref surface than the CLI's embedded ws-handlers/prefs.ts (which only knows
+// about YOLO/autonomy), so this module is a thin dispatch layer — the actual
+// logic stays in the index.ts closures (getPrefs/updatePrefs) that close over
+// the live boot context (config, context.meta, permissionPolicy, pipelines,
+// autoCompactor, logger). Mirrors the shape of the 11 sibling route handlers
+// already wired through `handleMessage`.
+//
+// Why callback injection (not the CLI's context-object style): the standalone
+// server has ~10 closure-captured dependencies the prefs handler reads (config
+// for feature-flag mutation, pipelines for AutoCompaction add/remove, logger
+// for runtime level, etc.) — bundling them into a PrefsContext interface
+// would duplicate state already living on index.ts. Two callbacks (one per
+// message type) keeps the contract minimal and avoids drift if any new
+// closure dependency is added.
+
+import type { WebSocket } from 'ws';
+import type { WSClientMessage } from './types.js';
+
+export interface PrefsRouteHandlers {
+  /** Respond to the WS client with the current pref snapshot. */
+  getPrefs: (ws: WebSocket) => Promise<void>;
+  /**
+   * Merge the supplied pref payload into context.meta, persist the durable
+   * keys to config.json, apply any runtime effects (YOLO toggle, feature-flag
+   * mutation, fallback chain update, AutoCompaction pipeline add/remove,
+   * logger.level), then broadcast the full current snapshot to all clients.
+   */
+  updatePrefs: (ws: WebSocket, payload: Record<string, unknown>) => Promise<void>;
+}
+
+/**
+ * Chain-of-responsibility dispatcher for the `prefs.*` WS message family.
+ * Returns `true` if the message was handled by this layer (so the caller's
+ * chain short-circuits), `false` if it should fall through to the next layer
+ * or the residual switch.
+ *
+ * Owned prefixes:
+ *   - `prefs.get`
+ *   - `prefs.update`
+ *
+ * Regression-tested by packages/webui/tests/server/dispatcher-routing.test.ts.
+ */
+export async function handlePrefsRoute(
+  ws: WebSocket,
+  msg: WSClientMessage,
+  handlers: PrefsRouteHandlers,
+): Promise<boolean> {
+  switch (msg.type) {
+    case 'prefs.get': {
+      await handlers.getPrefs(ws);
+      return true;
+    }
+    case 'prefs.update': {
+      await handlers.updatePrefs(ws, (msg.payload ?? {}) as Record<string, unknown>);
+      return true;
+    }
+    default:
+      return false;
+  }
+}

--- a/packages/webui/tests/server/dispatcher-routing.test.ts
+++ b/packages/webui/tests/server/dispatcher-routing.test.ts
@@ -33,6 +33,7 @@ import { handleProviderRoute } from '../../src/server/provider-routes.js';
 import { handleSessionRoute } from '../../src/server/session-routes.js';
 import { handleProjectRoute } from '../../src/server/project-routes.js';
 import { handleModeRoute } from '../../src/server/mode-routes.js';
+import { handlePrefsRoute } from '../../src/server/prefs-routes.js';
 import { handleShellGitRoute } from '../../src/server/shell-git-routes.js';
 import { handleMailboxRoute } from '../../src/server/mailbox-routes.js';
 import { handleBrainRoute } from '../../src/server/brain-routes.js';
@@ -164,6 +165,41 @@ describe('WS message dispatcher routing (Issue #31 PR 0)', () => {
     const out = await handleModeRoute(ws, { type: FOREIGN }, {
       listModes: vi.fn(),
       switchMode: vi.fn(),
+    } as never);
+    expect(out).toBe(false);
+  });
+
+  // ── PrefsRouteHandlers ─────────────────────────────────────────────
+  // Issue #31 follow-on (extracted from index.ts as the 12th sibling).
+  // Two callbacks only — `getPrefs` and `updatePrefs` — because the
+  // standalone server's pref logic is rich enough that bundling 10+
+  // closure-captured dependencies into a single PrefsContext would
+  // duplicate state already living on index.ts.
+  it('handlePrefsRoute: claims prefs.get; rejects foreign', async () => {
+    const getPrefs = vi.fn();
+    const out = await handlePrefsRoute(ws, { type: 'prefs.get' }, {
+      getPrefs,
+      updatePrefs: vi.fn(),
+    } as never);
+    expect(out).toBe(true);
+    expect(getPrefs).toHaveBeenCalledOnce();
+  });
+
+  it('handlePrefsRoute: claims prefs.update; rejects foreign', async () => {
+    const updatePrefs = vi.fn();
+    const out = await handlePrefsRoute(ws, { type: 'prefs.update', payload: { yolo: true } }, {
+      getPrefs: vi.fn(),
+      updatePrefs,
+    } as never);
+    expect(out).toBe(true);
+    expect(updatePrefs).toHaveBeenCalledOnce();
+    expect(updatePrefs).toHaveBeenCalledWith(ws, { yolo: true });
+  });
+
+  it('handlePrefsRoute: returns false for foreign message type', async () => {
+    const out = await handlePrefsRoute(ws, { type: FOREIGN }, {
+      getPrefs: vi.fn(),
+      updatePrefs: vi.fn(),
     } as never);
     expect(out).toBe(false);
   });


### PR DESCRIPTION
# Extract `prefs.{get,update}` into the 12th sibling route handler (#31)

Following the active pattern set by PRs **#94–#110** (case-group extractions into sibling route modules), this lifts the standalone server's `prefs.*` logic out of the residual switch in `server/index.ts` into its own sibling: **`packages/webui/src/server/prefs-routes.ts`**.

## What's extracted

- **`prefs.get`** — sends the current `prefSnapshot()` to the WS client.
- **`prefs.update`** — validates the payload (`validatePrefsUpdatePayload`), merges into `context.meta`, persists durable keys to `config.json`, applies runtime effects (YOLO toggle on `permissionPolicy`, feature-flag mutation on `config.features`, fallback-chain update on `config`, AutoCompaction pipeline add/remove, `logger.level` mutation), then broadcasts the full current snapshot to every connected client.

The dispatch chain in `index.ts:1807–1822` now walks **12 handlers** before falling through to the residual switch. Order matches import order: `provider → session → project → mode → prefs → shell-git → mailbox → brain → autophase → specs → sdd-board → sdd-wizard`.

## Why a new module (vs. reusing the CLI's `prefs.ts`)

The CLI's `packages/cli/src/webui-server/ws-handlers/prefs.ts` (from PR 5f of issue #30) already implements `prefs.get`, `prefs.update`, and `handleAutonomySwitch` — but only for **YOLO/autonomy**. The standalone server owns a much richer pref surface (5 feature flags, fallback chain, AutoCompaction pipeline mutation, logger level mutation, ~12 prefs keys persisted to `config.json`'s `autonomy` block + top-level `nextPrediction`/`fallbackModels`). Diverging the implementations via a single shared `PrefsContext` interface would mean bundling ~10 closure-captured dependencies into a context object — duplicate state already living on `index.ts`.

Two callbacks per message type (`getPrefs`, `updatePrefs`) keeps the contract minimal and lets the rich logic stay inline in `index.ts` where it can close over `permissionPolicy`, `pipelines`, `autoCompactor`, `logger`, `config`, `context.meta`, etc. The new module is ~60 lines of dispatch + interface, ~95 lines of inline arrow functions on the `index.ts` side. Net change: **−78 lines of switch arms, +201 lines (mostly comments and the new module)**.

## Behavioral preservation

Every side-effect that the old `case 'prefs.update'` arm performed is preserved in the new `updatePrefs` closure:

- ✅ Merge each pref key/value into `context.meta`
- ✅ Persist durable keys to `config.json` via `persistPrefsToConfig`
- ✅ YOLO toggle on `permissionPolicy.setYolo`
- ✅ Feature flags on `config.features.{mcp,plugins,memory,skills,modelsRegistry}`
- ✅ Fallback chain on `config.fallbackModels` + `config.fallbackAuto`
- ✅ `AutoCompaction` middleware add/remove on `pipelines.contextWindow`
- ✅ `logger.level` mutation (validates against `['debug','info','warn','error']`)
- ✅ Broadcast `prefs.updated` snapshot to all clients

The two former `case 'prefs.{get,update}'` arms in the residual switch are replaced with **tripwire `throw new Error` blocks** that fail fast if the chain ever stops claiming `prefs.*`. That converts a silent regression (message falls through to the residual switch's `default:` arm → "Unknown message type") into a loud crash with an actionable error message.

## Tests

`packages/webui/tests/server/dispatcher-routing.test.ts` (the PR 0 baseline from #118) is extended with **3 new tests**:

- `handlePrefsRoute: claims prefs.get; rejects foreign` — verifies `getPrefs` callback invoked
- `handlePrefsRoute: claims prefs.update; rejects foreign` — verifies `updatePrefs` invoked with the right `ws` and payload
- `handlePrefsRoute: returns false for foreign message type` — verifies chain fall-through

All **25 dispatcher tests pass** (was 22 + 3 new).

## Validation

| Check | Result |
|---|---|
| `pnpm --filter @wrongstack/webui typecheck` | **clean** |
| `pnpm --filter @wrongstack/webui test` | **110 test files / 1726+ tests passing, 0 failures** (after `pnpm --filter @wrongstack/tools build` — the tools dist was stale from other agents' WIP) |
| `git diff --stat main` (this branch) | +1 new module (`prefs-routes.ts`), 5 hunks in `index.ts`, +36 lines in `dispatcher-routing.test.ts` |

## Files

- `packages/webui/src/server/prefs-routes.ts` (new, +63 lines)
- `packages/webui/src/server/index.ts` (+103 / −78)
- `packages/webui/tests/server/dispatcher-routing.test.ts` (+36 / −0)

Refs #31 (follow-on extraction; pairs with #118 the PR 0 baseline).
