### PR TITLE
refactor(webui): shared agent-status helpers (dedupe Fleet sort/count)

### DIFF
--- a/packages/webui/src/components/FleetMonitor.tsx
+++ b/packages/webui/src/components/FleetMonitor.tsx
@@ -34,6 +34,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ConcurrencyGauge, EventTimeline } from '@/components/ui';
 import { SparklineChart } from '@/components/ui/sparkline';
 import { cn } from '@/lib/utils';
+import { compareAgentsByActivity, tallyAgents } from '@/lib/agent-status';
 import type { SubagentView } from '@/stores';
 import { useFleetStore } from '@/stores';
 
@@ -504,11 +505,7 @@ export function FleetMonitor({
       // Leader first
       if (x.id === leaderId) return -1;
       if (y.id === leaderId) return 1;
-      // Running before done
-      const xa = x.status === 'running' ? 0 : 1;
-      const ya = y.status === 'running' ? 0 : 1;
-      if (xa !== ya) return xa - ya;
-      return x.startedAt - y.startedAt;
+      return compareAgentsByActivity(x, y);
     });
     return arr;
   }, [fleetAgents, leaderId]);
@@ -518,7 +515,7 @@ export function FleetMonitor({
     [fleetAgents],
   );
 
-  const runningCount = fleetList.filter((a) => a.status === 'running').length;
+  const runningCount = tallyAgents(fleetList).running;
   const selectedAgent = selectedIdx !== null ? fleetList[selectedIdx] : null;
 
   const handleAgentClick = useCallback(

--- a/packages/webui/src/components/FleetPanel.tsx
+++ b/packages/webui/src/components/FleetPanel.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils';
 import { type SubagentView, useFleetStore } from '@/stores';
+import { compareAgentsByActivity, tallyAgents } from '@/lib/agent-status';
 import { Bot, Check, ChevronDown, ChevronRight, Clock, Copy, Cpu, Crown, Wrench, X, Zap } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { SparklineChart } from '@/components/ui/sparkline';
@@ -419,12 +420,7 @@ export function FleetPanel({
 
   const list = useMemo(() => {
     const arr = Array.from(agents.values());
-    arr.sort((x, y) => {
-      const xa = x.status === 'running' ? 0 : 1;
-      const ya = y.status === 'running' ? 0 : 1;
-      if (xa !== ya) return xa - ya;
-      return x.startedAt - y.startedAt;
-    });
+    arr.sort(compareAgentsByActivity);
     return arr;
   }, [agents]);
 
@@ -432,9 +428,7 @@ export function FleetPanel({
 
   if (list.length === 0) return null;
 
-  const running = list.filter((a) => a.status === 'running');
-  const done = list.filter((a) => a.status === 'completed');
-  const failed = list.filter((a) => a.status === 'failed' || a.status === 'timeout');
+  const tally = tallyAgents(list);
   const totalCost = list.reduce((sum, a) => sum + (a.costUsd ?? 0), 0);
 
   // Auto-expand when small fleet; collapse when large
@@ -458,17 +452,17 @@ export function FleetPanel({
 
           {/* Compact summary pills */}
           <span className="flex items-center gap-1.5 ml-auto text-[10px]">
-            {running.length > 0 && (
+            {tally.running > 0 && (
               <span className="flex items-center gap-1 text-[hsl(var(--success))]">
                 <span className="led led-pulse text-[hsl(var(--success))]" />
-                {running.length}
+                {tally.running}
               </span>
             )}
-            {done.length > 0 && (
-              <span className="text-muted-foreground">{done.length} done</span>
+            {tally.completed > 0 && (
+              <span className="text-muted-foreground">{tally.completed} done</span>
             )}
-            {failed.length > 0 && (
-              <span className="text-destructive">{failed.length} err</span>
+            {tally.failed > 0 && (
+              <span className="text-destructive">{tally.failed} err</span>
             )}
             {totalCost > 0 && (
               <span className="tabular text-foreground/70">{fmtCost(totalCost)}</span>

--- a/packages/webui/src/lib/agent-status.ts
+++ b/packages/webui/src/lib/agent-status.ts
@@ -1,0 +1,70 @@
+/**
+ * agent-status — shared, presentation-agnostic helpers for in-process subagent
+ * (`SubagentView`) state.
+ *
+ * The Fleet surfaces (FleetMonitor, FleetPanel) each hand-rolled the same
+ * "running-first" sort, the same status counts, and the same `status ===
+ * 'running'` active check. This module is the single source for that pure logic
+ * so the surfaces stop drifting.
+ *
+ * Deliberately NOT here: the per-surface visual status maps. FleetMonitor uses
+ * the tailwind palette (`bg-emerald-500`) while FleetPanel uses CSS-var tokens
+ * (`text-[hsl(var(--success))]`); unifying those would change rendered colors,
+ * so each surface keeps its own color map. Only the canonical short labels
+ * (identical across surfaces) live here.
+ */
+
+import type { SubagentView } from '@/stores';
+
+export type AgentStatus = SubagentView['status'];
+
+/** Canonical short label per status (shared by the Fleet surfaces). */
+export const AGENT_STATUS_LABEL: Record<AgentStatus, string> = {
+  running: 'running',
+  completed: 'done',
+  failed: 'failed',
+  timeout: 'timeout',
+  stopped: 'stopped',
+};
+
+/** A subagent is "active" only while running. */
+export function isAgentActive(status: string): boolean {
+  return status === 'running';
+}
+
+/**
+ * Sort comparator: running agents first, then oldest-started first. Generic over
+ * anything carrying `status` + `startedAt` so both the store's `SubagentView` and
+ * lighter row shapes can use it. Callers that pin a leader to the top should
+ * apply that special-case before delegating here.
+ */
+export function compareAgentsByActivity<T extends { status: string; startedAt: number }>(
+  a: T,
+  b: T,
+): number {
+  const aActive = isAgentActive(a.status) ? 0 : 1;
+  const bActive = isAgentActive(b.status) ? 0 : 1;
+  if (aActive !== bActive) return aActive - bActive;
+  return a.startedAt - b.startedAt;
+}
+
+export interface AgentTally {
+  running: number;
+  completed: number;
+  /** failed + timeout — the two terminal-error states the Fleet UIs group. */
+  failed: number;
+  total: number;
+}
+
+/** Count agents by activity bucket (running / completed / failed-or-timeout). */
+export function tallyAgents<T extends { status: string }>(list: readonly T[]): AgentTally {
+  let running = 0;
+  let completed = 0;
+  let failed = 0;
+  for (const a of list) {
+    if (a.status === 'running') running++;
+    else if (a.status === 'completed') completed++;
+    else if (a.status === 'failed' || a.status === 'timeout') failed++;
+  }
+  return { running, completed, failed, total: list.length };
+}

--- a/packages/webui/tests/lib/agent-status.test.ts
+++ b/packages/webui/tests/lib/agent-status.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_STATUS_LABEL,
+  compareAgentsByActivity,
+  isAgentActive,
+  tallyAgents,
+} from '../../src/lib/agent-status.js';
+
+const mk = (status: string, startedAt: number) => ({ status, startedAt });
+
+describe('agent-status helpers', () => {
+  it('isAgentActive is true only for running', () => {
+    expect(isAgentActive('running')).toBe(true);
+    for (const s of ['completed', 'failed', 'timeout', 'stopped', 'idle']) {
+      expect(isAgentActive(s)).toBe(false);
+    }
+  });
+
+  it('AGENT_STATUS_LABEL maps completed → done and passes others through', () => {
+    expect(AGENT_STATUS_LABEL.completed).toBe('done');
+    expect(AGENT_STATUS_LABEL.running).toBe('running');
+    expect(AGENT_STATUS_LABEL.failed).toBe('failed');
+    expect(AGENT_STATUS_LABEL.timeout).toBe('timeout');
+    expect(AGENT_STATUS_LABEL.stopped).toBe('stopped');
+  });
+
+  it('compareAgentsByActivity puts running first, then oldest-started', () => {
+    const list = [
+      mk('completed', 100),
+      mk('running', 300),
+      mk('running', 200),
+      mk('failed', 50),
+    ];
+    const sorted = [...list].sort(compareAgentsByActivity);
+    // Running agents first; within each bucket, oldest-started first.
+    expect(sorted.map((a) => `${a.status}@${a.startedAt}`)).toEqual([
+      'running@200',
+      'running@300',
+      'failed@50',
+      'completed@100',
+    ]);
+  });
+
+  it('tallyAgents buckets running / completed / failed(+timeout) and total', () => {
+    const t = tallyAgents([
+      mk('running', 1),
+      mk('running', 2),
+      mk('completed', 3),
+      mk('failed', 4),
+      mk('timeout', 5),
+      mk('stopped', 6),
+    ]);
+    expect(t).toEqual({ running: 2, completed: 1, failed: 2, total: 6 });
+  });
+
+  it('tallyAgents on an empty list is all zeros', () => {
+    expect(tallyAgents([])).toEqual({ running: 0, completed: 0, failed: 0, total: 0 });
+  });
+});


### PR DESCRIPTION
Batch 5c of the WebUI improvement plan (state simplification), scoped to the safe, behavior-preserving part.

## What
`FleetMonitor` and `FleetPanel` each hand-rolled the same logic over `SubagentView`:
- the "running-first, then oldest-started" sort comparator,
- the running/done/failed counts,
- the `status === 'running'` active check.

Extracted into `packages/webui/src/lib/agent-status.ts` (`isAgentActive`, `compareAgentsByActivity`, `tallyAgents`, `AGENT_STATUS_LABEL`) with unit tests; both surfaces now import them.

## Deliberately NOT done (would be net-negative)
- **Merging the three "agent" stores** — `fleet` (in-process subagents), `monitor` (cross-process live sessions), and `viz` (event-graph nodes) are purpose-distinct, fed by different WS streams; they are not duplicates.
- **Unifying the per-surface visual `STATUS_META` maps** — FleetMonitor uses the tailwind palette (`bg-emerald-500`), FleetPanel uses CSS-var tokens (`text-[hsl(var(--success))]`); unifying would change rendered colors (unverifiable here). Pure logic only → behavior-preserving.

## Verification
Built/verified in the main tree before the source branch (#124/#125) merged: webui typecheck clean, full webui suite green (1784), new `tests/lib/agent-status.test.ts` (5 cases) green, biome clean. Delivered via an isolated git worktree off the post-merge `main` (the concurrent process was churning the primary working tree); cherry-pick applied with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)