### PR TITLE
fix(webui): AutoPhase stop actually halts + clear/new/revert lifecycle

### DIFF
--- a/packages/webui/src/App.tsx
+++ b/packages/webui/src/App.tsx
@@ -388,8 +388,13 @@ function AppInner() {
             {/* WorkspaceDock — one slim chip strip (AutoPhase, Goal, Fleet,
                 Work, Worktrees, Collab); at most one panel expands below it
                 instead of the old always-on vertical pile. */}
+            {/* shrink-0 + capped height + own scroll: an expanded dock section
+                (Work tasks, Fleet, AutoPhase board, …) must never grow tall
+                enough to push the chat transcript off-screen and kill its
+                scroll. The dock scrolls internally past the cap; ChatView keeps
+                the remaining height as its own scroll region. */}
             {sessionId && (
-              <div className="px-4 pt-2">
+              <div className="px-4 pt-2 shrink-0 max-h-[45vh] overflow-y-auto">
                 <WorkspaceDock sessionId={sessionId} />
               </div>
             )}

--- a/packages/webui/src/components/AutoPhaseView.tsx
+++ b/packages/webui/src/components/AutoPhaseView.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 import { BoardView } from './BoardView';
 import { WorktreeGraph } from './WorktreeGraph';
 import { WorktreeLanes } from './WorktreeLanes';
-import { Layers, Loader2, Pause, Play, Rocket, Square, X, Zap } from 'lucide-react';
+import { Layers, Loader2, Pause, Play, Plus, Rocket, Square, Undo2, X, Zap } from 'lucide-react';
 import { Button } from './ui/button';
 
 /**
@@ -88,7 +88,24 @@ export function AutoPhaseView({ onClose }: { onClose: () => void }): React.React
     client?.send?.({ type: 'autophase.stop', payload: {} });
   }, [client]);
 
+  // Reset to an empty board and start fresh. Clears locally too so the start
+  // screen shows immediately, even before the server's cleared state arrives.
+  const handleNew = useCallback(() => {
+    client?.send?.({ type: 'autophase.clear', payload: {} });
+    useAutoPhaseStore.getState().clear();
+    setPlanningGoal(null);
+    setGoal('');
+  }, [client]);
+
+  const [confirmRevert, setConfirmRevert] = useState(false);
+  const handleRevert = useCallback(() => {
+    client?.send?.({ type: 'autophase.revert', payload: {} });
+    setConfirmRevert(false);
+  }, [client]);
+
   const isLive = status === 'running' || status === 'paused';
+  // A finished/halted run: offer New (reset) and Revert (undo the run's commits).
+  const isDone = status === 'stopped' || status === 'completed' || status === 'failed';
 
   const handleSelectBoard = useCallback(
     (graphId: string) => {
@@ -183,6 +200,46 @@ export function AutoPhaseView({ onClose }: { onClose: () => void }): React.React
               >
                 <Square className="h-3.5 w-3.5 fill-current" /> Stop
               </button>
+            </>
+          )}
+          {hasPhases && isDone && (
+            <>
+              <button
+                type="button"
+                onClick={handleNew}
+                title="Clear this board and start a new AutoPhase run"
+                className="inline-flex items-center gap-1 rounded border border-primary/30 bg-primary/10 px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+              >
+                <Plus className="h-3.5 w-3.5" /> New
+              </button>
+              {confirmRevert ? (
+                <span className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-xs">
+                  <span className="text-amber-700 dark:text-amber-300">Revert run's commits?</span>
+                  <button
+                    type="button"
+                    onClick={handleRevert}
+                    className="rounded bg-destructive/15 px-1.5 py-0.5 font-medium text-destructive hover:bg-destructive/25"
+                  >
+                    Yes
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmRevert(false)}
+                    className="rounded px-1.5 py-0.5 text-muted-foreground hover:text-foreground"
+                  >
+                    No
+                  </button>
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setConfirmRevert(true)}
+                  title="Undo this run — git-revert the commits it landed and remove its worktrees"
+                  className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <Undo2 className="h-3.5 w-3.5" /> Revert
+                </button>
+              )}
             </>
           )}
           <Button variant="ghost" size="icon" onClick={onClose}>

--- a/packages/webui/src/hooks/ws-handlers/misc-handlers.ts
+++ b/packages/webui/src/hooks/ws-handlers/misc-handlers.ts
@@ -69,6 +69,23 @@ export function handleAutoPhaseLifecycle(msg: WSServerMessage) {
     toast.warn('AutoPhase stopped');
     return;
   }
+  if (msg.type === 'autophase.cleared') {
+    // Reset to an empty board → the view falls back to the goal-entry screen.
+    useAutoPhaseStore.getState().clear();
+    return;
+  }
+  if (msg.type === 'autophase.reverted') {
+    const ok = (p as { ok?: boolean }).ok === true;
+    const reverted = typeof p.reverted === 'number' ? p.reverted : 0;
+    const reason = typeof p.reason === 'string' ? p.reason : undefined;
+    if (ok) {
+      toast.success(reverted > 0 ? `Reverted ${reverted} commit${reverted === 1 ? '' : 's'}` : 'Nothing to revert');
+    } else {
+      toast.error(`Revert failed: ${reason ?? 'unknown error'}`);
+    }
+    useAutoPhaseStore.getState().setState({ lastEvent: 'reverted' });
+    return;
+  }
   if (msg.type === 'autophase.saved') {
     useAutoPhaseStore.getState().setState({ lastEvent: 'saved' });
     toast.success('AutoPhase graph saved');
@@ -319,6 +336,8 @@ export const miscHandlerMap: Partial<Record<string, (msg: WSServerMessage) => vo
   'autophase.paused': handleAutoPhaseLifecycle,
   'autophase.resumed': handleAutoPhaseLifecycle,
   'autophase.stopped': handleAutoPhaseLifecycle,
+  'autophase.cleared': handleAutoPhaseLifecycle,
+  'autophase.reverted': handleAutoPhaseLifecycle,
   'autophase.saved': handleAutoPhaseLifecycle,
   'autophase.completed': handleAutoPhaseLifecycle,
   'autophase.failed': handleAutoPhaseLifecycle,

--- a/packages/webui/src/server/autophase-ws-handler.ts
+++ b/packages/webui/src/server/autophase-ws-handler.ts
@@ -39,6 +39,25 @@ function isGitRepo(cwd: string): boolean {
   }
 }
 
+/**
+ * List the commits on `branch` since `baseSha` (oldest → newest, the order they
+ * landed). Used by `autophase.revert` to feed WorktreeManager.revertCommits,
+ * which reverses them. Returns [] on any git error.
+ */
+function commitsSince(cwd: string, baseSha: string, branch: string): string[] {
+  try {
+    const r = spawnSync('git', ['log', '--reverse', '--format=%H', `${baseSha}..${branch}`], {
+      cwd,
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    if (r.status !== 0) return [];
+    return r.stdout.split('\n').map((s) => s.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 interface WSClient {
   ws: WebSocket;
   id: string;
@@ -67,10 +86,17 @@ export class AutoPhaseWebSocketHandler {
   private store: PhaseStore;
   private clients = new Set<WSClient>();
   private broadcastInterval: ReturnType<typeof setInterval> | null = null;
-  /** Aborts in-flight task agents when the run is stopped. */
+  /** Aborts in-flight task agents AND the planning turn when the run is stopped. */
   private abort: AbortController | null = null;
+  /** Set the instant a stop/clear/revert is requested, so a planning turn that
+   *  resolves afterwards never launches the orchestrator (the abort alone can't
+   *  cover the window between the LLM call resolving and the orchestrator start). */
+  private stopping = false;
   /** Optional per-phase git-worktree isolation (lazily created at start). */
   private worktrees: WorktreeManager | null = null;
+  /** Base branch + tip SHA captured at run start so a revert can git-revert the
+   *  run's squash commits (history-preserving) instead of a destructive reset. */
+  private runBase: { branch: string; sha: string } | null = null;
   /** Per-run worker identities so the board can show "who is on what". */
   private usedNicknames = new Set<string>();
 
@@ -110,11 +136,13 @@ export class AutoPhaseWebSocketHandler {
         this.broadcast({ type: 'autophase.resumed', payload: {} });
         break;
       case 'autophase.stop':
-        this.abort?.abort();
-        this.orchestrator?.stop();
-        this.stopBroadcast();
-        if (this.graph) void this.store.save(this.graph);
-        this.broadcast({ type: 'autophase.stopped', payload: {} });
+        await this.handleStop();
+        break;
+      case 'autophase.clear':
+        await this.handleClear();
+        break;
+      case 'autophase.revert':
+        await this.handleRevert();
         break;
       case 'autophase.status':
         this.broadcastState();
@@ -210,13 +238,28 @@ export class AutoPhaseWebSocketHandler {
     const title = deriveTitle(goal);
     const autonomous = (payload?.autonomous as boolean) ?? true;
 
+    // Fresh abort for THIS run, created BEFORE planning so a stop pressed during
+    // the (long) planning turn actually cancels it. Previously the controller was
+    // created only after planning, so a stop while "starting" was a no-op and the
+    // run launched anyway.
+    this.abort = new AbortController();
+    this.stopping = false;
+
     // Phase plan resolution:
     //   1. explicit phases in the payload win (caller override);
     //   2. otherwise the LLM plans phases+todos for the goal;
     //   3. failing that, fall back to the generic default phases.
     const phases = Array.isArray(payload?.phases)
       ? (payload.phases as PhaseTemplate[])
-      : await this.planPhases(goal);
+      : await this.planPhases(goal, this.abort.signal);
+
+    // Stop requested during planning → never launch the orchestrator. The abort
+    // may not have interrupted the in-flight LLM call promptly, so the `stopping`
+    // flag is the authoritative guard for the resolve-after-stop window.
+    if (this.stopping || this.abort.signal.aborted) {
+      this.broadcast({ type: 'autophase.stopped', payload: { title } });
+      return;
+    }
 
     this.logger.info(`[AutoPhase] Starting: ${title}`);
 
@@ -224,7 +267,6 @@ export class AutoPhaseWebSocketHandler {
     // persistence *before* the (long-running) build begins.
     const graph = await new PhaseGraphBuilder({ title, description: goal, phases, autonomous }).build();
     this.graph = graph;
-    this.abort = new AbortController();
     await this.store.save(graph);
 
     // Per-phase git-worktree isolation, when enabled and inside a git repo.
@@ -240,6 +282,11 @@ export class AutoPhaseWebSocketHandler {
       isGitRepo(this.projectRoot)
     ) {
       this.worktrees = new WorktreeManager({ projectRoot: this.projectRoot, events: this.events });
+    }
+    // Capture the pre-run base tip so `autophase.revert` can git-revert exactly
+    // the commits this run lands on the base branch.
+    if (this.worktrees) {
+      this.runBase = await this.worktrees.currentBase();
     }
 
     // NOTE: this interactive-board orchestrator deliberately omits the CLI host's
@@ -309,6 +356,66 @@ export class AutoPhaseWebSocketHandler {
       });
   }
 
+  /**
+   * Halt the run NOW — at any phase. Sets `stopping` (so a planning turn that
+   * resolves afterwards bails), aborts in-flight agents, stops the orchestrator
+   * tick, and ends the live broadcast. The board is kept for review; use
+   * `autophase.clear` to reset or `autophase.revert` to undo the changes.
+   */
+  private async handleStop(): Promise<void> {
+    this.stopping = true;
+    this.abort?.abort();
+    this.orchestrator?.stop();
+    this.stopBroadcast();
+    if (this.graph) await this.store.save(this.graph).catch(() => undefined);
+    this.broadcast({ type: 'autophase.stopped', payload: { title: this.graph?.title } });
+  }
+
+  /**
+   * Stop + wipe: tear down phase worktrees and reset to an empty board so the UI
+   * returns to the start screen ("new one"). Does NOT touch already-merged commits
+   * on the base branch — that is `autophase.revert`.
+   */
+  private async handleClear(): Promise<void> {
+    await this.handleStop();
+    if (this.worktrees) await this.worktrees.cleanupAllManaged().catch(() => undefined);
+    this.orchestrator = null;
+    this.graph = null;
+    this.runBase = null;
+    this.usedNicknames.clear();
+    this.broadcast({ type: 'autophase.cleared', payload: {} });
+    // Empty state → board/wizard falls back to the goal-entry screen.
+    this.broadcast({ type: 'autophase.state', payload: this.buildState() });
+  }
+
+  /**
+   * Stop + undo: remove phase worktrees, then history-preservingly `git revert`
+   * every commit this run landed on the base branch (captured `runBase`..HEAD),
+   * then reset to an empty board. Refuses (reports a reason) on a dirty tree or a
+   * conflicting revert rather than leaving the tree half-reverted.
+   */
+  private async handleRevert(): Promise<void> {
+    await this.handleStop();
+    if (!this.worktrees || !this.runBase || !this.projectRoot) {
+      this.broadcast({
+        type: 'autophase.reverted',
+        payload: { ok: false, reverted: 0, reason: 'no git baseline was captured for this run' },
+      });
+      return;
+    }
+    await this.worktrees.cleanupAllManaged().catch(() => undefined);
+    const shas = commitsSince(this.projectRoot, this.runBase.sha, this.runBase.branch);
+    const res = await this.worktrees.revertCommits(this.runBase.branch, shas);
+    this.broadcast({ type: 'autophase.reverted', payload: res });
+    if (res.ok) {
+      this.orchestrator = null;
+      this.graph = null;
+      this.runBase = null;
+      this.broadcast({ type: 'autophase.cleared', payload: {} });
+      this.broadcast({ type: 'autophase.state', payload: this.buildState() });
+    }
+  }
+
   /** Generic fallback phases when the LLM planner produces nothing usable. */
   private defaultPhases(): PhaseTemplate[] {
     return [
@@ -320,13 +427,18 @@ export class AutoPhaseWebSocketHandler {
     ];
   }
 
-  /** Plan phases+todos for the goal via the LLM; fall back to defaults on failure. */
-  private async planPhases(goal: string): Promise<PhaseTemplate[]> {
+  /** Plan phases+todos for the goal via the LLM; fall back to defaults on failure.
+   *  The caller passes the run's abort signal so a stop during planning cancels
+   *  the LLM turn (the previous fresh, never-aborted controller made planning
+   *  uninterruptible). */
+  private async planPhases(goal: string, signal?: AbortSignal): Promise<PhaseTemplate[]> {
     try {
       const planner = new AutoPhasePlanner({
         goal,
         runOnce: async (prompt) => {
-          const result = (await this.agent.run(prompt, { signal: new AbortController().signal })) as {
+          const result = (await this.agent.run(prompt, {
+            signal: signal ?? new AbortController().signal,
+          })) as {
             status: string;
             finalText?: string | undefined;
           };

--- a/packages/webui/src/types.ts
+++ b/packages/webui/src/types.ts
@@ -749,7 +749,9 @@ export interface WSAutoPhaseLifecycle {
     | 'autophase.saved'
     | 'autophase.completed'
     | 'autophase.failed'
-    | 'autophase.error';
+    | 'autophase.error'
+    | 'autophase.cleared'
+    | 'autophase.reverted';
   payload: Record<string, unknown>;
 }
 
@@ -832,6 +834,8 @@ export type WSClientMessage =
   | { type: 'autophase.pause'; payload: Record<string, never> }
   | { type: 'autophase.resume'; payload: Record<string, never> }
   | { type: 'autophase.stop'; payload: Record<string, never> }
+  | { type: 'autophase.clear'; payload?: Record<string, never> }
+  | { type: 'autophase.revert'; payload?: Record<string, never> }
   | { type: 'autophase.status'; payload?: Record<string, never> }
   | { type: 'autophase.save'; payload?: Record<string, never> }
   | { type: 'autophase.list'; payload?: Record<string, never> }

--- a/packages/webui/tests/server/autophase-lifecycle.test.ts
+++ b/packages/webui/tests/server/autophase-lifecycle.test.ts
@@ -1,0 +1,91 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AutoPhaseWebSocketHandler } from '../../src/server/autophase-ws-handler.js';
+
+/** Minimal fake WS that records every JSON message the handler sends. */
+function mockWs() {
+  return {
+    readyState: 1,
+    send: vi.fn(),
+    on: vi.fn(),
+  } as never as import('ws').WebSocket & { send: ReturnType<typeof vi.fn> };
+}
+
+function sentTypes(ws: { send: ReturnType<typeof vi.fn> }): string[] {
+  return ws.send.mock.calls.map(([raw]) => (JSON.parse(String(raw)) as { type: string }).type);
+}
+
+const fakeLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+const fakeContext = { cwd: os.tmpdir() } as never;
+
+function makeHandler(agentRun: () => Promise<unknown>) {
+  const agent = { run: vi.fn(agentRun) } as never;
+  const storeDir = path.join(os.tmpdir(), `ap-lifecycle-${Math.random().toString(36).slice(2)}`);
+  // No events / projectRoot → no git worktrees (keeps the test hermetic).
+  return new AutoPhaseWebSocketHandler(agent, fakeContext, fakeLogger, storeDir);
+}
+
+describe('AutoPhaseWebSocketHandler lifecycle', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('stop during planning never launches the orchestrator', async () => {
+    // Planning resolves only after we release it — simulating an in-flight LLM
+    // turn during which the user hits Stop.
+    let release: (v: unknown) => void = () => {};
+    const planning = new Promise((r) => {
+      release = r;
+    });
+    const h = makeHandler(async () => {
+      await planning;
+      return { status: 'done', finalText: 'not parseable json' };
+    });
+    const ws = mockWs();
+    h.addClient(ws);
+
+    // Start (do NOT await — it suspends inside planPhases), then Stop, then let
+    // planning resolve and the start settle.
+    const startP = h.handleMessage({ type: 'autophase.start', payload: { title: 'demo' } });
+    await h.handleMessage({ type: 'autophase.stop', payload: {} });
+    release(undefined);
+    await startP;
+
+    const types = sentTypes(ws);
+    expect(types).toContain('autophase.stopped');
+    // The run must NOT have started: no completion and no board state with phases.
+    expect(types).not.toContain('autophase.completed');
+    const startedBoard = ws.send.mock.calls
+      .map(([raw]) => JSON.parse(String(raw)) as { type: string; payload?: { phases?: unknown[] } })
+      .some((m) => m.type === 'autophase.state' && (m.payload?.phases?.length ?? 0) > 0);
+    expect(startedBoard).toBe(false);
+  });
+
+  it('clear broadcasts a cleared event + an empty board state', async () => {
+    const h = makeHandler(async () => ({ status: 'done', finalText: '' }));
+    const ws = mockWs();
+    h.addClient(ws);
+
+    await h.handleMessage({ type: 'autophase.clear', payload: {} });
+
+    const types = sentTypes(ws);
+    expect(types).toContain('autophase.cleared');
+    const emptyState = ws.send.mock.calls
+      .map(([raw]) => JSON.parse(String(raw)) as { type: string; payload?: { phases?: unknown[] } })
+      .find((m) => m.type === 'autophase.state');
+    expect(emptyState?.payload?.phases).toEqual([]);
+  });
+
+  it('revert with no captured git baseline reports a reason instead of throwing', async () => {
+    const h = makeHandler(async () => ({ status: 'done', finalText: '' }));
+    const ws = mockWs();
+    h.addClient(ws);
+
+    await h.handleMessage({ type: 'autophase.revert', payload: {} });
+
+    const reverted = ws.send.mock.calls
+      .map(([raw]) => JSON.parse(String(raw)) as { type: string; payload?: { ok?: boolean; reason?: string } })
+      .find((m) => m.type === 'autophase.reverted');
+    expect(reverted?.payload?.ok).toBe(false);
+    expect(reverted?.payload?.reason).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes a real bug and fills in the AutoPhase run lifecycle (stop / new / revert), reported by the user: "stop while it was starting didn't stop it — it kept running in the background; and after stop there's no clear/new."

## The bug
Stop was a **no-op while a run was "starting"**: the `AbortController` was created only *after* the planning LLM turn, and `planPhases` ran the agent with a fresh, never-aborted signal. So a Stop pressed during planning was ignored and the orchestrator launched anyway.

## Fixes
- Create the run's `AbortController` **before** planning and thread its signal into `planPhases` → `agent.run` → planning is cancelable.
- Add a `stopping` guard: after planning resolves, **bail before starting the orchestrator** if stop/clear/revert was requested (covers the resolve-after-stop window the abort alone can't).
- `autophase.stop` now reliably halts at any phase.

## New lifecycle
- **`autophase.clear`** — stop + tear down phase worktrees + reset to an empty board; the view returns to the goal-entry screen (= "new one").
- **`autophase.revert`** — stop + remove worktrees + **history-preserving `git revert`** of the run's commits (captured `base..HEAD` via `WorktreeManager.currentBase` / `revertCommits`). Reports a reason instead of throwing on a dirty tree / no baseline.
- Frontend: status-driven header controls — Stop/Pause while live, Cancel while planning, **New + Revert** (inline confirm) once stopped/failed/completed.

Shared handler → covers both webui servers; the `autophase.*` prefix auto-routes the new messages (no route changes).

## Verification
webui typecheck + full suite (1787) + build green; new `tests/server/autophase-lifecycle.test.ts` (3 cases incl. the stop-during-planning guard) green; biome clean; cli ws-parity green. Built off the post-merge `main`; the concurrent `autophase-sdd-viz` merge may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-up: dock can no longer break chat scroll
The dock area above the chat (chip strip + any expanded section — Work tasks, Fleet, etc.) had no height cap and no `shrink-0`. Inside `<main>` (flex-col, `overflow-hidden`), a tall expanded section consumed the column height and pushed the chat transcript off-screen so it couldn't scroll. Now capped at `max-h-[45vh]` with its own `overflow-y-auto` + `shrink-0`; `ChatView` (`flex-1 min-h-0`) keeps the rest as its own scroll region.

_Note: the AutoPhase chip already opens the **full board view** directly (no inline phase/task pile) as of #124 — if an inline AutoPhase panel with a "Full view" button is still visible, the running WebUI is a stale build; rebuild `@wrongstack/webui` and restart._
