### PR TITLE
test(webui): assert SDD run-config knobs reach startRun

### DIFF
--- a/packages/webui/tests/server/sdd-wizard-ws-handler.test.ts
+++ b/packages/webui/tests/server/sdd-wizard-ws-handler.test.ts
@@ -114,6 +114,26 @@ describe('SddWizardWebSocketHandler (end-to-end message flow)', () => {
     expect(lastOfType(ws, 'sdd.run.started').payload.runId).toBe('run-xyz');
   });
 
+  it('forwards the run-config knobs (parallelSlots + worktrees) to startRun', async () => {
+    const { handler, startRunCalls } = makeHandler();
+    const ws = fakeWs();
+    handler.addClient(ws);
+
+    await handler.handleMessage({ type: 'sdd.spec.start', payload: { goal: 'OAuth login' } });
+    await handler.handleMessage({ type: 'sdd.spec.message', payload: { text: 'Google and GitHub' } });
+    await handler.handleMessage({ type: 'sdd.spec.approve', payload: {} });
+
+    // Start with explicit parallel slots + worktrees disabled.
+    await handler.handleMessage({
+      type: 'sdd.run.start',
+      payload: { parallelSlots: 8, worktrees: false },
+    });
+
+    expect(startRunCalls).toHaveLength(1);
+    expect(startRunCalls[0]?.opts.parallelSlots).toBe(8);
+    expect(startRunCalls[0]?.opts.worktrees).toBe(false);
+  });
+
   it('surfaces an error when starting a run with no spec', async () => {
     const { handler, startRunCalls } = makeHandler();
     const ws = fakeWs();


### PR DESCRIPTION
Adds the missing regression test for the run-configuration knobs shipped in `80871bc4` (which landed src-only, no test).

The new case drives the wizard to a run-ready state and sends `sdd.run.start` with `{ parallelSlots: 8, worktrees: false }`, asserting both reach the wizard's `startRun` (the mock already captures `opts`). Locks the per-run parallel-slots + worktree-isolation override against regressions.

Test-only change. Verified green in an isolated worktree: `tests/server/sdd-wizard-ws-handler.test.ts` 5/5 pass. (The worktree's `tsc` reports `@wrongstack/core has no exported member …` — a worktree artifact from core's `dist` not being built there, unrelated to this change; CI builds core before typecheck.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)