### PR TITLE
feat(picker): live type-to-filter search + alphabetical ordering

### DIFF
--- a/packages/cli/src/picker.ts
+++ b/packages/cli/src/picker.ts
@@ -1,14 +1,202 @@
 import os from 'node:os';
-import type { Config, ModelsRegistry, ResolvedProvider } from '@wrongstack/core';
-import { color, expectDefined } from '@wrongstack/core';
+import type { Config, ModelsDevModel, ModelsRegistry, ResolvedProvider } from '@wrongstack/core';
+import { color, expectDefined, setOutputLineGuard, setRawMode, writeOut } from '@wrongstack/core';
+import { toErrorMessage } from '@wrongstack/core/utils';
 import { appendHistory, backupCurrent } from './config-history.js';
 import type { ReadlineInputReader } from './input-reader.js';
 import { hasApiKey, visibleModelIds } from './provider-helpers.js';
 import type { TerminalRenderer } from './renderer.js';
-import { toErrorMessage } from '@wrongstack/core/utils';
 
 // Simple theme alias (avoids importing the full theme module just for one color)
 const theme = { primary: color.amber };
+
+/**
+ * Filter providers by a free-text query: case-insensitive substring match
+ * against the provider id OR display name. An empty/whitespace query returns
+ * all providers (as a copy). Input order is preserved. Powers the live
+ * type-to-filter provider picker.
+ */
+export function filterProviders(query: string, providers: ResolvedProvider[]): ResolvedProvider[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...providers];
+  return providers.filter(
+    (p) => p.id.toLowerCase().includes(q) || p.name.toLowerCase().includes(q),
+  );
+}
+
+export interface ProviderPickerState {
+  query: string;
+  selected: number;
+  status: 'typing' | 'submitted' | 'cancelled';
+}
+
+/**
+ * Advance the live type-to-filter provider picker by one raw input chunk.
+ * Pure: given the current state, a key chunk (a single keystroke, a paste, or
+ * a multi-byte arrow escape sequence), and the number of providers matching
+ * the CURRENT query, returns the next state. The raw-stdin loop in
+ * runLiveProviderPicker is a thin shell around this so the input logic is
+ * fully unit-testable.
+ */
+export function applyPickerKey(
+  state: ProviderPickerState,
+  chunk: string,
+  matchCount: number,
+): ProviderPickerState {
+  // Arrow keys arrive as a 3-byte CSI sequence.
+  if (chunk === '\x1b[A') return { ...state, selected: Math.max(0, state.selected - 1) };
+  if (chunk === '\x1b[B')
+    return { ...state, selected: Math.min(Math.max(0, matchCount - 1), state.selected + 1) };
+  // Lone Esc clears the query (same as Ctrl+U).
+  if (chunk === '\x1b') return { ...state, query: '', selected: 0, status: 'typing' };
+  // Ignore other escape sequences (left/right arrows, etc.).
+  if (chunk.charCodeAt(0) === 0x1b) return state;
+
+  let query = state.query;
+  let selected = state.selected;
+  const status: ProviderPickerState['status'] = 'typing';
+  for (const ch of chunk) {
+    if (ch === '\r' || ch === '\n') {
+      return { ...state, status: matchCount > 0 ? 'submitted' : 'typing' };
+    }
+    if (ch === '\x03') return { ...state, status: 'cancelled' };
+    if (ch === '\x15') {
+      query = '';
+      selected = 0;
+      continue;
+    }
+    if (ch === '\x7f' || ch === '\b') {
+      if (query.length > 0) query = query.slice(0, -1);
+      selected = 0;
+      continue;
+    }
+    if (ch < ' ') continue; // skip stray control bytes
+    query += ch;
+    selected = 0;
+  }
+  return { query, selected, status };
+}
+
+/** Preferred family display order; remaining families follow in insertion order. */
+const PROVIDER_FAMILY_PREFERRED_ORDER = [
+  'anthropic',
+  'anthropic-oauth',
+  'openai',
+  'openai-codex',
+  'github-copilot',
+  'google',
+  'openai-compatible',
+];
+
+/** Max providers rendered in one live-picker frame (keeps a frame in-viewport). */
+export const LIVE_PICKER_MAX_VISIBLE = 15;
+
+/**
+ * Order providers for display: grouped by wire family in preferred order, then
+ * alphabetical by id within each family. Pure. Shared by the live render and
+ * the raw-stdin loop so the selection index and the rendered cursor always
+ * refer to the same provider.
+ */
+function orderProvidersForDisplay(filtered: ResolvedProvider[]): ResolvedProvider[] {
+  const families = new Map<string, ResolvedProvider[]>();
+  for (const p of filtered) {
+    const arr = families.get(p.family) ?? [];
+    arr.push(p);
+    families.set(p.family, arr);
+  }
+  const order = [
+    ...PROVIDER_FAMILY_PREFERRED_ORDER.filter((f) => families.has(f)),
+    ...[...families.keys()].filter((f) => !PROVIDER_FAMILY_PREFERRED_ORDER.includes(f)),
+  ];
+  const flat: ResolvedProvider[] = [];
+  for (const fam of order) {
+    const arr = (families.get(fam) ?? [])
+      .slice()
+      .sort((a, b) => a.id.toLowerCase().localeCompare(b.id.toLowerCase()));
+    flat.push(...arr);
+  }
+  return flat;
+}
+
+/**
+ * Render the live type-to-filter provider view as one string: the query line,
+ * providers grouped by wire family (preferred order, alphabetical within each
+ * family), the selected provider marked with ▶, and a key hint. Capped to
+ * LIVE_PICKER_MAX_VISIBLE rows so a frame always fits the viewport (the raw
+ * loop redraws by moving the cursor up and clearing). Pure.
+ */
+export function renderLiveProviderList(
+  query: string,
+  filtered: ResolvedProvider[],
+  selectedIdx: number,
+): string {
+  const ordered = orderProvidersForDisplay(filtered);
+  const visible = ordered.slice(0, LIVE_PICKER_MAX_VISIBLE);
+  let out = `? Select provider: ${query}\n`;
+  let flat = 0;
+  let lastFamily = '';
+  for (const p of visible) {
+    if (p.family !== lastFamily) {
+      out += `  ${p.family}\n`;
+      lastFamily = p.family;
+    }
+    const marker = flat === selectedIdx ? '▶ ' : '  ';
+    out += `${marker}${p.id.padEnd(24)} ${p.name}\n`;
+    flat++;
+  }
+  if (ordered.length > LIVE_PICKER_MAX_VISIBLE) {
+    out += `  … ${ordered.length - LIVE_PICKER_MAX_VISIBLE} more — type to filter\n`;
+  }
+  out += '  ↑↓ move · Enter select · Esc clear · Ctrl+C quit';
+  return out;
+}
+
+/**
+ * Filter models by a free-text query: case-insensitive substring match against
+ * the model id OR display name. Empty/whitespace query returns all (copy).
+ * Powers the live type-to-filter model picker.
+ */
+export function filterModels(query: string, models: ModelsDevModel[]): ModelsDevModel[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...models];
+  return models.filter((m) => m.id.toLowerCase().includes(q) || m.name.toLowerCase().includes(q));
+}
+
+/**
+ * Render the live type-to-filter model view as one string: the provider header,
+ * the query line, models sorted newest-first (release_date desc) with context /
+ * cost / capability columns, the selected model marked with ▶, and a key hint.
+ * Capped to LIVE_PICKER_MAX_VISIBLE rows so a frame fits the viewport. Pure.
+ */
+export function renderLiveModelList(
+  query: string,
+  filtered: ModelsDevModel[],
+  selectedIdx: number,
+  header: string,
+): string {
+  const ordered = [...filtered].sort((a, b) =>
+    (b.release_date ?? '').localeCompare(a.release_date ?? ''),
+  );
+  const visible = ordered.slice(0, LIVE_PICKER_MAX_VISIBLE);
+  let out = `  ${header}\n? Select model: ${query}\n`;
+  let flat = 0;
+  for (const m of visible) {
+    const ctx = m.limit?.context ? `${(m.limit.context / 1000).toFixed(0)}k`.padStart(6) : '     ?';
+    const cost = m.cost?.input !== undefined ? `$${m.cost.input}/$${m.cost.output ?? '?'}` : '';
+    const caps: string[] = [];
+    if (m.tool_call) caps.push('tools');
+    if (m.reasoning) caps.push('reason');
+    if (m.modalities?.input?.includes('image')) caps.push('vision');
+    const marker = flat === selectedIdx ? '▶ ' : '  ';
+    out += `${marker}${m.id.padEnd(34)}${ctx}  ${cost.padEnd(12)} ${caps.join(',')}\n`;
+    flat++;
+  }
+  if (ordered.length > LIVE_PICKER_MAX_VISIBLE) {
+    out += `  … ${ordered.length - LIVE_PICKER_MAX_VISIBLE} more — type to filter\n`;
+  }
+  out += '  ↑↓ move · Enter select · Esc clear · Ctrl+C quit';
+  return out;
+}
 
 /**
  * Save provider + model to the global config file.
@@ -93,6 +281,87 @@ export interface PickerResult {
  * When `defaultProvider`/`defaultModel` are passed, they're pre-selected
  * so the user can press Enter to accept the previous choice.
  */
+/**
+ * Live type-to-filter provider picker (TTY only). Takes over stdin in raw mode
+ * and redraws the filtered, family-grouped list on every keystroke. Thin I/O
+ * shell around the pure filterProviders / applyPickerKey / renderLiveProviderList
+ * helpers (which are fully unit-tested). Returns the chosen provider, or
+ * undefined on cancel. runPicker only calls this when stdin is a TTY; non-TTY
+ * callers (CI, piped input, tests) fall through to the numbered readLine picker.
+ */
+async function runLiveProviderPicker(
+  displayList: ResolvedProvider[],
+): Promise<ResolvedProvider | undefined> {
+  const stdin = process.stdin;
+  const out = process.stdout;
+  if (!stdin.isTTY || !out.isTTY) return undefined;
+
+  setOutputLineGuard(null);
+  let state: ProviderPickerState = { query: '', selected: 0, status: 'typing' };
+  let ordered = orderProvidersForDisplay(filterProviders(state.query, displayList));
+  // Selection lives within the visible window so it always maps to a rendered row.
+  const visibleCount = (): number => Math.min(ordered.length, LIVE_PICKER_MAX_VISIBLE);
+  const clamp = (): void => {
+    if (state.selected >= visibleCount()) state.selected = Math.max(0, visibleCount() - 1);
+  };
+  clamp();
+  let frame = renderLiveProviderList(state.query, ordered, state.selected);
+  writeOut(frame);
+
+  return new Promise<ResolvedProvider | undefined>((resolve) => {
+    const wasRaw = stdin.isRaw;
+    const wasPaused = stdin.isPaused();
+    setRawMode(stdin, true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+
+    const cleanup = (): void => {
+      stdin.off('data', onData);
+      setRawMode(stdin, wasRaw);
+      if (wasPaused) stdin.pause();
+    };
+    const repaint = (): void => {
+      // Move back to the top of the previous frame and clear to end of screen.
+      const ups = (frame.match(/\n/g) ?? []).length;
+      writeOut(`\x1b[${ups}A\r\x1b[J`);
+      ordered = orderProvidersForDisplay(filterProviders(state.query, displayList));
+      clamp();
+      frame = renderLiveProviderList(state.query, ordered, state.selected);
+      writeOut(frame);
+    };
+    const onData = (chunk: string): void => {
+      ordered = orderProvidersForDisplay(filterProviders(state.query, displayList));
+      state = applyPickerKey(state, chunk, visibleCount());
+      // applyPickerKey may have changed the query (type/paste) — recompute against
+      // the NEW query before resolving a selection, so a paste like "zzz\r" can't
+      // submit a provider from the pre-paste list.
+      ordered = orderProvidersForDisplay(filterProviders(state.query, displayList));
+      clamp();
+      if (state.status === 'cancelled') {
+        cleanup();
+        writeOut('\n');
+        resolve(undefined);
+        return;
+      }
+      if (state.status === 'submitted') {
+        // Query emptied the matches mid-chunk (e.g. paste): stay in the picker.
+        if (ordered.length === 0) {
+          state = { ...state, status: 'typing' };
+          repaint();
+          return;
+        }
+        const pick = ordered[state.selected] ?? ordered[0];
+        cleanup();
+        writeOut('\n');
+        resolve(pick);
+        return;
+      }
+      repaint();
+    };
+    stdin.on('data', onData);
+  });
+}
+
 export async function runPicker(deps: {
   modelsRegistry: ModelsRegistry;
   renderer: TerminalRenderer;
@@ -149,8 +418,12 @@ export async function runPicker(deps: {
         // know which models their endpoint actually serves (e.g. LM
         // Studio, vLLM, or a proxy with custom model ids). Otherwise the
         // catalog list keeps providing suggestions.
-        models: visibleModelIds(p.id, config ?? ({ providers: {} } as Config), p.models.map((m) => m.id), cfg)
-          .map((m) => p.models.find((pm) => pm.id === m) ?? { id: m, name: m }),
+        models: visibleModelIds(
+          p.id,
+          config ?? ({ providers: {} } as Config),
+          p.models.map((m) => m.id),
+          cfg,
+        ).map((m) => p.models.find((pm) => pm.id === m) ?? { id: m, name: m }),
       });
     } else {
       merged.push(p);
@@ -167,8 +440,12 @@ export async function runPicker(deps: {
       family: cfg.family,
       apiBase: cfg.baseUrl ?? inherited?.apiBase,
       envVars: cfg.envVars ?? inherited?.envVars ?? [],
-      models: visibleModelIds(id, config ?? ({ providers: {} } as Config), (inherited?.models ?? []).map((m) => m.id), cfg)
-        .map((m) => inherited?.models.find((pm) => pm.id === m) ?? { id: m, name: m }),
+      models: visibleModelIds(
+        id,
+        config ?? ({ providers: {} } as Config),
+        (inherited?.models ?? []).map((m) => m.id),
+        cfg,
+      ).map((m) => inherited?.models.find((pm) => pm.id === m) ?? { id: m, name: m }),
       npm: inherited?.npm,
     });
   }
@@ -188,6 +465,17 @@ export async function runPicker(deps: {
   if (keyed.length === 0) {
     displayList = merged;
     showingFallback = true;
+  }
+
+  // TTY: live type-to-filter picker. Non-TTY (CI, piped, tests) falls through
+  // to the numbered readLine picker below.
+  if (process.stdin.isTTY) {
+    const chosen = await runLiveProviderPicker(displayList);
+    if (!chosen) {
+      renderer.write(color.dim('Cancelled.\n'));
+      return undefined;
+    }
+    return pickModel(chosen, modelsRegistry, renderer, reader, defaultModel);
   }
 
   // Group by family for nicer display
@@ -223,7 +511,10 @@ export async function runPicker(deps: {
   let defaultIdx: number | undefined;
   renderer.write('\n');
   for (const fam of familyOrder) {
-    const list = families.get(fam);
+    // Sort within each family alphabetically (case-insensitive) by id.
+    const list = [...(families.get(fam) ?? [])].sort((a, b) =>
+      a.id.toLowerCase().localeCompare(b.id.toLowerCase()),
+    );
     if (!list || list.length === 0) continue;
     renderer.write(`  ${color.bold(fam)}\n`);
     for (const p of list) {
@@ -299,6 +590,95 @@ export async function runPicker(deps: {
   return pickModel(chosen.provider, modelsRegistry, renderer, reader, modelHint);
 }
 
+/**
+ * Live type-to-filter model picker (TTY only). Mirrors runLiveProviderPicker:
+ * takes over stdin in raw mode and redraws the filtered, newest-first model
+ * list on every keystroke. Selection indexes the release_date-desc order used
+ * by renderLiveModelList so the ▶ cursor and Enter always agree. Returns the
+ * chosen model, or undefined on cancel.
+ */
+async function runLiveModelPicker(
+  provider: ResolvedProvider,
+  defaultModel?: string,
+): Promise<ModelsDevModel | undefined> {
+  const stdin = process.stdin;
+  const out = process.stdout;
+  if (!stdin.isTTY || !out.isTTY) return undefined;
+
+  const header = `${provider.name} (${provider.id}) models:`;
+  const byNewest = (a: ModelsDevModel, b: ModelsDevModel): number =>
+    (b.release_date ?? '').localeCompare(a.release_date ?? '');
+  // Pre-select the default model (if any) in newest-first order.
+  const ranked = [...provider.models].sort(byNewest);
+  const defaultIdx =
+    defaultModel !== undefined ? ranked.findIndex((m) => m.id === defaultModel) : -1;
+
+  setOutputLineGuard(null);
+  let state: ProviderPickerState = {
+    query: '',
+    selected: defaultIdx >= 0 ? defaultIdx : 0,
+    status: 'typing',
+  };
+  const order = (filtered: ModelsDevModel[]): ModelsDevModel[] => [...filtered].sort(byNewest);
+  let ordered = order(filterModels(state.query, provider.models));
+  const visibleCount = (): number => Math.min(ordered.length, LIVE_PICKER_MAX_VISIBLE);
+  const clamp = (): void => {
+    if (state.selected >= visibleCount()) state.selected = Math.max(0, visibleCount() - 1);
+  };
+  clamp();
+  let frame = renderLiveModelList(state.query, ordered, state.selected, header);
+  writeOut(frame);
+
+  return new Promise<ModelsDevModel | undefined>((resolve) => {
+    const wasRaw = stdin.isRaw;
+    const wasPaused = stdin.isPaused();
+    setRawMode(stdin, true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+
+    const cleanup = (): void => {
+      stdin.off('data', onData);
+      setRawMode(stdin, wasRaw);
+      if (wasPaused) stdin.pause();
+    };
+    const repaint = (): void => {
+      const ups = (frame.match(/\n/g) ?? []).length;
+      writeOut(`\x1b[${ups}A\r\x1b[J`);
+      ordered = order(filterModels(state.query, provider.models));
+      clamp();
+      frame = renderLiveModelList(state.query, ordered, state.selected, header);
+      writeOut(frame);
+    };
+    const onData = (chunk: string): void => {
+      ordered = order(filterModels(state.query, provider.models));
+      state = applyPickerKey(state, chunk, visibleCount());
+      // applyPickerKey may have changed the query — recompute before resolving.
+      ordered = order(filterModels(state.query, provider.models));
+      clamp();
+      if (state.status === 'cancelled') {
+        cleanup();
+        writeOut('\n');
+        resolve(undefined);
+        return;
+      }
+      if (state.status === 'submitted') {
+        if (ordered.length === 0) {
+          state = { ...state, status: 'typing' };
+          repaint();
+          return;
+        }
+        const pick = ordered[state.selected] ?? ordered[0];
+        cleanup();
+        writeOut('\n');
+        resolve(pick);
+        return;
+      }
+      repaint();
+    };
+    stdin.on('data', onData);
+  });
+}
+
 async function pickModel(
   provider: ResolvedProvider,
   registry: ModelsRegistry,
@@ -315,6 +695,20 @@ async function pickModel(
   if (models.length === 0) {
     renderer.writeError('  No models listed for this provider in the catalog.');
     return undefined;
+  }
+
+  // TTY: live type-to-filter model picker. Non-TYY (CI/piped/tests) falls
+  // through to the paginated numbered picker below.
+  if (process.stdin.isTTY) {
+    const chosen = await runLiveModelPicker(provider, defaultModel);
+    if (!chosen) {
+      renderer.write(color.dim('Cancelled.\n'));
+      return undefined;
+    }
+    renderer.write(
+      `\n  ${color.green('✓')} ${color.bold(provider.id)} / ${color.bold(chosen.id)}\n\n`,
+    );
+    return { provider: provider.id, model: chosen.id };
   }
 
   // Find default-model index for the "Enter = default" hint.

--- a/packages/cli/tests/picker.test.ts
+++ b/packages/cli/tests/picker.test.ts
@@ -1,7 +1,16 @@
 import { Writable } from 'node:stream';
 import type { ModelsDevModel, ResolvedProvider } from '@wrongstack/core';
 import { describe, expect, it, vi } from 'vitest';
-import { runPicker, saveToGlobalConfig } from '../src/picker.js';
+import {
+  applyPickerKey,
+  filterModels,
+  filterProviders,
+  type ProviderPickerState,
+  renderLiveModelList,
+  renderLiveProviderList,
+  runPicker,
+  saveToGlobalConfig,
+} from '../src/picker.js';
 import { TerminalRenderer } from '../src/renderer.js';
 
 class CapStream extends Writable {
@@ -233,10 +242,7 @@ describe('runPicker', () => {
     const { renderer, err } = mkRig();
     const providers = [
       fakeProvider({
-        models: [
-          fakeModel({ id: 'claude-opus-4' }),
-          fakeModel({ id: 'claude-sonnet-4' }),
-        ],
+        models: [fakeModel({ id: 'claude-opus-4' }), fakeModel({ id: 'claude-sonnet-4' })],
       }),
     ];
     // 'claude' matches both — should print an error and return undefined
@@ -331,6 +337,53 @@ describe('runPicker', () => {
     expect(err.buf).toMatch(/No models listed/);
   });
 
+  it('renders providers within each family in alphabetical (case-insensitive) order', async () => {
+    const { renderer, out } = mkRig();
+    // Same family, deliberately non-alphabetical and mixed-case to pin
+    // case-insensitive ordering. Without sorting these would render in
+    // insertion order (zzz-last, aaa-first, Mmm-mid).
+    const providers = [
+      fakeProvider({
+        id: 'zzz-last',
+        name: 'ZZZ',
+        family: 'openai-compatible',
+        envVars: [],
+        models: [fakeModel({ id: 'm1' })],
+      }),
+      fakeProvider({
+        id: 'aaa-first',
+        name: 'AAA',
+        family: 'openai-compatible',
+        envVars: [],
+        models: [fakeModel({ id: 'm1' })],
+      }),
+      fakeProvider({
+        id: 'Mmm-mid',
+        name: 'MMM',
+        family: 'openai-compatible',
+        envVars: [],
+        models: [fakeModel({ id: 'm1' })],
+      }),
+      fakeProvider({
+        id: 'anthropic',
+        name: 'Anthropic',
+        family: 'anthropic',
+        envVars: ['ANTHROPIC_API_KEY'],
+        models: [fakeModel()],
+      }),
+    ];
+    // Cancel at the provider prompt; the provider list is already rendered.
+    const reader = fakeReader(['']);
+    const registry = fakeRegistry(providers);
+    await runPicker({ modelsRegistry: registry as never, renderer, reader: reader as never });
+
+    const pos = (id: string) => out.buf.indexOf(id);
+    expect(pos('aaa-first')).toBeGreaterThan(-1);
+    // Case-insensitive alphabetical: aaa-first < Mmm-mid < zzz-last
+    expect(pos('aaa-first')).toBeLessThan(pos('Mmm-mid'));
+    expect(pos('Mmm-mid')).toBeLessThan(pos('zzz-last'));
+  });
+
   it('matches provider by id string', async () => {
     const { renderer } = mkRig();
     const providers = [
@@ -354,6 +407,257 @@ describe('runPicker', () => {
     expect(result).toBeDefined();
     expect(result!.provider).toBe('openai');
     expect(result!.model).toBe('gpt-4o');
+  });
+});
+
+describe('filterProviders', () => {
+  const sample = [
+    fakeProvider({ id: 'anthropic', name: 'Anthropic', family: 'anthropic', envVars: [] }),
+    fakeProvider({
+      id: 'google-vertex-anthropic',
+      name: 'Vertex (Anthropic)',
+      family: 'anthropic',
+      envVars: [],
+    }),
+    fakeProvider({ id: 'openai', name: 'OpenAI', family: 'openai', envVars: ['OPENAI_API_KEY'] }),
+    fakeProvider({
+      id: 'openrouter',
+      name: 'OpenRouter',
+      family: 'openai-compatible',
+      envVars: [],
+    }),
+    fakeProvider({ id: 'kimi', name: 'Kimi For Coding', family: 'anthropic', envVars: [] }),
+  ];
+
+  it('returns all providers when the query is empty or whitespace', () => {
+    expect(filterProviders('', sample)).toHaveLength(sample.length);
+    expect(filterProviders('   ', sample)).toHaveLength(sample.length);
+  });
+
+  it('matches by id substring (case-insensitive)', () => {
+    expect(filterProviders('anthr', sample).map((p) => p.id)).toEqual([
+      'anthropic',
+      'google-vertex-anthropic',
+    ]);
+  });
+
+  it('matches by name substring when the id does not contain the query', () => {
+    // "coding" is in the name "Kimi For Coding" but not in the id "kimi".
+    expect(filterProviders('coding', sample).map((p) => p.id)).toEqual(['kimi']);
+  });
+
+  it('matches id or name as a union, preserving input order', () => {
+    expect(filterProviders('open', sample).map((p) => p.id)).toEqual(['openai', 'openrouter']);
+  });
+
+  it('is case-insensitive', () => {
+    expect(filterProviders('KIMI', sample).map((p) => p.id)).toEqual(['kimi']);
+  });
+
+  it('returns an empty list when nothing matches', () => {
+    expect(filterProviders('zzz-nope', sample)).toEqual([]);
+  });
+});
+
+describe('filterModels', () => {
+  const models = [
+    fakeModel({ id: 'glm-5.2', name: 'GLM 5.2' }),
+    fakeModel({ id: 'glm-4.5-air', name: 'GLM 4.5 Air' }),
+    fakeModel({ id: 'special-1', name: 'Special Model' }),
+  ];
+
+  it('returns all models when the query is empty', () => {
+    expect(filterModels('', models)).toHaveLength(models.length);
+  });
+
+  it('matches by id substring (case-insensitive)', () => {
+    expect(filterModels('GLM', models).map((m) => m.id)).toEqual(['glm-5.2', 'glm-4.5-air']);
+  });
+
+  it('matches by name substring when the id does not contain the query', () => {
+    expect(filterModels('special', models).map((m) => m.id)).toEqual(['special-1']);
+  });
+
+  it('returns an empty list when nothing matches', () => {
+    expect(filterModels('zzz-nope', models)).toEqual([]);
+  });
+});
+
+describe('renderLiveModelList', () => {
+  const models = [
+    fakeModel({
+      id: 'glm-4.5-air',
+      name: 'GLM 4.5 Air',
+      release_date: '2025-01-01',
+      limit: { context: 131000, output: 8192 },
+      cost: { input: 0, output: 0 },
+      tool_call: true,
+      reasoning: true,
+    }),
+    fakeModel({
+      id: 'glm-5.2',
+      name: 'GLM 5.2',
+      release_date: '2026-06-01',
+      limit: { context: 1000000, output: 8192 },
+      cost: { input: 0, output: 0 },
+      tool_call: true,
+      reasoning: true,
+    }),
+    fakeModel({
+      id: 'glm-5v-turbo',
+      name: 'GLM 5V Turbo',
+      release_date: '2026-05-01',
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      tool_call: true,
+      reasoning: true,
+    }),
+  ];
+  const header = 'Z.AI Coding Plan (zai-coding-plan) models:';
+
+  it('sorts by release_date desc (newest first)', () => {
+    const out = renderLiveModelList('', models, 0, header);
+    expect(out.indexOf('glm-5.2')).toBeLessThan(out.indexOf('glm-5v-turbo'));
+    expect(out.indexOf('glm-5v-turbo')).toBeLessThan(out.indexOf('glm-4.5-air'));
+  });
+
+  it('echoes the query and the provider header', () => {
+    const out = renderLiveModelList('5.2', filterModels('5.2', models), 0, header);
+    expect(out).toContain('Select model: 5.2');
+    expect(out).toContain(header);
+  });
+
+  it('marks only the selected model with the cursor', () => {
+    // sorted desc: [glm-5.2, glm-5v-turbo, glm-4.5-air]; index 0 = glm-5.2
+    const out = renderLiveModelList('', models, 0, header);
+    const lines = out.split('\n');
+    expect(lines.find((l) => l.includes('glm-5.2'))).toMatch(/▶/);
+    expect(lines.find((l) => l.includes('glm-5v-turbo'))).not.toMatch(/▶/);
+  });
+
+  it('caps the list to a visible window with a "more" hint when results exceed it', () => {
+    const many = Array.from({ length: 20 }, (_, i) =>
+      fakeModel({ id: `model-${String(i + 1).padStart(2, '0')}`, name: `Model ${i}` }),
+    );
+    const out = renderLiveModelList('', many, 0, header);
+    expect(out).toContain('model-15');
+    expect(out).not.toContain('model-16');
+    expect(out).toMatch(/more/i);
+  });
+});
+
+describe('applyPickerKey', () => {
+  const st = (
+    query = '',
+    selected = 0,
+    status: ProviderPickerState['status'] = 'typing',
+  ): ProviderPickerState => ({ query, selected, status });
+
+  it('appends a printable char to the query and resets selection', () => {
+    expect(applyPickerKey(st('a', 3), 'b', 5)).toEqual(st('ab', 0));
+  });
+
+  it('appends a pasted run of chars', () => {
+    expect(applyPickerKey(st(), 'abc', 5)).toEqual(st('abc', 0));
+  });
+
+  it('erases one char on backspace and resets selection', () => {
+    expect(applyPickerKey(st('ab', 2), '\x7f', 5)).toEqual(st('a', 0));
+  });
+
+  it('keeps an empty query on backspace', () => {
+    expect(applyPickerKey(st(''), '\x7f', 5)).toEqual(st(''));
+  });
+
+  it('clears the whole query on Ctrl+U', () => {
+    expect(applyPickerKey(st('abc', 2), '\x15', 5)).toEqual(st('', 0));
+  });
+
+  it('clears the whole query on lone Esc', () => {
+    expect(applyPickerKey(st('abc', 2), '\x1b', 5)).toEqual(st('', 0));
+  });
+
+  it('moves selection up on Up arrow, clamped at top', () => {
+    expect(applyPickerKey(st('x', 2), '\x1b[A', 5).selected).toBe(1);
+    expect(applyPickerKey(st('x', 0), '\x1b[A', 5).selected).toBe(0);
+  });
+
+  it('moves selection down on Down arrow, clamped at bottom', () => {
+    expect(applyPickerKey(st('x', 1), '\x1b[B', 5).selected).toBe(2);
+    expect(applyPickerKey(st('x', 4), '\x1b[B', 5).selected).toBe(4);
+  });
+
+  it('submits on Enter when matches exist', () => {
+    expect(applyPickerKey(st('x', 1), '\r', 3).status).toBe('submitted');
+    expect(applyPickerKey(st('x', 1), '\n', 3).status).toBe('submitted');
+  });
+
+  it('ignores Enter when there are zero matches', () => {
+    expect(applyPickerKey(st('zzz', 0), '\r', 0).status).toBe('typing');
+  });
+
+  it('cancels on Ctrl+C', () => {
+    expect(applyPickerKey(st('x', 1), '\x03', 5).status).toBe('cancelled');
+  });
+
+  it('ignores other escape sequences (e.g. left/right arrows)', () => {
+    expect(applyPickerKey(st('x', 2), '\x1b[C', 5)).toEqual(st('x', 2));
+  });
+});
+
+describe('renderLiveProviderList', () => {
+  const list = [
+    fakeProvider({ id: 'zzz-gw', name: 'ZZZ Gateway', family: 'openai-compatible', envVars: [] }),
+    fakeProvider({ id: 'aaa-gw', name: 'AAA Gateway', family: 'openai-compatible', envVars: [] }),
+    fakeProvider({ id: 'anthropic', name: 'Anthropic', family: 'anthropic', envVars: [] }),
+    fakeProvider({ id: 'openai', name: 'OpenAI', family: 'openai', envVars: [] }),
+    fakeProvider({ id: 'google', name: 'Google', family: 'google', envVars: [] }),
+  ];
+
+  it('groups families in preferred order then the rest', () => {
+    const out = renderLiveProviderList('', list, 0);
+    const pos = (id: string) => out.indexOf(id);
+    expect(pos('anthropic')).toBeLessThan(pos('openai'));
+    expect(pos('openai')).toBeLessThan(pos('google'));
+    expect(pos('google')).toBeLessThan(pos('aaa-gw'));
+  });
+
+  it('sorts within each family alphabetically by id', () => {
+    const out = renderLiveProviderList('', list, 0);
+    expect(out.indexOf('aaa-gw')).toBeLessThan(out.indexOf('zzz-gw'));
+  });
+
+  it('echoes the current query in the prompt line', () => {
+    expect(renderLiveProviderList('anthr', list, 0)).toContain('Select provider: anthr');
+  });
+
+  it('marks only the selected provider with the cursor', () => {
+    const out = renderLiveProviderList('gw', filterProviders('gw', list), 1);
+    const lines = out.split('\n');
+    const sel = lines.find((l) => l.includes('zzz-gw'));
+    const other = lines.find((l) => l.includes('aaa-gw'));
+    expect(sel).toMatch(/▶/);
+    expect(other).not.toMatch(/▶/);
+  });
+
+  it('renders every provider when the query is empty', () => {
+    const out = renderLiveProviderList('', list, 0);
+    for (const p of list) expect(out).toContain(p.id);
+  });
+
+  it('caps the list to a visible window with a "more" hint when results exceed it', () => {
+    const many = Array.from({ length: 25 }, (_, i) =>
+      fakeProvider({
+        id: `prov-${String(i).padStart(2, '0')}`,
+        name: `Prov ${i}`,
+        family: 'openai-compatible',
+        envVars: [],
+      }),
+    );
+    const out = renderLiveProviderList('', many, 0);
+    expect(out).toContain('prov-00');
+    expect(out).toContain('prov-14');
+    expect(out).not.toContain('prov-15');
+    expect(out).toMatch(/more/i);
   });
 });
 


### PR DESCRIPTION
## Summary

Three provider/model picker UX improvements found while walking the install → first-run flow. All changes are isolated to the launch picker (`packages/cli/src/picker.ts`) and are fully unit-tested.

## Changes

1. **Alphabetical ordering** — providers are now sorted alphabetically (case-insensitive, by id) within each wire-family group. Previously they rendered in catalog/insertion order.

2. **Live type-to-filter search for the provider picker** — on a TTY, the provider picker is now an interactive fuzzy list: type to filter (case-insensitive substring on id **and** display name), `↑`/`↓` to move the cursor, `Enter` to select, `Esc`/`Ctrl-U` to clear, `Ctrl-C` to cancel. A viewport cap (`LIVE_PICKER_MAX_VISIBLE = 15`) keeps each frame inside the terminal and shows a `… N more — type to filter` hint. Non-TTY callers (CI, piped input, the test suite) fall through to the existing numbered `readLine` picker unchanged.

3. **Live type-to-filter search for the model picker** — the same live UX is mirrored onto the model picker (release_date-desc order, with context / cost / capability columns).

## Correctness notes

- A single ordering helper (`orderProvidersForDisplay` for providers, release-date sort for models) is used by **both** the rendered cursor and the selection index, so `Enter` always selects the highlighted row.
- A paste-with-newline chunk (e.g. pasting `zzz\r` in one event) recomputes the filtered list after the key is applied, so a query that empties the matches cannot submit a provider from the pre-paste list.

## Testing

- 32 new unit tests for the pure helpers (`filterProviders`, `filterModels`, `applyPickerKey`, `renderLiveProviderList`, `renderLiveModelList`).
- All **49** picker tests pass; `pnpm --filter @wrongstack/cli typecheck` clean; `biome check` clean.
- Verified live in a TTY (isolated `HOME`): type-to-filter, `↑`/`↓`, `Enter`, and the TTY→non-TTY fallback.

## Notes / follow-ups

- The OAuth/subscription wire families (`anthropic-oauth`, `openai-codex`, `github-copilot`) are unaffected — they keep their existing selection path.
- The raw-stdin loop (`runLiveProviderPicker` / `runLiveModelPicker`) mirrors the proven `ReadlineInputReader.readSecret` pattern; it is thin I/O glue over the unit-tested pure helpers.
