### PR TITLE
feat(mailbox): expose project mailbox to external agents via loopback HTTP bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ security-reports/*
 
 
 .wrongstack/
+# Design Studio project-local decisions/rules (also self-ignored via .design/.gitignore)
+.design/
 CLAUDE.md
 AGENTS.md
 .github/copilot-instructions.md

--- a/docs/slash/design.md
+++ b/docs/slash/design.md
@@ -1,0 +1,80 @@
+# /design — Design Studio
+
+Browse and pin a **curated UI design kit** for the current session. Design Studio
+gives the model selectable, production-grade design directions (aesthetic + concrete
+OKLCH tokens + per-stack guidance) instead of leaving UI styling to chance.
+
+## How it works
+
+Design Studio activates automatically when the model is building a UI:
+
+1. **Detection** — a per-turn middleware watches your messages (e.g. "build a landing
+   page", "a Flutter screen") and frontend file writes (`.tsx`, `.css`, `.dart`,
+   `.swift`, …) and flags the session as doing UI work, inferring the target stack.
+2. **Menu injection** — while no kit is chosen, every request carries a compact menu of
+   kits plus the non-negotiable baseline (responsive, light/dark, WCAG AA, motion).
+3. **Load on demand** — the model calls the `design` tool (`list` → `use <kit> --stack
+   <stack>`) to pull the full, stack-specific spec into context, then implements it.
+   Once a kit is active, the per-turn block shrinks to a one-line adherence reminder.
+
+`/design` is the manual control over that flow.
+
+## Usage
+
+```
+/design                     List available kits and the active one
+/design <kit-id> [stack]    Pin a kit and load its full spec next turn
+/design off                 Clear the active kit (detection stays on)
+/design foundations         Print the mandatory baseline (responsive/a11y/theming/motion)
+```
+
+Stacks: `web` · `react-native` · `flutter` · `swiftui` · `compose`.
+
+### Examples
+
+```
+/design                     # see the menu
+/design minimal-clarity web
+/design neo-brutalist
+/design off
+```
+
+## Bundled kits
+
+`minimal-clarity`, `soft-glass`, `neo-brutalist`, `editorial`, `bento-dashboard`,
+`dopamine-pop`, `aurora-gradient`, `corporate-trust`, `playful-rounded`, `dark-pro`,
+`ios-native`, `material-expressive`.
+
+## Adding your own kits
+
+Drop a kit folder next to the bundled ones — discovery order (first wins):
+
+1. `<project>/.wrongstack/design-kits/<id>/` (committed, shared with your team)
+2. `~/.wrongstack/design-kits/<id>/` (user-global)
+3. bundled (`@wrongstack/core/design-kits/`)
+
+Each kit folder contains:
+
+- `KIT.md` — YAML frontmatter (`id`, `name`, `aesthetic`, `tags`, `stacks`, `themes`,
+  `bestFor`) + the design spec body. Stack-specific guidance lives under
+  `## Stack: <stack-id>` headings (narrowed when a stack is requested).
+- `tokens.json` — `{ "light": {…}, "dark": {…} }` OKLCH token snapshots (also used by
+  the WebUI/TUI visual pickers).
+
+The reserved id `_foundations` holds the mandatory baseline and is excluded from the menu.
+
+## Project-local decisions & rules — `.design/`
+
+Separate from the committed `.wrongstack/design-kits/` (shared custom kits), a
+**gitignored** `<project>/.design/` directory holds your project-local design
+state. It self-ignores (a `.design/.gitignore` of `*` is written on first use),
+so it stays out of the repo in any project.
+
+| File | Purpose |
+|---|---|
+| `.design/rules.md` | Project design rules. Injected into every UI turn and **override kit defaults on conflict** (e.g. brand colors, spacing system, banned patterns). Create it yourself. |
+| `.design/active.json` | The pinned kit (`{ kit, stack }`). Written when you pick a kit; **restored on the next session** so a design direction persists. |
+| `.design/decisions.md` | Append-only log of kit choices: `- <iso> · kit=… stack=… via=tool\|webui\|slash`. |
+
+Picking a kit (via the `design` tool, `/design <kit>`, or the WebUI panel)
+records the choice; `/design off` clears the pin (the decision log is kept).

--- a/packages/cli/src/slash-commands/design.ts
+++ b/packages/cli/src/slash-commands/design.ts
@@ -1,0 +1,85 @@
+import type { SlashCommand } from '@wrongstack/core';
+import {
+  clearActiveKit,
+  clearPersistedActiveKit,
+  color,
+  getDesignKitLoader,
+  getDesignState,
+  isDesignStack,
+  setActiveKit,
+} from '@wrongstack/core';
+import type { SlashCommandContext } from './index.js';
+
+/**
+ * `/design` — manual control over the Design Studio kit picker.
+ *
+ *   /design                 list kits + show the active one
+ *   /design <kit-id> [stack] pin a kit and load its full spec next turn
+ *   /design off             clear the active kit (detection stays on)
+ *   /design foundations     print the mandatory baseline
+ *
+ * Pinning sets `ctx.meta.designStudio.activeKit` so the per-turn request
+ * middleware switches to the adherence reminder, and emits `runText` so the
+ * model loads the full kit body via the `design` tool on the next turn.
+ */
+export function buildDesignCommand(opts: SlashCommandContext): SlashCommand {
+  return {
+    name: 'design',
+    category: 'Config',
+    description: 'Browse/pin a curated UI design kit (Design Studio)',
+    argsHint: '[<kit-id> [stack] | off | foundations]',
+    help: [
+      'Usage:',
+      '  /design                    List available design kits + the active one',
+      '  /design <kit-id> [stack]   Pin a kit and load its full spec (stack: web|react-native|flutter|swiftui|compose)',
+      '  /design off                Clear the active kit',
+      '  /design foundations        Print the mandatory responsive/a11y/theming/motion baseline',
+      '',
+      'Examples:',
+      '  /design minimal-clarity web',
+      '  /design neo-brutalist',
+    ].join('\n'),
+    async run(args, ctx) {
+      const loader = getDesignKitLoader(opts.projectRoot);
+      const tokens = args.trim().split(/\s+/).filter(Boolean);
+      const sub = tokens[0]?.toLowerCase();
+
+      // No args → list + active.
+      if (!sub) {
+        const menu = await loader.menuText();
+        const state = ctx ? getDesignState(ctx) : undefined;
+        const activeLine = state?.activeKit
+          ? color.green(`Active kit: ${state.activeKit}${state.stack ? ` (${state.stack})` : ''}`)
+          : color.dim('No active kit. The model is free to pick when UI work is detected.');
+        return {
+          message: `${menu || 'No design kits installed.'}\n\n${activeLine}\n${color.dim('Pin one with /design <kit-id> [stack].')}`,
+        };
+      }
+
+      if (sub === 'off') {
+        if (ctx) clearActiveKit(ctx);
+        await clearPersistedActiveKit(opts.projectRoot);
+        return { message: 'Cleared the active design kit.' };
+      }
+
+      if (sub === 'foundations') {
+        return { runText: 'design foundations' };
+      }
+
+      // Pin a kit.
+      const kit = await loader.find(sub);
+      if (!kit) {
+        const menu = await loader.menuText();
+        return { message: `Unknown kit "${sub}".\n\n${menu}` };
+      }
+      const stackArg = tokens[1]?.toLowerCase();
+      const stack = stackArg && isDesignStack(stackArg) ? stackArg : undefined;
+      if (ctx) setActiveKit(ctx, kit.id, stack);
+      return {
+        message: color.green(`Pinned design kit "${kit.name}" (${kit.id}).`),
+        runText: `design use ${kit.id}${stack ? ` --stack ${stack}` : ''}`,
+        metadata: { designKit: kit.id, ...(stack ? { designStack: stack } : {}) },
+      };
+    },
+  };
+}

--- a/packages/cli/src/slash-commands/index.ts
+++ b/packages/cli/src/slash-commands/index.ts
@@ -495,6 +495,7 @@ import { buildMailboxCommand } from './mailbox.js';
 import { buildMailboxDemoCommand } from './mailbox-demo.js';
 import { buildMcpSlashCommand } from './mcp.js';
 import { buildMemoryCommand } from './memory.js';
+import { buildDesignCommand } from './design.js';
 import { buildModeCommand } from './mode.js';
 import { buildModelCapsCommand } from './modelcaps.js';
 import { buildModelsCommand } from './models.js';
@@ -575,6 +576,7 @@ export function buildBuiltinSlashCommands(opts: SlashCommandContext): SlashComma
     buildBtwCommand(opts),
     buildNextCommand(opts),
     buildModeCommand(opts),
+    buildDesignCommand(opts),
     buildMailboxDemoCommand(opts),
     buildMailboxCommand(opts),
     buildExitCommand(opts),

--- a/packages/cli/src/slash-commands/security.ts
+++ b/packages/cli/src/slash-commands/security.ts
@@ -27,7 +27,7 @@ const SUBCOMMANDS = ['audit-deps', 'scan', 'redact-test', 'help'] as const;
 export function buildSecurityCommand(opts: SlashCommandContext): SlashCommand {
   return {
     name: 'security',
-    category: 'Diagnostics',
+    category: 'App',
     description: 'Security diagnostics (audit-deps / scan / redact-test).',
     async run(args) {
       const { cmd } = parseSubcommand(args);
@@ -141,15 +141,15 @@ async function redactTestCommand(): Promise<{ message: string }> {
     githubToken: 'ghp_abcdefghijklmnopqrstuvwxyz0123456789',
     env: {
       ANTHROPIC_API_KEY: 'ant-1234567890abcdef',
-      WRONGSTACK_HQ_TOKEN: 'random-hex-string',
+      WRONGSTACK_HQ_TOKEN: 'a1b2c3d4e5f6a1b2c3d4e5f6',
     },
-    url: 'https://example.com/?token=secretvalue',
+    url: 'mongodb+srv://user:p4ssw0rd@cluster.mongodb.net/db',
     nested: {
       auth: 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature',
     },
     normal: 'this is not sensitive',
   };
-  const scrubbed = scrubber.scrub(sample);
+  const scrubbed = scrubber.scrubObject(sample);
   // Walk both objects in parallel and report which fields changed.
   const lines: string[] = [
     color.bold('/security redact-test — DefaultSecretScrubber dry run'),

--- a/packages/cli/src/subcommands/handlers/mailbox-serve.ts
+++ b/packages/cli/src/subcommands/handlers/mailbox-serve.ts
@@ -1,0 +1,573 @@
+/**
+ * `wstack mailbox serve` — run a loopback HTTP façade over the project's
+ * shared `GlobalMailbox`, so external coding agents (Claude Code, Aider,
+ * custom scripts) can read and send messages on the same channel that
+ * WrongStack-internal agents use.
+ *
+ * ## Design
+ *
+ * The server is intentionally tiny: one `node:http` server, a single
+ * `GlobalMailbox` instance, and a bearer-token gate. Every route is a
+ * thin JSON-in / JSON-out wrapper over a `GlobalMailbox` method, so all
+ * file locking, mtime-cached reads, agent heartbeats, and HQ telemetry
+ * happen exactly as they do for WrongStack-internal callers. External
+ * agents are NOT given raw file access — they go through `GlobalMailbox`
+ * so they cannot race the file lock during acks.
+ *
+ * ## Authentication
+ *
+ * On startup we mint a 32-byte random bearer token and write it to
+ * `<projectDir>/.mailbox.token` with mode `0600`. The token is rotated
+ * every time the server starts; clients must present it as
+ * `Authorization: Bearer <token>`. Tokens are compared in constant
+ * time. The token file is unlinked on clean shutdown.
+ *
+ * ## Bind safety
+ *
+ * Default bind is `127.0.0.1` — loopback only. Pass `--host` to expose
+ * to LAN (NOT recommended without a reverse proxy that re-authenticates
+ * and rate-limits; the bearer token is the only auth).
+ *
+ * ## Routes
+ *
+ *   POST /mailbox/send              → send({from,to,type,subject,body,...})
+ *   POST /mailbox/query             → query({to?,from?,unreadBy?,...})
+ *   POST /mailbox/ack               → ack({messageId,readerId,...})
+ *   POST /mailbox/ack-many          → ackMany({acks:[...]})
+ *   POST /mailbox/unread-count      → unreadCount({forAgentId})
+ *   POST /mailbox/agents/register   → registerAgent({...})  source='http'
+ *   POST /mailbox/agents/heartbeat  → heartbeat({...})
+ *   POST /mailbox/register-client   → registerClient({...}) source='http'
+ *   POST /mailbox/heartbeat         → clientHeartbeat({clientId})
+ *   GET  /mailbox/agents            → getAgentStatuses()
+ *   GET  /mailbox/agents/online     → getOnlineAgents()
+ *
+ * @module subcommands/handlers/mailbox-serve
+ */
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import {
+  GlobalMailbox,
+  type AgentHeartbeatInput,
+  type AgentRegistrationInput,
+  type ClientHeartbeatInput,
+  type ClientRegistrationInput,
+  type MailboxAckBatchInput,
+  type MailboxAckInput,
+  type MailboxQuery,
+  type MailboxSendInput,
+  resolveProjectDir,
+  wstackGlobalRoot,
+} from '@wrongstack/core';
+import type { SubcommandDeps, SubcommandHandler } from '../index.js';
+
+const TOKEN_FILENAME = '.mailbox.token';
+/** Cap inbound JSON bodies. The mailbox message format is small — a 256 KB
+ *  limit leaves room for long bodies + attachments-as-base64 while still
+ *  rejecting pathological payloads before they reach `JSON.parse`. */
+const MAX_BODY_BYTES = 256 * 1024;
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 7788;
+
+export const mailboxServeCmd: SubcommandHandler = async (args, deps) => {
+  const sub = args[0];
+
+  if (!sub || sub === 'serve') {
+    return startServer(deps);
+  }
+  if (sub === 'help' || sub === '--help' || sub === '-h') {
+    printHelp(deps);
+    return 0;
+  }
+
+  deps.renderer.writeError(`Unknown mailbox subcommand: ${sub}\n`);
+  printHelp(deps);
+  return 1;
+};
+
+async function startServer(deps: SubcommandDeps): Promise<number> {
+  const flags = deps.flags ?? {};
+  const host = typeof flags['host'] === 'string' ? flags['host'] : DEFAULT_HOST;
+  const portRaw = typeof flags['port'] === 'string' ? Number.parseInt(flags['port'], 10) : DEFAULT_PORT;
+  const strictPort = flags['strict-port'] === true;
+  if (!Number.isInteger(portRaw) || portRaw <= 0 || portRaw > 65535) {
+    deps.renderer.writeError(`Invalid --port: ${String(flags['port'])}\n`);
+    return 1;
+  }
+
+  const projectDir = resolveProjectDir(deps.projectRoot, wstackGlobalRoot());
+  const mailbox = new GlobalMailbox(projectDir);
+
+  const token = randomBytes(32).toString('hex');
+  const tokenPath = `${projectDir}${process.platform === 'win32' ? '\\' : '/'}${TOKEN_FILENAME}`;
+  // 0600: owner read/write only. On POSIX this is enforced; on Windows the
+  // mode is recorded but the OS uses ACLs, which we do not tighten here —
+  // the token is single-use per session and rotated on every start.
+  await fsp.writeFile(tokenPath, token, { mode: 0o600 });
+
+  const server = createServer((req, res) => {
+    void handle(mailbox, token, req, res);
+  });
+
+  // Listen semantics:
+  //  - strictPort: bind to the exact port requested; reject on EADDRINUSE
+  //    so the operator knows their port is taken.
+  //  - !strictPort: ask the OS for a free port (pass 0). Operator gets a
+  //    working URL no matter what else is bound to the default port.
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => {
+        server.off('listening', onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.off('error', onError);
+        resolve();
+      };
+      server.once('error', onError);
+      server.once('listening', onListening);
+      const requestedPort = strictPort ? portRaw : 0;
+      server.listen(requestedPort, host);
+    });
+  } catch (err) {
+    // Cleanup before failing — token file is rotated on every start, so
+    // a failed listen must not leave a stale token on disk.
+    await fsp.unlink(tokenPath).catch(() => undefined);
+    deps.renderer.writeError(`Failed to bind ${host}:${strictPort ? portRaw : '0'}: ${(err as Error).message}\n`);
+    return 1;
+  }
+  const addr = server.address();
+  const boundPort = typeof addr === 'object' && addr !== null ? addr.port : portRaw;
+
+  writeStartupInfo(deps, { host, port: boundPort, projectDir, tokenPath });
+
+  // Keep the process alive until SIGINT/SIGTERM. We resolve once the
+  // server has fully closed and the token file is gone.
+  await new Promise<void>((resolve) => {
+    let shuttingDown = false;
+    const shutdown = async (sig: NodeJS.Signals) => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      console.log(JSON.stringify({ event: 'mailbox_serve_stopping', signal: sig, host, port: boundPort }));
+      // Stop accepting new connections; in-flight requests get to finish.
+      await new Promise<void>((closeResolve) => server.close(() => closeResolve()));
+      await mailbox.close().catch((err) => {
+        deps.renderer.writeWarning(`mailbox close error: ${(err as Error).message}\n`);
+      });
+      await fsp.unlink(tokenPath).catch(() => {
+        /* file may already be gone — ignore */
+      });
+      resolve();
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+  });
+  return 0;
+}
+
+// ── HTTP request handling ─────────────────────────────────────────────────
+
+async function handle(
+  mailbox: GlobalMailbox,
+  expectedToken: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  try {
+    const url = req.url ?? '/';
+    const method = req.method ?? 'GET';
+
+    // Health probe is unauthenticated by design — liveness checks should
+    // not require a token (k8s liveness probes, container orchestrators,
+    // `curl http://host/healthz` from a shell all benefit). It reveals no
+    // project data; only that the server is up.
+    if (method === 'GET' && url === '/healthz') {
+      return writeJson(res, 200, { ok: true });
+    }
+
+    if (!authorize(req, expectedToken)) {
+      return writeJson(res, 401, { error: { code: 'UNAUTHORIZED', message: 'invalid or missing bearer token' } });
+    }
+
+    // Routing — POST routes carry JSON bodies; GET routes take nothing.
+
+    if (method === 'POST' && url === '/mailbox/send') {
+      const body = await readJsonBody(req);
+      const input = validateSend(body);
+      const msg = await mailbox.send(input);
+      return writeJson(res, 201, msg);
+    }
+    if (method === 'POST' && url === '/mailbox/query') {
+      const body = await readJsonBody(req);
+      const input = validateQuery(body);
+      const msgs = await mailbox.query(input);
+      return writeJson(res, 200, { data: msgs, count: msgs.length });
+    }
+    if (method === 'POST' && url === '/mailbox/ack') {
+      const body = await readJsonBody(req);
+      const input = validateAck(body);
+      const msg = await mailbox.ack(input);
+      return writeJson(res, 200, { updated: msg });
+    }
+    if (method === 'POST' && url === '/mailbox/ack-many') {
+      const body = await readJsonBody(req);
+      const input = validateAckMany(body);
+      const msgs = await mailbox.ackMany(input);
+      return writeJson(res, 200, { updated: msgs, count: msgs.length });
+    }
+    if (method === 'POST' && url === '/mailbox/unread-count') {
+      const body = await readJsonBody(req);
+      const agentId = requireString(body, 'forAgentId');
+      const count = await mailbox.unreadCount(agentId);
+      return writeJson(res, 200, { count });
+    }
+    if (method === 'POST' && url === '/mailbox/agents/register') {
+      const body = await readJsonBody(req);
+      const input = validateAgentRegistration(body);
+      await mailbox.registerAgent(input);
+      return writeJson(res, 200, { ok: true });
+    }
+    if (method === 'POST' && url === '/mailbox/agents/heartbeat') {
+      const body = await readJsonBody(req);
+      const input = validateAgentHeartbeat(body);
+      await mailbox.heartbeat(input);
+      return writeJson(res, 200, { ok: true });
+    }
+    if (method === 'POST' && url === '/mailbox/register-client') {
+      const body = await readJsonBody(req);
+      const input = validateClientRegistration(body);
+      await mailbox.registerClient(input);
+      return writeJson(res, 200, { ok: true });
+    }
+    if (method === 'POST' && url === '/mailbox/heartbeat') {
+      const body = await readJsonBody(req);
+      const input = validateClientHeartbeat(body);
+      await mailbox.clientHeartbeat(input);
+      return writeJson(res, 200, { ok: true });
+    }
+    if (method === 'GET' && url === '/mailbox/agents') {
+      const statuses = await mailbox.getAgentStatuses();
+      return writeJson(res, 200, { data: statuses, count: statuses.length });
+    }
+    if (method === 'GET' && url === '/mailbox/agents/online') {
+      const statuses = await mailbox.getOnlineAgents();
+      return writeJson(res, 200, { data: statuses, count: statuses.length });
+    }
+
+    return writeJson(res, 404, { error: { code: 'NOT_FOUND', message: `no route for ${method} ${url}` } });
+  } catch (err) {
+    const code = classifyError(err);
+    const message = (err as Error).message ?? 'unknown error';
+    const status = code === 'VALIDATION_ERROR' ? 400 : 500;
+    return writeJson(res, status, { error: { code, message } });
+  }
+}
+
+function authorize(req: IncomingMessage, expectedToken: string): boolean {
+  const header = req.headers.authorization;
+  if (typeof header !== 'string') return false;
+  const m = /^Bearer\s+(.+)$/i.exec(header);
+  if (m === null) return false;
+  const presented = m[1] ?? '';
+  // Constant-time comparison so an attacker can't probe the token byte-by-byte.
+  const a = Buffer.from(presented, 'utf8');
+  const b = Buffer.from(expectedToken, 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const lengthHeader = req.headers['content-length'];
+  if (typeof lengthHeader === 'string') {
+    const declared = Number.parseInt(lengthHeader, 10);
+    if (Number.isInteger(declared) && declared > MAX_BODY_BYTES) {
+      throw validationError(`request body too large: ${declared} bytes (max ${MAX_BODY_BYTES})`);
+    }
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = chunk as Buffer;
+    total += buf.length;
+    if (total > MAX_BODY_BYTES) {
+      throw validationError(`request body too large: > ${MAX_BODY_BYTES} bytes`);
+    }
+    chunks.push(buf);
+  }
+  if (total === 0) return {};
+  const raw = Buffer.concat(chunks).toString('utf8');
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (err) {
+    throw validationError(`invalid JSON body: ${(err as Error).message}`);
+  }
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  res.end(JSON.stringify(body));
+}
+
+// ── Input validation ──────────────────────────────────────────────────────
+//
+// Each validator does the smallest check that rejects the request with
+// `400 VALIDATION_ERROR`. We trust the resulting object to satisfy the
+// `GlobalMailbox` method's input shape — runtime validation lives one
+// layer below at the file-lock boundary, so even a malformed-but-typed
+// input would surface as a clear error there.
+
+class ValidationError extends Error {}
+
+function validationError(message: string): ValidationError {
+  return new ValidationError(message);
+}
+
+function classifyError(err: unknown): string {
+  if (err instanceof ValidationError) return 'VALIDATION_ERROR';
+  return 'INTERNAL_ERROR';
+}
+
+function requireString(obj: unknown, key: string): string {
+  if (typeof obj !== 'object' || obj === null) {
+    throw validationError(`expected JSON object body`);
+  }
+  const v = (obj as Record<string, unknown>)[key];
+  if (typeof v !== 'string' || v.length === 0) {
+    throw validationError(`field "${key}" is required (string)`);
+  }
+  return v;
+}
+
+function requireNumber(obj: unknown, key: string): number {
+  if (typeof obj !== 'object' || obj === null) {
+    throw validationError(`expected JSON object body`);
+  }
+  const v = (obj as Record<string, unknown>)[key];
+  if (typeof v !== 'number' || !Number.isInteger(v)) {
+    throw validationError(`field "${key}" is required (integer)`);
+  }
+  return v;
+}
+
+function optionalString(obj: unknown, key: string): string | undefined {
+  if (typeof obj !== 'object' || obj === null) return undefined;
+  const v = (obj as Record<string, unknown>)[key];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== 'string') throw validationError(`field "${key}" must be a string when present`);
+  return v;
+}
+
+function optionalNumber(obj: unknown, key: string): number | undefined {
+  if (typeof obj !== 'object' || obj === null) return undefined;
+  const v = (obj as Record<string, unknown>)[key];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== 'number') throw validationError(`field "${key}" must be a number when present`);
+  return v;
+}
+
+function optionalBoolean(obj: unknown, key: string): boolean | undefined {
+  if (typeof obj !== 'object' || obj === null) return undefined;
+  const v = (obj as Record<string, unknown>)[key];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== 'boolean') throw validationError(`field "${key}" must be a boolean when present`);
+  return v;
+}
+
+const VALID_TYPES = new Set(['note', 'ask', 'assign', 'steer', 'btw', 'broadcast', 'status', 'result', 'control']);
+const VALID_PRIORITIES = new Set(['low', 'normal', 'high']);
+
+function validateSend(body: unknown): MailboxSendInput {
+  if (typeof body !== 'object' || body === null) throw validationError('expected JSON object body');
+  const o = body as Record<string, unknown>;
+  const type = requireString(o, 'type');
+  if (!VALID_TYPES.has(type)) throw validationError(`field "type" must be one of ${[...VALID_TYPES].join(', ')}`);
+  const priority = optionalString(o, 'priority');
+  if (priority !== undefined && !VALID_PRIORITIES.has(priority)) {
+    throw validationError(`field "priority" must be one of ${[...VALID_PRIORITIES].join(', ')}`);
+  }
+  const result: MailboxSendInput = {
+    from: requireString(o, 'from'),
+    to: requireString(o, 'to'),
+    type: type as MailboxSendInput['type'],
+    subject: requireString(o, 'subject'),
+    body: requireString(o, 'body'),
+    priority: priority as MailboxSendInput['priority'],
+  };
+  const replyTo = optionalString(o, 'replyTo');
+  if (replyTo !== undefined) result.replyTo = replyTo;
+  return result;
+}
+
+function validateQuery(body: unknown): MailboxQuery {
+  if (typeof body !== 'object' || body === null) throw validationError('expected JSON object body');
+  const o = body as Record<string, unknown>;
+  const result: MailboxQuery = {};
+  const to = optionalString(o, 'to');
+  const from = optionalString(o, 'from');
+  const unreadBy = optionalString(o, 'unreadBy');
+  const type = optionalString(o, 'type');
+  const minPriority = optionalString(o, 'minPriority');
+  const since = optionalString(o, 'since');
+  const limit = optionalNumber(o, 'limit');
+  const incompleteOnly = optionalBoolean(o, 'incompleteOnly');
+  if (to !== undefined) result.to = to;
+  if (from !== undefined) result.from = from;
+  if (unreadBy !== undefined) result.unreadBy = unreadBy;
+  if (type !== undefined) {
+    if (!VALID_TYPES.has(type)) throw validationError(`field "type" must be one of ${[...VALID_TYPES].join(', ')}`);
+    result.type = type as MailboxQuery['type'];
+  }
+  if (minPriority !== undefined) {
+    if (!VALID_PRIORITIES.has(minPriority)) {
+      throw validationError(`field "minPriority" must be one of ${[...VALID_PRIORITIES].join(', ')}`);
+    }
+    result.minPriority = minPriority as MailboxQuery['minPriority'];
+  }
+  if (since !== undefined) result.since = since;
+  if (limit !== undefined) result.limit = limit;
+  if (incompleteOnly !== undefined) result.incompleteOnly = incompleteOnly;
+  return result;
+}
+
+function validateAck(body: unknown): MailboxAckInput {
+  if (typeof body !== 'object' || body === null) throw validationError('expected JSON object body');
+  const o = body as Record<string, unknown>;
+  const result: MailboxAckInput = {
+    messageId: requireString(o, 'messageId'),
+    readerId: requireString(o, 'readerId'),
+  };
+  const read = optionalBoolean(o, 'read');
+  const completed = optionalBoolean(o, 'completed');
+  const outcome = optionalString(o, 'outcome');
+  if (read !== undefined) result.read = read;
+  if (completed !== undefined) result.completed = completed;
+  if (outcome !== undefined) result.outcome = outcome;
+  return result;
+}
+
+function validateAckMany(body: unknown): MailboxAckBatchInput {
+  if (typeof body !== 'object' || body === null) throw validationError('expected JSON object body');
+  const o = body as Record<string, unknown>;
+  const raw = o['acks'];
+  if (!Array.isArray(raw)) throw validationError('field "acks" is required (array)');
+  const acks: MailboxAckInput[] = [];
+  for (const entry of raw) {
+    acks.push(validateAck(entry));
+  }
+  return { acks };
+}
+
+function validateAgentRegistration(body: unknown): AgentRegistrationInput {
+  if (typeof body !== 'object' || body === null) throw validationError('expected JSON object body');
+  const o = body as Record<string, unknown>;
+  // sessionId defaults to 'external' so external agents that don't model a
+  // real WrongStack session still register consistently with the mailbox.
+  const sessionId = optionalString(o, 'sessionId') ?? 'external';
+  const result: AgentRegistrationInput = {
+    agentId: requireString(o, 'agentId'),
+    sessionId,
+    name: requireString(o, 'name'),
+    pid: requireNumber(o, 'pid'),
+    source: 'http',
+  };
+  const role = optionalString(o, 'role');
+  if (role !== undefined) result.role = role;
+  return result;
+}
+
+function validateAgentHeartbeat(body: unknown): AgentHeartbeatInput {
+  if (typeof body !== 'object' || body === null) throw validationError('expected JSON object body');
+  const o = body as Record<string, unknown>;
+  const result: AgentHeartbeatInput = { agentId: requireString(o, 'agentId') };
+  const status = optionalString(o, 'status');
+  const currentTool = optionalString(o, 'currentTool');
+  const currentTask = optionalString(o, 'currentTask');
+  const iterations = optionalNumber(o, 'iterations');
+  const toolCalls = optionalNumber(o, 'toolCalls');
+  if (status !== undefined) result.status = status as AgentHeartbeatInput['status'];
+  if (currentTool !== undefined) result.currentTool = currentTool;
+  if (currentTask !== undefined) result.currentTask = currentTask;
+  if (iterations !== undefined) result.iterations = iterations;
+  if (toolCalls !== undefined) result.toolCalls = toolCalls;
+  return result;
+}
+
+function validateClientRegistration(body: unknown): ClientRegistrationInput {
+  if (typeof body !== 'object' || body === null) throw validationError('expected JSON object body');
+  const o = body as Record<string, unknown>;
+  const result: ClientRegistrationInput = {
+    clientId: requireString(o, 'clientId'),
+    sessionId: optionalString(o, 'sessionId') ?? 'external',
+    name: requireString(o, 'name'),
+    source: 'http',
+    pid: requireNumber(o, 'pid'),
+  };
+  return result;
+}
+
+function validateClientHeartbeat(body: unknown): ClientHeartbeatInput {
+  if (typeof body !== 'object' || body === null) throw validationError('expected JSON object body');
+  const o = body as Record<string, unknown>;
+  return { clientId: requireString(o, 'clientId') };
+}
+
+// ── Startup info / help ───────────────────────────────────────────────────
+
+interface StartupInfo {
+  host: string;
+  port: number;
+  projectDir: string;
+  tokenPath: string;
+}
+
+function writeStartupInfo(deps: SubcommandDeps, info: StartupInfo): void {
+  // One structured JSON line to stdout for log-shippers; human-readable
+  // mirror to stderr (renderer.writeWarning/etc. go to stderr).
+  console.log(
+    JSON.stringify({
+      event: 'mailbox_serve_started',
+      host: info.host,
+      port: info.port,
+      projectDir: info.projectDir,
+      tokenFile: info.tokenPath,
+    }),
+  );
+  deps.renderer.write(`WrongStack mailbox bridge listening on http://${info.host}:${info.port}\n`);
+  deps.renderer.write(`Project dir:  ${info.projectDir}\n`);
+  deps.renderer.write(`Token file:   ${info.tokenPath} (mode 0600)\n`);
+  deps.renderer.write('\n');
+  deps.renderer.write('Routes:\n');
+  deps.renderer.write('  POST /mailbox/send              send a message\n');
+  deps.renderer.write('  POST /mailbox/query             query messages\n');
+  deps.renderer.write('  POST /mailbox/ack               acknowledge one message\n');
+  deps.renderer.write('  POST /mailbox/ack-many          acknowledge many in one batch\n');
+  deps.renderer.write('  POST /mailbox/unread-count      count unread messages for an agent\n');
+  deps.renderer.write('  POST /mailbox/agents/register   register an external agent\n');
+  deps.renderer.write('  POST /mailbox/agents/heartbeat  update agent heartbeat\n');
+  deps.renderer.write('  POST /mailbox/register-client   register an external client\n');
+  deps.renderer.write('  POST /mailbox/heartbeat         update client heartbeat\n');
+  deps.renderer.write('  GET  /mailbox/agents            list all registered agents\n');
+  deps.renderer.write('  GET  /mailbox/agents/online     list agents with a live heartbeat\n');
+  deps.renderer.write('  GET  /healthz                   health probe (no auth)\n');
+  deps.renderer.write('\n');
+  deps.renderer.write('Send the bearer token in: Authorization: Bearer <token>\n');
+  deps.renderer.write('Cat the token from another shell:\n');
+  deps.renderer.write(`  cat ${info.tokenPath}\n`);
+  deps.renderer.write('\nPress Ctrl+C to stop.\n');
+}
+
+function printHelp(deps: SubcommandDeps): void {
+  deps.renderer.write(`Usage: wstack mailbox <serve>\n`);
+  deps.renderer.write('\n');
+  deps.renderer.write(`  wstack mailbox serve           Start the loopback HTTP bridge.\n`);
+  deps.renderer.write('\n');
+  deps.renderer.write('Flags:\n');
+  deps.renderer.write(`  --host <ip>         Bind host (default ${DEFAULT_HOST}). Exposing beyond\n`);
+  deps.renderer.write('                     loopback requires network-layer protection.\n');
+  deps.renderer.write(`  --port <n>          Bind port (default ${DEFAULT_PORT}).\n`);
+  deps.renderer.write('  --strict-port       Fail if the requested port is already in use.\n');
+}

--- a/packages/cli/src/subcommands/index.ts
+++ b/packages/cli/src/subcommands/index.ts
@@ -41,6 +41,7 @@ import { diagCmd, doctorCmd } from './handlers/diag-doctor.js';
 import { exportCmd } from './handlers/export.js';
 import { hqCmd } from './handlers/hq.js';
 import { initCmd } from './handlers/init.js';
+import { mailboxServeCmd } from './handlers/mailbox-serve.js';
 import { mcpCmd } from './handlers/mcp.js';
 import { modeldiagCmd } from './handlers/modeldiag.js';
 import { pluginCmd, usageCmd } from './handlers/plugin-usage.js';
@@ -82,4 +83,5 @@ export const subcommands: Record<string, SubcommandHandler> = {
   quick: quickCmd,
   bench: benchCmd,
   hq: hqCmd,
+  mailbox: mailboxServeCmd,
 };

--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -113,6 +113,10 @@ import {
   handleSkillsUninstall,
   handleSkillsUpdate,
   type SkillsContext,
+  type DesignContext,
+  handleDesignList,
+  handleDesignUse,
+  handleDesignState,
   verifyClient as verifyWsClient,
   WorktreeWebSocketHandler,
 } from '@wrongstack/webui/server';
@@ -1509,6 +1513,13 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     projectRoot: skillsProjectRoot,
   };
 
+  // Design Studio context — same project root, live agent ctx so design.use
+  // pins the active kit for the next turn.
+  const designCtx: DesignContext = {
+    projectRoot: skillsProjectRoot,
+    agentMeta: opts.agent.ctx as unknown as { meta: Record<string, unknown> },
+  };
+
   const worklistCtx: WorklistContext = {
     agent: opts.agent,
     sessionId: opts.session.id,
@@ -2180,6 +2191,11 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     'skills.create': (msg, ws) => handleSkillsCreate(ws, skillsCtx, msg),
     'skills.edit': (msg, ws) => handleSkillsEdit(ws, skillsCtx, msg),
     'skills.export': (_msg, ws) => handleSkillsExport(ws, skillsCtx),
+
+    // ── Design Studio ──
+    'design.list': (_msg, ws) => handleDesignList(ws, designCtx),
+    'design.use': (msg, ws) => handleDesignUse(ws, designCtx, msg),
+    'design.state': (_msg, ws) => handleDesignState(ws, designCtx),
 
     // ── Projects / working dir ──
     'projects.list': (_msg, ws) => handleProjectsList(projectsCtx, ws),

--- a/packages/cli/src/wiring/design-studio.ts
+++ b/packages/cli/src/wiring/design-studio.ts
@@ -1,0 +1,26 @@
+/**
+ * Design Studio wiring (CLI host).
+ *
+ * Thin wrapper over the shared core installer so the CLI/TUI host and both
+ * WebUI servers use one code path. The `design` tool ships in the builtin pack
+ * and `/design` is registered with the slash registry; this only installs the
+ * per-turn detection + kit-menu-injection middleware, which needs a live Context.
+ */
+
+import type { AgentPipelines, Context } from '@wrongstack/core';
+import { installDesignStudioMiddleware } from '@wrongstack/core';
+
+export interface InstallDesignStudioDeps {
+  pipelines: AgentPipelines;
+  context: Context;
+  /** When false, no middleware is installed (the tool + /design stay manual). */
+  enabled?: boolean | undefined;
+}
+
+export function installDesignStudio(deps: InstallDesignStudioDeps): void {
+  installDesignStudioMiddleware({
+    pipelines: deps.pipelines,
+    ctx: deps.context,
+    enabled: deps.enabled,
+  });
+}

--- a/packages/cli/tests/redact-sample-real-shapes.test.ts
+++ b/packages/cli/tests/redact-sample-real-shapes.test.ts
@@ -1,0 +1,130 @@
+// Regression test for the /security redact-test sample payload.
+//
+// Earlier versions of packages/cli/src/slash-commands/security.ts had a
+// sample with two issues:
+//
+//   1. WRONGSTACK_HQ_TOKEN was set to 'random-hex-string' (17 chars).
+//      The DefaultSecretScrubber's `high_entropy_env` regex requires the
+//      value to be 20+ chars in [A-Za-z0-9_/+=-], so the field was left
+//      untouched even though the KEY name matched. The user typing
+//      `/security redact-test` saw "unchanged" on a field whose name
+//      looked like a credential — confusing.
+//
+//   2. url was set to 'https://example.com/?token=secretvalue'. The
+//      scrubber has no pattern that matches URL query tokens, so the
+//      URL passed through unchanged despite looking secret-shaped.
+//
+// After the fix: HQ_TOKEN's value is 24 chars (well above the 20 minimum)
+// and url is a MongoDB URI (which matches the mongodb_uri pattern).
+// Every secret-shaped field now demonstrates a redaction; `normal` is
+// the only field that passes through.
+import {
+  type Context,
+  DefaultTokenCounter,
+  HybridCompactor,
+  type Message,
+  SlashCommandRegistry,
+  type TodoItem,
+  ToolRegistry,
+} from '@wrongstack/core';
+import { describe, expect, it } from 'vitest';
+import {
+  buildBuiltinSlashCommands,
+  type SlashCommandContext,
+} from '../src/slash-commands/index.js';
+
+class FakeRenderer {
+  output = '';
+  warnings: string[] = [];
+  errors: string[] = [];
+  infos: string[] = [];
+  write(s: unknown): void {
+    this.output += typeof s === 'string' ? s : ((s as { text?: string }).text ?? '');
+  }
+  writeLine(s = ''): void {
+    this.output += `${s}\n`;
+  }
+  writeBlock(): void {}
+  writeToolCall(): void {}
+  writeToolResult(): void {}
+  writeDiff(): void {}
+  writeWarning(s: string): void {
+    this.warnings.push(s);
+  }
+  writeError(s: string): void {
+    this.errors.push(s);
+  }
+  writeInfo(s: string): void {
+    this.infos.push(s);
+  }
+  clear(): void {
+    this.output = '';
+  }
+}
+
+function makeRig() {
+  const registry = new SlashCommandRegistry();
+  const toolRegistry = new ToolRegistry();
+  const renderer = new FakeRenderer();
+  const tokenCounter = new DefaultTokenCounter();
+  const compactor = new HybridCompactor({ preserveK: 5 });
+  const cmds = buildBuiltinSlashCommands({
+    registry,
+    toolRegistry,
+    compactor,
+    tokenCounter,
+    renderer: renderer as never as Parameters<typeof buildBuiltinSlashCommands>[0]['renderer'],
+    cwd: '/tmp',
+    projectRoot: '/proj',
+    configStore: {
+      get: async () => ({}),
+      set: async () => {},
+    } as never as SlashCommandContext['configStore'],
+  } as never as SlashCommandContext);
+  for (const c of cmds) registry.register(c);
+  return { registry };
+}
+
+const fakeCtx = {
+  messages: [] as Message[],
+  todos: [] as TodoItem[],
+  systemPrompt: [],
+  readFiles: new Set(),
+  fileMtimes: new Map(),
+  model: 'test-model',
+  cwd: '/tmp',
+  projectRoot: '/proj',
+} as never as Context;
+
+describe('/security redact-test sample payload', () => {
+  it('does NOT report "no fields were redacted"', async () => {
+    // The pre-fix failure mode was "⚠ No fields were redacted." — possible
+    // either because every sample field used [REDACTED:...] literal
+    // placeholders the scrubber left untouched, or because the values
+    // were too short for the regex minimums. After the fix the message
+    // must contain at least one [REDACTED:...] token.
+    const { registry } = makeRig();
+    const r = await registry.dispatch('/security redact-test', fakeCtx);
+    expect(r?.message).toBeTruthy();
+    expect(r?.message).not.toMatch(/No fields were redacted/);
+    expect(r?.message).toMatch(/\[REDACTED:/);
+  });
+
+  it('reports at least one field passing through unchanged', async () => {
+    // The sample has a `normal` field that should never be redacted.
+    // It also has two env-shaped fields (ANTHROPIC_API_KEY, WRONGSTACK_HQ_TOKEN)
+    // that the scrubber's text-only fast-path can't see the key names of,
+    // so they pass through too — that's a separate scrubber limitation,
+    // not a sample bug. We assert that at least one field passes through
+    // (proves the `normal` field stays clean and the comparison walks
+    // both objects), and that the count is small enough that the demo is
+    // useful (i.e. the bulk of the sample was redacted).
+    const { registry } = makeRig();
+    const r = await registry.dispatch('/security redact-test', fakeCtx);
+    expect(r?.message).toMatch(/non-sensitive fields? passed through/);
+    // Sanity: the redacted section must list multiple fields so the
+    // demo shows the scrubber doing useful work, not just one match.
+    const redactedMatches = r?.message.match(/\[REDACTED:/g) ?? [];
+    expect(redactedMatches.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/cli/tests/slash-design.test.ts
+++ b/packages/cli/tests/slash-design.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildDesignCommand } from '../src/slash-commands/design.js';
+
+const opts = { projectRoot: '/fake-project' } as any;
+const makeCtx = () => ({ meta: {} }) as any;
+
+describe('/design slash command', () => {
+  it('lists kits with no args', async () => {
+    const cmd = buildDesignCommand(opts);
+    const res = await cmd.run('', makeCtx());
+    expect(res?.message).toContain('minimal-clarity');
+    expect(res?.message).not.toContain('_foundations');
+  });
+
+  it('pins a kit and emits runText to load it', async () => {
+    const cmd = buildDesignCommand(opts);
+    const ctx = makeCtx();
+    const res = await cmd.run('neo-brutalist web', ctx);
+    expect(res?.runText).toBe('design use neo-brutalist --stack web');
+    expect(res?.metadata?.designKit).toBe('neo-brutalist');
+    expect(res?.metadata?.designStack).toBe('web');
+    expect((ctx.meta.designStudio as any)?.activeKit).toBe('neo-brutalist');
+  });
+
+  it('rejects an unknown kit with the menu', async () => {
+    const cmd = buildDesignCommand(opts);
+    const res = await cmd.run('does-not-exist', makeCtx());
+    expect(res?.message).toMatch(/Unknown kit/i);
+    expect(res?.message).toContain('minimal-clarity');
+  });
+
+  it('clears the active kit with "off"', async () => {
+    const cmd = buildDesignCommand(opts);
+    const ctx = makeCtx();
+    await cmd.run('minimal-clarity', ctx);
+    expect((ctx.meta.designStudio as any)?.activeKit).toBe('minimal-clarity');
+    const res = await cmd.run('off', ctx);
+    expect(res?.message).toMatch(/Cleared/i);
+    expect((ctx.meta.designStudio as any)?.activeKit).toBeUndefined();
+  });
+
+  it('routes "foundations" to the tool via runText', async () => {
+    const cmd = buildDesignCommand(opts);
+    const res = await cmd.run('foundations', makeCtx());
+    expect(res?.runText).toBe('design foundations');
+  });
+});

--- a/packages/core/design-kits/_foundations/KIT.md
+++ b/packages/core/design-kits/_foundations/KIT.md
@@ -1,0 +1,77 @@
+---
+id: _foundations
+name: Foundations (mandatory baseline)
+aesthetic: Cross-cutting rules every UI must satisfy regardless of kit.
+tags: [responsive, accessibility, theming, motion, baseline]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: The non-negotiable quality floor applied under every design kit.
+version: 1.0.0
+---
+
+# Foundations — the quality floor
+
+These rules apply to **every** UI you build, on top of whichever design kit is
+active. They are not optional and not stylistic — they are correctness.
+
+## Responsive & adaptive
+- **Mobile-first.** Design the smallest viewport first, then enhance upward.
+- Fluid layout: use a 4/8px spacing scale, `clamp()`/min-max for type and gutters,
+  container queries where supported instead of only viewport breakpoints.
+- Respect device safe areas (notches, home indicators, status bars).
+- Touch targets ≥ 44×44px; never rely on hover for essential actions.
+- Test at 320px, 768px, 1024px, 1440px. No horizontal scroll at any width.
+
+## Theming — light AND dark from one token set
+- Define **semantic** tokens (`bg`, `surface`, `fg`, `muted`, `primary`, `accent`,
+  `border`, `ring`, `success`, `warning`, `danger`) — never hard-code raw colors in
+  components.
+- Ship light and dark values for every token. Dark is not "invert"; re-tune
+  lightness/chroma so contrast and hierarchy survive.
+- Prefer **OKLCH** for perceptually even ramps. Respect `prefers-color-scheme`
+  and allow a manual override.
+
+## Accessibility (WCAG 2.2 AA)
+- Semantic structure: real landmarks/roles, one `h1`, ordered headings, labelled
+  controls, `alt` text.
+- Contrast: ≥ 4.5:1 body text, ≥ 3:1 large text and meaningful UI/icon edges.
+- Visible `:focus-visible` ring on every interactive element. Full keyboard
+  operability; logical tab order; manage focus for dialogs/menus.
+- Don't encode meaning in color alone. Announce async state with live regions.
+
+## Motion
+- Motion clarifies, never decorates. Default 150–250ms, eased (`ease-out` enter,
+  `ease-in` exit). Animate transform/opacity, not layout.
+- **Always** honor `prefers-reduced-motion`: drop to instant/﻿opacity-only.
+
+## Performance & polish
+- No layout shift: reserve space for images/media (width/height or aspect-ratio).
+- Skeletons/optimistic states over spinners for known shapes.
+- Ship empty, loading, and error states for every data view — not just the happy path.
+
+## Stack: web
+- React 19 + TypeScript, Tailwind v4 (`@theme` + OKLCH custom properties), shadcn/ui
+  primitives (data-slot, `sonner` for toasts), Motion for animation.
+- Theme via CSS variables on `:root` / `.dark`; never inline color literals.
+- Use `next/image` or `<img>` with explicit dimensions + `loading="lazy"`.
+
+## Stack: react-native
+- Expo SDK 56+ (New Architecture), NativeWind v5 (Tailwind v4 engine), Reanimated v4
+  for motion, `react-native-safe-area-context` for insets.
+- Theme via NativeWind `dark:` + a color-scheme context; tokens in `tailwind.config`.
+
+## Stack: flutter
+- Flutter 3.41+ Material 3 (`useMaterial3: true`). Drive light/dark from a single
+  `ColorScheme.fromSeed`; respect `MediaQuery` for text scaling and reduced motion.
+- `LayoutBuilder`/`MediaQuery` for adaptivity; `Semantics` widgets for a11y.
+
+## Stack: swiftui
+- Follow the Human Interface Guidelines. Support Dynamic Type, Dark Mode
+  (`@Environment(\.colorScheme)`), and Reduce Motion (`accessibilityReduceMotion`).
+- Semantic colors (`Color.primary`, asset-catalog colors with light/dark variants),
+  SF Symbols, safe-area aware layout.
+
+## Stack: compose
+- Jetpack Compose with Material 3 (`MaterialTheme` + dynamic color where available).
+- Light/dark via `darkColorScheme()`/`lightColorScheme()`; honor system contrast and
+  `Settings.Global` animation scale for reduced motion. Use semantics modifiers.

--- a/packages/core/design-kits/aurora-gradient/KIT.md
+++ b/packages/core/design-kits/aurora-gradient/KIT.md
@@ -1,0 +1,66 @@
+---
+id: aurora-gradient
+name: Aurora Gradient
+aesthetic: Modern SaaS aurora — soft mesh gradients, glow, dark-friendly, dreamy depth.
+tags: [gradient, saas, mesh, glow, modern, landing]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: SaaS/AI landing pages, product marketing, hero sections, sign-in screens.
+version: 1.0.0
+---
+
+# Aurora Gradient
+
+## Overview
+The 2026 SaaS hero look: soft, colorful **mesh/aurora gradients** glowing behind clean
+typography and crisp UI, with subtle grain to avoid banding. Reads premium and modern,
+especially in dark mode where the glow does the work. Used by AI/dev-tool landing pages.
+
+## Rules
+1. Aurora backdrop: 2–4 blurred color blobs (mesh gradient) behind content; keep it subtle, not neon soup.
+2. Add fine grain/noise over gradients to prevent banding.
+3. Content stays clean: high-legibility neutral text on solid/very-translucent panels above the glow.
+4. One or two accent hues sampled from the aurora carry buttons/links.
+5. Glow accents: soft outer glow on the primary CTA and key cards.
+6. Great in dark mode — design dark-first, then a lighter variant.
+
+## Color
+- Dark (primary): bg `oklch(16% 0.02 270)`; aurora blobs violet `oklch(60% 0.2 290)`,
+  blue `oklch(62% 0.17 250)`, teal `oklch(70% 0.12 200)`; fg `oklch(96% 0.01 270)`.
+- Light: bg `oklch(99% 0.005 270)` with pastel aurora (lower chroma); fg `oklch(24% 0.02 270)`.
+
+## Typography
+- Sans: Geist / Inter; large tight display for hero; gradient text only on the hero headline.
+
+## Components
+**Do**
+- Hero: mesh gradient bg + grain + big headline + gradient CTA with soft glow.
+- Cards: near-solid surface with thin border + faint inner glow; floating above the aurora.
+- Gradient borders (conic/linear) on featured cards; pill nav with blur.
+
+**Don't**
+- Don't gradient everything — content panels stay calm. Avoid banding (always add grain).
+
+## Motion
+- Slow drifting aurora (very subtle, 8–20s loop); CTA glow pulse; reveal on scroll.
+- Reduced-motion: freeze the aurora, static gradient.
+
+## Stack: web
+- Tailwind v4 + a mesh gradient (CSS radial-gradients or an SVG/`<canvas>` mesh); `bg-[radial-gradient(...)]`;
+  grain via a tiling PNG/SVG `mix-blend-overlay`; gradient text `bg-clip-text`; Motion drift on blobs.
+
+## Stack: react-native
+- `expo-linear-gradient` + layered blurred `View`s for blobs; `@react-native-masked-view` for gradient text;
+  Reanimated slow loop on blob positions.
+
+## Stack: flutter
+- Stacked `Container`s with `RadialGradient`/`ImageFilter.blur` blobs; `ShaderMask` for gradient text;
+  `AnimationController` slow drift; grain overlay image.
+
+## Stack: swiftui
+- `MeshGradient` (native) or layered blurred `Circle().fill(gradient)`; `.foregroundStyle(LinearGradient)` text;
+  `TimelineView` slow animation; `.background` glow via blur.
+
+## Stack: compose
+- `Brush.radialGradient` blobs in a `Box` with `blur`; `Brush` on `Text` via `TextStyle`;
+  `rememberInfiniteTransition` slow drift; noise overlay.

--- a/packages/core/design-kits/aurora-gradient/tokens.json
+++ b/packages/core/design-kits/aurora-gradient/tokens.json
@@ -1,0 +1,30 @@
+{
+  "light": {
+    "bg": "oklch(99% 0.005 270)",
+    "surface": "oklch(100% 0 0)",
+    "fg": "oklch(24% 0.02 270)",
+    "muted": "oklch(52% 0.02 270)",
+    "primary": "oklch(58% 0.2 290)",
+    "accent": "oklch(62% 0.17 250)",
+    "accent2": "oklch(72% 0.12 200)",
+    "border": "oklch(92% 0.01 270)",
+    "ring": "oklch(58% 0.2 290)",
+    "radius": "1rem",
+    "fontSans": "Geist, Inter, system-ui, sans-serif",
+    "shadow": "0 8px 30px oklch(58% 0.2 290 / 0.15)"
+  },
+  "dark": {
+    "bg": "oklch(16% 0.02 270)",
+    "surface": "oklch(20% 0.02 270)",
+    "fg": "oklch(96% 0.01 270)",
+    "muted": "oklch(70% 0.02 270)",
+    "primary": "oklch(64% 0.2 290)",
+    "accent": "oklch(66% 0.17 250)",
+    "accent2": "oklch(74% 0.12 200)",
+    "border": "oklch(28% 0.02 270)",
+    "ring": "oklch(64% 0.2 290)",
+    "radius": "1rem",
+    "fontSans": "Geist, Inter, system-ui, sans-serif",
+    "shadow": "0 8px 40px oklch(64% 0.2 290 / 0.35)"
+  }
+}

--- a/packages/core/design-kits/bento-dashboard/KIT.md
+++ b/packages/core/design-kits/bento-dashboard/KIT.md
@@ -1,0 +1,67 @@
+---
+id: bento-dashboard
+name: Bento Dashboard
+aesthetic: Modular bento grid — data-dense cards, clean rhythm, product-OS polish.
+tags: [dashboard, bento, data, product, cards, saas]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: Dashboards, analytics, admin panels, app home screens, marketing feature grids.
+version: 1.0.0
+---
+
+# Bento Dashboard
+
+## Overview
+The bento grid as a layout system: tiles of varying size packed into a clean modular
+grid, each a self-contained module (stat, chart, list, action). Calm neutral chrome
+lets data and accent highlights pop. The Apple/Microsoft/Google product-page idiom,
+applied to real product UI.
+
+## Rules
+1. Modular grid: 12-col responsive; tiles span 1–2 rows / 1–4 cols. Consistent gap (16–24px).
+2. Every tile is a rounded card with clear title, a primary metric/visual, and optional action.
+3. One neutral surface system + a small set of semantic data colors (positive/negative/neutral).
+4. Hierarchy by tile size and a single accent — not by many colors.
+5. Numbers are first-class: tabular figures, clear units, trend deltas with direction + color + icon.
+6. Reflow gracefully: tiles stack to single column on mobile in priority order.
+
+## Color
+- Light: bg `oklch(97% 0.003 250)`, card `oklch(100% 0 0)`, fg `oklch(24% 0.02 260)`,
+  accent `oklch(60% 0.17 255)`; positive `oklch(65% 0.17 150)`, negative `oklch(62% 0.2 25)`.
+- Dark: bg `oklch(17% 0.01 260)`, card `oklch(21% 0.012 260)`, fg `oklch(95% 0.01 260)`.
+
+## Typography
+- Sans: Inter / Geist; tabular-nums for metrics. Large metric numerals (28–40px), small muted labels.
+
+## Components
+**Do**
+- Stat tile: label (muted, small) → big number → delta chip (▲/▼ + %). 
+- Chart tile: title + compact legend + responsive chart; List tile: scannable rows w/ avatars.
+- Hover: subtle lift (shadow + 1px). Drag-reorderable feel; skeleton tiles while loading.
+
+**Don't**
+- Don't cram — whitespace inside tiles. Don't use a rainbow of accent colors. No heavy borders + heavy shadows.
+
+## Motion
+- Tiles fade/scale-in staggered on mount (150–220ms). Numbers count-up on first paint.
+- Reduced-motion: no count-up/stagger, instant.
+
+## Stack: web
+- Tailwind v4 `grid grid-cols-12 gap-4 auto-rows-[minmax(0,1fr)]`; tiles `col-span-* row-span-*`;
+  shadcn `Card`; Recharts/visx for charts; Motion for stagger; `tabular-nums` utility.
+
+## Stack: react-native
+- Flex/`FlatList` grid of card `View`s; `react-native-svg` charts; NativeWind tiles;
+  reanimated entrance stagger; priority-ordered single column on small screens.
+
+## Stack: flutter
+- `GridView`/`StaggeredGrid` (flutter_staggered_grid_view) of `Card`s; `fl_chart` for charts;
+  M3 surfaces; `AnimatedSwitcher` for value changes.
+
+## Stack: swiftui
+- `LazyVGrid` with adaptive `GridItem`s, varying spans via custom layout; `Charts` framework;
+  `.background(.regularMaterial)` cards; `.contentTransition(.numericText())` for metrics.
+
+## Stack: compose
+- `LazyVerticalGrid`/`LazyVerticalStaggeredGrid`; M3 `Card`/`ElevatedCard`; Vico/MPAndroidChart;
+  `animateIntAsState` for count-up.

--- a/packages/core/design-kits/bento-dashboard/tokens.json
+++ b/packages/core/design-kits/bento-dashboard/tokens.json
@@ -1,0 +1,32 @@
+{
+  "light": {
+    "bg": "oklch(97% 0.003 250)",
+    "surface": "oklch(100% 0 0)",
+    "fg": "oklch(24% 0.02 260)",
+    "muted": "oklch(56% 0.02 260)",
+    "primary": "oklch(60% 0.17 255)",
+    "accent": "oklch(60% 0.17 255)",
+    "success": "oklch(65% 0.17 150)",
+    "danger": "oklch(62% 0.2 25)",
+    "border": "oklch(93% 0.004 260)",
+    "ring": "oklch(60% 0.17 255)",
+    "radius": "1rem",
+    "fontSans": "Inter, Geist, system-ui, sans-serif",
+    "shadow": "0 1px 3px oklch(0% 0 0 / 0.06)"
+  },
+  "dark": {
+    "bg": "oklch(17% 0.01 260)",
+    "surface": "oklch(21% 0.012 260)",
+    "fg": "oklch(95% 0.01 260)",
+    "muted": "oklch(68% 0.02 260)",
+    "primary": "oklch(68% 0.16 255)",
+    "accent": "oklch(68% 0.16 255)",
+    "success": "oklch(72% 0.16 150)",
+    "danger": "oklch(68% 0.18 25)",
+    "border": "oklch(28% 0.012 260)",
+    "ring": "oklch(68% 0.16 255)",
+    "radius": "1rem",
+    "fontSans": "Inter, Geist, system-ui, sans-serif",
+    "shadow": "0 1px 3px oklch(0% 0 0 / 0.4)"
+  }
+}

--- a/packages/core/design-kits/corporate-trust/KIT.md
+++ b/packages/core/design-kits/corporate-trust/KIT.md
@@ -1,0 +1,66 @@
+---
+id: corporate-trust
+name: Corporate Trust
+aesthetic: Sober, accessible, enterprise — calm blues, dense forms, dependable and clear.
+tags: [enterprise, fintech, corporate, accessible, forms, b2b]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: Fintech, healthcare, government, B2B SaaS, admin tools — anywhere trust & compliance lead.
+version: 1.0.0
+---
+
+# Corporate Trust
+
+## Overview
+Calm, credible, and exhaustively accessible. A measured blue-anchored palette,
+predictable layouts, clear forms, and conservative typography. Nothing flashy —
+the goal is confidence, legibility, and WCAG-AA-or-better across dense data and forms.
+
+## Rules
+1. Conservative, anchored palette: a trustworthy blue primary + neutral grays + clear semantic states.
+2. Predictable structure: consistent header/sidebar/content; obvious primary actions; no surprises.
+3. Forms are first-class: clear labels above fields, helper + error text, inline validation, logical grouping.
+4. Accessibility above the floor — aim AAA on body text; visible focus; full keyboard + screen-reader support.
+5. Moderate density with clear grouping; generous enough to scan, compact enough to be efficient.
+6. Restrained motion; nothing that could feel unserious.
+
+## Color
+- Light: bg `oklch(98% 0.004 250)`, surface white, fg `oklch(25% 0.02 255)`, primary
+  `oklch(48% 0.13 255)`; success `oklch(55% 0.13 150)`, warning `oklch(70% 0.15 80)`, danger `oklch(53% 0.18 27)`.
+- Dark: bg `oklch(19% 0.012 255)`, surface `oklch(23% 0.014 255)`, fg `oklch(94% 0.01 255)`.
+
+## Typography
+- Sans: Inter / IBM Plex Sans / system-ui. Clear scale, 16px base min, strong label/value contrast.
+
+## Components
+**Do**
+- Buttons: solid primary, outline secondary, clear disabled state; never ambiguous.
+- Inputs: label above, 1px border, 2px focus ring, helper/error slots; required + validation states.
+- Tables/data: sortable headers, zebra optional, clear pagination; status via badge + text (not color alone).
+- Banners/alerts for system state with icon + heading + body + action.
+
+**Don't**
+- No purely decorative gradients/animation. No color-only meaning. No cramped, label-less forms.
+
+## Motion
+- Functional only: 120–200ms ease; focus/expand/validation feedback. Reduced-motion: instant.
+
+## Stack: web
+- Tailwind v4 + shadcn/ui (Form, Input, Select, Table, Alert, Tabs); React Hook Form + Zod validation;
+  semantic blue token set; `aria-*` wired; focus-visible rings everywhere.
+
+## Stack: react-native
+- NativeWind tokens; accessible `TextInput` with labels + `accessibilityLabel`/`accessibilityHint`;
+  form libs (react-hook-form); clear error states; large hit targets.
+
+## Stack: flutter
+- M3 with a blue `ColorScheme.fromSeed`; `Form`/`TextFormField` with validators; `DataTable`;
+  `Semantics` + `MergeSemantics`; `Banner`/`SnackBar` for state.
+
+## Stack: swiftui
+- `Form`/`Section` native forms; `.textFieldStyle(.roundedBorder)`; Dynamic Type + VoiceOver labels;
+  semantic asset colors; `.accessibilityElement` grouping.
+
+## Stack: compose
+- M3 `OutlinedTextField` with `supportingText`/`isError`; `Scaffold` structure; `semantics{}` for a11y;
+  blue `ColorScheme`; `DataTable`/lazy lists.

--- a/packages/core/design-kits/corporate-trust/tokens.json
+++ b/packages/core/design-kits/corporate-trust/tokens.json
@@ -1,0 +1,34 @@
+{
+  "light": {
+    "bg": "oklch(98% 0.004 250)",
+    "surface": "oklch(100% 0 0)",
+    "fg": "oklch(25% 0.02 255)",
+    "muted": "oklch(50% 0.02 255)",
+    "primary": "oklch(48% 0.13 255)",
+    "accent": "oklch(48% 0.13 255)",
+    "success": "oklch(55% 0.13 150)",
+    "warning": "oklch(70% 0.15 80)",
+    "danger": "oklch(53% 0.18 27)",
+    "border": "oklch(90% 0.006 255)",
+    "ring": "oklch(48% 0.13 255)",
+    "radius": "0.5rem",
+    "fontSans": "Inter, IBM Plex Sans, system-ui, sans-serif",
+    "shadow": "0 1px 2px oklch(0% 0 0 / 0.06)"
+  },
+  "dark": {
+    "bg": "oklch(19% 0.012 255)",
+    "surface": "oklch(23% 0.014 255)",
+    "fg": "oklch(94% 0.01 255)",
+    "muted": "oklch(68% 0.02 255)",
+    "primary": "oklch(62% 0.13 255)",
+    "accent": "oklch(62% 0.13 255)",
+    "success": "oklch(64% 0.13 150)",
+    "warning": "oklch(76% 0.14 80)",
+    "danger": "oklch(64% 0.17 27)",
+    "border": "oklch(30% 0.014 255)",
+    "ring": "oklch(62% 0.13 255)",
+    "radius": "0.5rem",
+    "fontSans": "Inter, IBM Plex Sans, system-ui, sans-serif",
+    "shadow": "0 1px 2px oklch(0% 0 0 / 0.4)"
+  }
+}

--- a/packages/core/design-kits/dark-pro/KIT.md
+++ b/packages/core/design-kits/dark-pro/KIT.md
@@ -1,0 +1,67 @@
+---
+id: dark-pro
+name: Dark Pro
+aesthetic: Dark-first pro tool — deep neutrals, neon accents, terminal/IDE precision.
+tags: [dark, developer, pro, terminal, neon, technical]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [dark, light]
+bestFor: Developer tools, IDEs, terminals, crypto/trading, technical dashboards, power-user apps.
+version: 1.0.0
+---
+
+# Dark Pro
+
+## Overview
+A dark-first interface built for focus and density: deep, slightly-blue neutrals, a
+single electric accent (and a couple of semantic neons), monospace where it counts,
+and crisp hairlines. The aesthetic of a great IDE/terminal — precise, fast, low-glare.
+
+## Rules
+1. Dark-first: design the dark theme as primary; light is the secondary derivative.
+2. Deep neutral base (not pure black) with layered surfaces by subtle lightness steps.
+3. One electric accent + restrained semantic neons (green/amber/red) for status.
+4. Density is a feature: compact rows, monospace for code/IDs/numbers, tight but legible.
+5. Hairline 1px borders define structure; glow only on the accent/active states.
+6. Maintain contrast (AA+) despite the dark base — text never dips below 4.5:1.
+
+## Color
+- Dark (primary): bg `oklch(17% 0.015 265)`, surface `oklch(21% 0.018 265)`, raised
+  `oklch(25% 0.02 265)`, fg `oklch(93% 0.01 265)`, accent electric `oklch(72% 0.18 200)` (cyan)
+  or `oklch(70% 0.2 145)` (green); status: ok `oklch(72% 0.17 150)`, warn `oklch(78% 0.15 80)`, err `oklch(66% 0.2 25)`.
+- Light: bg `oklch(98% 0.004 265)`, fg `oklch(22% 0.02 265)`, same accent at lower lightness.
+
+## Typography
+- UI sans: Inter / Geist. Mono: JetBrains Mono / Geist Mono for code, IDs, metrics. Tabular nums.
+
+## Components
+**Do**
+- Compact toolbars, command palette (⌘K), keyboard-first; statusable rows; monospace data columns.
+- Buttons: subtle filled accent primary, ghost neutral secondary; active = accent glow ring.
+- Code/terminal blocks with syntax tints; badges with neon dot + label.
+
+**Don't**
+- No pure-black + pure-white (harsh). No heavy color washes. Keep glow tasteful, not gamer-RGB.
+
+## Motion
+- Quick and precise: 100–160ms ease-out; subtle accent glow on focus; instant feedback.
+- Reduced-motion: drop glows/transitions.
+
+## Stack: web
+- Tailwind v4 dark-first (`@theme` dark default, light under `.light`); shadcn/ui dark; `cmdk` palette;
+  monospace utility for data; focus glow via `ring` + `shadow-<accent>/30`.
+
+## Stack: react-native
+- NativeWind dark theme default; mono font via `expo-font`; compact lists; subtle accent borders;
+  command-sheet pattern; Reanimated quick fades.
+
+## Stack: flutter
+- M3 `darkColorScheme` primary; `ThemeMode.dark` default; mono `TextStyle` for data; `Material` raised
+  surfaces by elevation tint; quick `AnimatedContainer`.
+
+## Stack: swiftui
+- `.preferredColorScheme(.dark)`; semantic dark asset colors; monospaced `Font.system(.body, design: .monospaced)`;
+  `.tint(accent)`; subtle `.shadow` glow on focus.
+
+## Stack: compose
+- `darkColorScheme()` default; `FontFamily.Monospace` for data; tonal elevation surfaces; `.tint` accent;
+  quick `animateColorAsState` on focus/active.

--- a/packages/core/design-kits/dark-pro/tokens.json
+++ b/packages/core/design-kits/dark-pro/tokens.json
@@ -1,0 +1,38 @@
+{
+  "dark": {
+    "bg": "oklch(17% 0.015 265)",
+    "surface": "oklch(21% 0.018 265)",
+    "raised": "oklch(25% 0.02 265)",
+    "fg": "oklch(93% 0.01 265)",
+    "muted": "oklch(66% 0.02 265)",
+    "primary": "oklch(72% 0.18 200)",
+    "accent": "oklch(70% 0.2 145)",
+    "success": "oklch(72% 0.17 150)",
+    "warning": "oklch(78% 0.15 80)",
+    "danger": "oklch(66% 0.2 25)",
+    "border": "oklch(28% 0.018 265)",
+    "ring": "oklch(72% 0.18 200)",
+    "radius": "0.5rem",
+    "fontSans": "Inter, Geist, system-ui, sans-serif",
+    "fontMono": "JetBrains Mono, Geist Mono, ui-monospace, monospace",
+    "shadow": "0 0 0 1px oklch(72% 0.18 200 / 0.25)"
+  },
+  "light": {
+    "bg": "oklch(98% 0.004 265)",
+    "surface": "oklch(100% 0 0)",
+    "raised": "oklch(96% 0.004 265)",
+    "fg": "oklch(22% 0.02 265)",
+    "muted": "oklch(50% 0.02 265)",
+    "primary": "oklch(55% 0.16 200)",
+    "accent": "oklch(55% 0.18 145)",
+    "success": "oklch(58% 0.15 150)",
+    "warning": "oklch(70% 0.15 80)",
+    "danger": "oklch(56% 0.2 25)",
+    "border": "oklch(90% 0.006 265)",
+    "ring": "oklch(55% 0.16 200)",
+    "radius": "0.5rem",
+    "fontSans": "Inter, Geist, system-ui, sans-serif",
+    "fontMono": "JetBrains Mono, Geist Mono, ui-monospace, monospace",
+    "shadow": "0 1px 2px oklch(0% 0 0 / 0.06)"
+  }
+}

--- a/packages/core/design-kits/dopamine-pop/KIT.md
+++ b/packages/core/design-kits/dopamine-pop/KIT.md
@@ -1,0 +1,67 @@
+---
+id: dopamine-pop
+name: Dopamine Pop
+aesthetic: Y2K / dopamine design — saturated color, playful shapes, high energy, joyful.
+tags: [y2k, vibrant, playful, gen-z, energetic, fun]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: Consumer & social apps, events, music, youth brands, promos that need to feel alive.
+version: 1.0.0
+---
+
+# Dopamine Pop
+
+## Overview
+Maximal joy: saturated "dopamine" color, bold rounded shapes, sticker graphics, and
+bouncy motion. Y2K nostalgia (chrome, gradients, stars/sparkles) meets modern polish.
+Energetic but still usable — keep one clear path through the noise.
+
+## Rules
+1. Saturated, high-energy palette: 2–3 vivid hues that clash on purpose, on a bright or inky base.
+2. Big rounded shapes (pill buttons, blobby cards), playful iconography, stickers/emoji accents.
+3. Chunky type with personality; oversized headlines; occasional outline/sticker text.
+4. Motion is springy and fun — bounce, wobble, confetti on key moments.
+5. Keep ONE primary CTA visually dominant despite the energy.
+6. Maintain contrast/AA — vivid ≠ unreadable; darken text or add solid chips behind it.
+
+## Color
+- Light: base `oklch(98% 0.02 320)`, hot pink `oklch(70% 0.24 350)`, electric blue
+  `oklch(68% 0.2 250)`, lime `oklch(85% 0.2 130)`, sunny `oklch(88% 0.18 95)`.
+- Dark: inky `oklch(20% 0.05 300)` base, same neons cranked, with glow.
+
+## Typography
+- Display: Clash Display / Cabinet Grotesk / a rounded heavy sans. Big, tight, bold.
+- Rounded sans body (Nunito / Plus Jakarta). Playful but legible.
+
+## Components
+**Do**
+- Pill buttons with vivid fills + soft colored glow; blobby cards; gradient/holographic accents.
+- Sticker badges, sparkle/star motifs, emoji-scale icons; bold tag chips.
+- Hover: bounce/scale 1.05 + glow; click: squish + confetti for celebrations.
+
+**Don't**
+- Don't let everything scream equally — one hero CTA. Don't sacrifice readability for saturation.
+
+## Motion
+- Springy (overshoot) 250–400ms; wobble/jiggle on tap; confetti/sparkle on success.
+- Reduced-motion: drop bounce/confetti, simple fade/scale.
+
+## Stack: web
+- Tailwind v4 vivid palette + `rounded-full`; gradient utilities; Motion springs (`type:'spring', bounce:0.5`);
+  a confetti lib (canvas-confetti) for celebrations; holographic gradient text via `bg-clip-text`.
+
+## Stack: react-native
+- NativeWind vivid tokens; Reanimated `withSpring` bounce; `expo-linear-gradient` pills;
+  haptics on tap (`expo-haptics`); lottie/confetti for moments.
+
+## Stack: flutter
+- M3 with vivid seed + custom bright scheme; `AnimatedScale`/`SpringSimulation`; `StadiumBorder` buttons;
+  `confetti` package; gradient containers.
+
+## Stack: swiftui
+- Bright asset colors + gradients; `.buttonStyle` custom pill; spring `.animation(.bouncy)`;
+  `.sensoryFeedback`; particle/confetti via `TimelineView`/SpriteKit for big moments.
+
+## Stack: compose
+- Vivid M3 scheme; `Modifier.clip(CircleShape)` pills; `spring(dampingRatio = Bouncy)`;
+  gradient `Brush`; haptics; confetti via custom canvas.

--- a/packages/core/design-kits/dopamine-pop/tokens.json
+++ b/packages/core/design-kits/dopamine-pop/tokens.json
@@ -1,0 +1,32 @@
+{
+  "light": {
+    "bg": "oklch(98% 0.02 320)",
+    "surface": "oklch(100% 0 0)",
+    "fg": "oklch(22% 0.05 320)",
+    "muted": "oklch(55% 0.05 320)",
+    "primary": "oklch(70% 0.24 350)",
+    "accent": "oklch(68% 0.2 250)",
+    "accent2": "oklch(85% 0.2 130)",
+    "border": "oklch(90% 0.04 320)",
+    "ring": "oklch(70% 0.24 350)",
+    "radius": "1.75rem",
+    "fontDisplay": "Clash Display, Cabinet Grotesk, system-ui, sans-serif",
+    "fontSans": "Plus Jakarta Sans, Nunito, system-ui, sans-serif",
+    "shadow": "0 8px 24px oklch(70% 0.24 350 / 0.3)"
+  },
+  "dark": {
+    "bg": "oklch(20% 0.05 300)",
+    "surface": "oklch(25% 0.05 300)",
+    "fg": "oklch(96% 0.03 320)",
+    "muted": "oklch(75% 0.05 320)",
+    "primary": "oklch(74% 0.24 350)",
+    "accent": "oklch(72% 0.2 250)",
+    "accent2": "oklch(85% 0.2 130)",
+    "border": "oklch(34% 0.05 300)",
+    "ring": "oklch(74% 0.24 350)",
+    "radius": "1.75rem",
+    "fontDisplay": "Clash Display, Cabinet Grotesk, system-ui, sans-serif",
+    "fontSans": "Plus Jakarta Sans, Nunito, system-ui, sans-serif",
+    "shadow": "0 8px 28px oklch(70% 0.24 350 / 0.45)"
+  }
+}

--- a/packages/core/design-kits/editorial/KIT.md
+++ b/packages/core/design-kits/editorial/KIT.md
@@ -1,0 +1,66 @@
+---
+id: editorial
+name: Editorial
+aesthetic: Magazine typography — serif display, asymmetric grids, big type, content-forward.
+tags: [editorial, typography, magazine, content, elegant]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: Blogs, publications, agencies, brand storytelling, marketing sites where words lead.
+version: 1.0.0
+---
+
+# Editorial
+
+## Overview
+Typography is the interface. Big expressive serif (or contrast serif/sans pairing),
+asymmetric editorial grids, generous measure, and restrained color so the words and
+imagery carry the page. Think a well-set magazine spread: rhythm, hierarchy, and pace.
+
+## Rules
+1. Lead with a display serif at large sizes; let headlines breathe.
+2. Asymmetric, column-based layouts — not everything centered; use the grid expressively.
+3. Long-form measure 60–75ch; line-height 1.6–1.75 for body.
+4. Minimal palette: ink, paper, one accent for links/marks. Color comes from imagery.
+5. Real typographic detail: drop caps, pull quotes, hanging punctuation, small caps for labels.
+6. Big, edge-to-edge imagery with captions.
+
+## Color
+- Light: warm paper `oklch(98% 0.01 85)`, ink `oklch(22% 0.01 60)`, accent `oklch(52% 0.16 25)` (vermillion).
+- Dark: `oklch(20% 0.01 60)` bg, `oklch(94% 0.01 85)` fg, accent `oklch(70% 0.14 25)`.
+
+## Typography
+- Display serif: Fraunces / Playfair / GT Sectra. Body: Newsreader / Source Serif, or
+  a clean sans (Inter) paired with the serif display for contrast.
+- Expressive scale: 0.875, 1, 1.25, 1.75, 2.75, 4. Italics for emphasis, not bold.
+
+## Components
+**Do**
+- Article hero: oversized serif headline, kicker (small caps), byline, lead paragraph.
+- Pull quotes set large with hanging quotation marks; drop cap on first paragraph.
+- Underline-on-hover links in the accent color; figure + caption pairs.
+
+**Don't**
+- Don't box everything in cards. Don't over-color. Avoid cramped measure / tight leading.
+
+## Motion
+- Quiet: text fades/rises 6–10px on scroll-in (staggered). 300–500ms ease-out.
+- Reduced-motion: reveal instantly.
+
+## Stack: web
+- Tailwind v4 with a serif `--font-display`; `prose` (typography plugin) for article bodies;
+  CSS `columns`/grid for asymmetric layouts; `text-balance`/`text-pretty` on headings.
+
+## Stack: react-native
+- Custom serif via `expo-font`; large `Text` hierarchy; generous `lineHeight`; reanimated FadeInUp on scroll.
+
+## Stack: flutter
+- `google_fonts` (Fraunces/Newsreader); `TextTheme` with strong display/headline scale;
+  `RichText` for pull quotes/drop caps; `CustomScrollView` slivers for editorial flow.
+
+## Stack: swiftui
+- Custom serif `Font`; `Text` with `.kerning`/`.lineSpacing`; Dynamic Type respected;
+  `ScrollView` with large headlines, `.italic()` for emphasis.
+
+## Stack: compose
+- `FontFamily` serif via resources; expressive `Typography` in `MaterialTheme`;
+  `Text` with `lineHeight`/`letterSpacing`; lazy column with big hero items.

--- a/packages/core/design-kits/editorial/tokens.json
+++ b/packages/core/design-kits/editorial/tokens.json
@@ -1,0 +1,30 @@
+{
+  "light": {
+    "bg": "oklch(98% 0.01 85)",
+    "surface": "oklch(99% 0.005 85)",
+    "fg": "oklch(22% 0.01 60)",
+    "muted": "oklch(48% 0.02 60)",
+    "primary": "oklch(52% 0.16 25)",
+    "accent": "oklch(52% 0.16 25)",
+    "border": "oklch(88% 0.01 70)",
+    "ring": "oklch(52% 0.16 25)",
+    "radius": "0.25rem",
+    "fontDisplay": "Fraunces, Playfair Display, Georgia, serif",
+    "fontSans": "Inter, system-ui, sans-serif",
+    "shadow": "none"
+  },
+  "dark": {
+    "bg": "oklch(20% 0.01 60)",
+    "surface": "oklch(24% 0.01 60)",
+    "fg": "oklch(94% 0.01 85)",
+    "muted": "oklch(70% 0.02 70)",
+    "primary": "oklch(70% 0.14 25)",
+    "accent": "oklch(70% 0.14 25)",
+    "border": "oklch(32% 0.01 60)",
+    "ring": "oklch(70% 0.14 25)",
+    "radius": "0.25rem",
+    "fontDisplay": "Fraunces, Playfair Display, Georgia, serif",
+    "fontSans": "Inter, system-ui, sans-serif",
+    "shadow": "none"
+  }
+}

--- a/packages/core/design-kits/ios-native/KIT.md
+++ b/packages/core/design-kits/ios-native/KIT.md
@@ -1,0 +1,63 @@
+---
+id: ios-native
+name: iOS Native (HIG)
+aesthetic: Apple Human Interface Guidelines — clarity, deference, depth, native materials.
+tags: [ios, apple, hig, native, mobile, liquid-glass]
+stacks: [swiftui, react-native, web, flutter]
+themes: [light, dark]
+bestFor: iOS apps that should feel truly native, plus web/RN that wants an Apple-grade feel.
+version: 1.0.0
+---
+
+# iOS Native (HIG)
+
+## Overview
+The Apple idiom: content-first clarity, deference (UI defers to content), and depth via
+translucent **materials** and layering. Uses system semantics — SF Pro + SF Symbols,
+Dynamic Type, system colors, standard navigation patterns, and the modern translucent
+("Liquid Glass") chrome. The result feels at home on iOS, not ported to it.
+
+## Rules
+1. Clarity, deference, depth. Let content lead; chrome is translucent and recedes.
+2. Use **system semantics**: SF Pro text styles (Dynamic Type), SF Symbols, semantic colors
+   (`label`, `secondaryLabel`, `systemBackground`, `tint`). Don't hard-code grays.
+3. Standard navigation: large titles, nav bars, tab bars, sheets, swipe-back, context menus.
+4. Materials for depth (`ultraThin`…`thick`), not heavy shadows. Respect safe areas.
+5. Controls follow platform metrics & a11y: 44pt targets, VoiceOver, Reduce Motion/Transparency.
+6. One tint color drives interactive elements; otherwise neutral system surfaces.
+
+## Color & type
+- Semantic system colors with automatic light/dark; a single app `tint`.
+- SF Pro (Text/Display) via system fonts; Dynamic Type text styles (`.largeTitle`…`.caption`).
+
+## Components
+**Do**
+- `NavigationStack` with large titles; `TabView`; `.sheet`/`.presentationDetents`; `List` (inset grouped);
+  `Form` for settings; `Menu`/context menus; `.searchable`.
+- Buttons: `.borderedProminent` primary, `.bordered`/`.plain` secondary; SF Symbols in controls.
+- Materials: `.regularMaterial`/`.ultraThinMaterial` toolbars and cards; `.background` safe-area aware.
+
+**Don't**
+- Don't reinvent native controls or navigation. Don't fight Dynamic Type. Avoid custom non-semantic grays.
+
+## Motion
+- Native, physics-based (`.snappy`/`.bouncy`/`.smooth`); standard push/sheet transitions.
+- Honor Reduce Motion (cross-fade instead of slide) and Reduce Transparency (solid fallback).
+
+## Stack: swiftui
+- SwiftUI is the native target. `NavigationStack`, `List(.insetGrouped)`, `.toolbar`, `.sheet`,
+  `.tint`, `Label("...", systemImage: "...")`, `@Environment(\.colorScheme)`, `.dynamicTypeSize`.
+- Materials via `.background(.regularMaterial)`; `@ScaledMetric` for adaptive spacing.
+
+## Stack: react-native
+- Match HIG: large-title header, native-feeling tab bar, action sheets, swipe-back; SF Symbols via
+  `sf-symbols`/`expo-symbols`; `expo-blur` for materials; respect Dynamic Type (`allowFontScaling`),
+  safe-area insets; haptics on key actions.
+
+## Stack: web
+- Apple-like web: SF Pro/`-apple-system` stack, translucent sticky headers (`backdrop-blur`),
+  inset-grouped list styling, generous spacing, `prefers-reduced-transparency`/`-motion` fallbacks.
+
+## Stack: flutter
+- Use `cupertino` widgets: `CupertinoApp`/`CupertinoNavigationBar`/`CupertinoButton`/`CupertinoListSection`;
+  `CupertinoColors` semantic; SF font; respect `MediaQuery` text scale + reduce-motion.

--- a/packages/core/design-kits/ios-native/tokens.json
+++ b/packages/core/design-kits/ios-native/tokens.json
@@ -1,0 +1,34 @@
+{
+  "light": {
+    "bg": "oklch(98% 0.001 250)",
+    "surface": "oklch(100% 0 0)",
+    "groupedBg": "oklch(96% 0.002 250)",
+    "fg": "oklch(15% 0.01 260)",
+    "muted": "oklch(55% 0.01 260)",
+    "primary": "oklch(60% 0.2 255)",
+    "accent": "oklch(60% 0.2 255)",
+    "success": "oklch(68% 0.17 150)",
+    "danger": "oklch(60% 0.21 25)",
+    "border": "oklch(90% 0.003 260)",
+    "ring": "oklch(60% 0.2 255)",
+    "radius": "0.75rem",
+    "fontSans": "-apple-system, SF Pro Text, system-ui, sans-serif",
+    "material": "blur(30px) saturate(180%)"
+  },
+  "dark": {
+    "bg": "oklch(15% 0.005 260)",
+    "surface": "oklch(20% 0.006 260)",
+    "groupedBg": "oklch(13% 0.005 260)",
+    "fg": "oklch(98% 0.005 260)",
+    "muted": "oklch(68% 0.01 260)",
+    "primary": "oklch(70% 0.18 255)",
+    "accent": "oklch(70% 0.18 255)",
+    "success": "oklch(72% 0.16 150)",
+    "danger": "oklch(66% 0.2 25)",
+    "border": "oklch(28% 0.006 260)",
+    "ring": "oklch(70% 0.18 255)",
+    "radius": "0.75rem",
+    "fontSans": "-apple-system, SF Pro Text, system-ui, sans-serif",
+    "material": "blur(30px) saturate(180%)"
+  }
+}

--- a/packages/core/design-kits/material-expressive/KIT.md
+++ b/packages/core/design-kits/material-expressive/KIT.md
@@ -1,0 +1,62 @@
+---
+id: material-expressive
+name: Material 3 Expressive
+aesthetic: Google Material 3 Expressive — dynamic color, bold shapes, lively motion.
+tags: [material, android, m3, expressive, dynamic-color, google]
+stacks: [compose, flutter, web, react-native]
+themes: [light, dark]
+bestFor: Android apps and cross-platform products that want Google's expressive, adaptive system.
+version: 1.0.0
+---
+
+# Material 3 Expressive
+
+## Overview
+Material 3 in its expressive form: dynamic, user-personalized color (from a seed or
+wallpaper), an expanded **shape** library, flexible type, and physics-based **motion**
+that gives the UI character. Components are tonal and adaptive; emphasis comes from
+color roles, shape, and motion rather than borders and shadows.
+
+## Rules
+1. Color **roles**, not raw colors: `primary`/`onPrimary`/`primaryContainer`/`surface`/`surfaceVariant`/
+   `outline`… generated from a seed via tonal palettes (or dynamic color where available).
+2. Tonal elevation: surfaces lift via tint/elevation, not heavy drop shadows.
+3. Expressive shapes: varied corner families (rounded → larger, some asymmetric); the M3 shape scale.
+4. Motion physics: spring-based, emphasized easing; container transforms between states; expressive but purposeful.
+5. Components from the M3 set (FAB, extended FAB, chips, navigation bar/rail, cards, split button).
+6. Accessibility: dynamic-contrast aware, large touch targets, honor system animation scale.
+
+## Color & type
+- Seed-based scheme: light + dark from `ColorScheme.fromSeed` / dynamic color. Roles drive everything.
+- Type: Roboto / Google Sans Flex with the M3 type scale (display/headline/title/body/label).
+
+## Components
+**Do**
+- Navigation bar/rail; FAB & extended FAB; assist/filter/input chips; `Card`/`ElevatedCard`;
+  filled/tonal/outlined/text buttons; the new **split button**; large expressive shapes for hero elements.
+- Emphasis via `primaryContainer`/`secondaryContainer` fills; tonal surfaces by elevation.
+
+**Don't**
+- Don't hard-code hex outside the scheme. Don't lean on shadows/borders for hierarchy — use tone + shape.
+
+## Motion
+- Spring physics + emphasized easing; shared-axis / container-transform transitions; expressive overshoot.
+- Honor `Settings.Global` animation scale / reduce-motion: fall back to fades.
+
+## Stack: compose
+- Jetpack Compose + Material 3 (`androidx.compose.material3`, expressive APIs). `MaterialTheme` with
+  `dynamicColorScheme()` (Android 12+) or `lightColorScheme()/darkColorScheme()` from a seed;
+  `Scaffold` + `NavigationBar`; `FloatingActionButton`; `MaterialShapes`; `spring()`/`MotionScheme`.
+
+## Stack: flutter
+- Flutter 3.41+ `useMaterial3: true`, `ColorScheme.fromSeed(...)` (+ `dynamic_color` package);
+  `NavigationBar`, `FilledButton`, `Card`, `Chip`; `MaterialApp` themeMode; expressive shapes via
+  `ShapeBorder`; animate with `AnimatedContainer`/implicit + spring curves.
+
+## Stack: web
+- Material Web (`@material/web`) or an M3 token system: generate roles from a seed (material-color-utilities),
+  expose as CSS custom properties (light/dark), tonal surfaces, M3 shape/type scales; motion via Web Animations.
+
+## Stack: react-native
+- `react-native-paper` (Material 3) with `MD3LightTheme`/`MD3DarkTheme` from a seed; `FAB`, `Chip`,
+  `Card`, navigation bar; Reanimated springs for expressive transitions; dynamic color where available.

--- a/packages/core/design-kits/material-expressive/tokens.json
+++ b/packages/core/design-kits/material-expressive/tokens.json
@@ -1,0 +1,32 @@
+{
+  "light": {
+    "bg": "oklch(98% 0.005 300)",
+    "surface": "oklch(98% 0.008 300)",
+    "surfaceVariant": "oklch(92% 0.02 300)",
+    "fg": "oklch(20% 0.02 300)",
+    "muted": "oklch(50% 0.02 300)",
+    "primary": "oklch(55% 0.18 300)",
+    "primaryContainer": "oklch(90% 0.08 300)",
+    "accent": "oklch(60% 0.15 200)",
+    "outline": "oklch(60% 0.02 300)",
+    "ring": "oklch(55% 0.18 300)",
+    "radius": "1rem",
+    "fontSans": "Roboto, Google Sans Flex, system-ui, sans-serif",
+    "shadow": "0 1px 3px oklch(0% 0 0 / 0.12)"
+  },
+  "dark": {
+    "bg": "oklch(18% 0.015 300)",
+    "surface": "oklch(22% 0.018 300)",
+    "surfaceVariant": "oklch(30% 0.025 300)",
+    "fg": "oklch(94% 0.01 300)",
+    "muted": "oklch(70% 0.02 300)",
+    "primary": "oklch(78% 0.14 300)",
+    "primaryContainer": "oklch(38% 0.1 300)",
+    "accent": "oklch(72% 0.13 200)",
+    "outline": "oklch(50% 0.02 300)",
+    "ring": "oklch(78% 0.14 300)",
+    "radius": "1rem",
+    "fontSans": "Roboto, Google Sans Flex, system-ui, sans-serif",
+    "shadow": "0 1px 3px oklch(0% 0 0 / 0.4)"
+  }
+}

--- a/packages/core/design-kits/minimal-clarity/KIT.md
+++ b/packages/core/design-kits/minimal-clarity/KIT.md
@@ -1,0 +1,82 @@
+---
+id: minimal-clarity
+name: Minimal Clarity
+aesthetic: Restrained, Linear/Vercel-style minimalism — whitespace, one accent, crisp type.
+tags: [minimal, saas, product, clean, professional]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: Developer tools, SaaS dashboards, docs, and B2B products that must feel precise and calm.
+version: 1.0.0
+---
+
+# Minimal Clarity
+
+## Overview
+Clarity over decoration. Near-neutral surfaces, a single confident accent, generous
+whitespace, and a tight type scale. The interface should feel quiet, fast, and
+trustworthy — every pixel earns its place. Inspired by Linear, Vercel, and Stripe.
+
+## Rules
+1. One accent color. Everything else is a neutral gray ramp.
+2. Whitespace is the primary design tool — increase padding before adding borders.
+3. Hairline borders (1px, low-contrast) and very soft shadows, never both heavy.
+4. Small radii (6–10px). Restrained, not pill-shaped.
+5. Type does the hierarchy: weight + size + muted color, not boxes and color blocks.
+6. Dense but breathable: 8px rhythm, comfortable line-height (1.5 body).
+
+## Color
+- Light: paper-white bg `oklch(99% 0 0)`, ink `oklch(20% 0.02 260)`, hairline
+  `oklch(92% 0.004 260)`, accent indigo `oklch(58% 0.16 264)`.
+- Dark: bg `oklch(18% 0.01 260)`, surface `oklch(22% 0.012 260)`, fg
+  `oklch(95% 0.01 260)`, accent `oklch(68% 0.15 264)`.
+- Muted text sits ~`oklch(55% 0.02 260)` light / `oklch(68% 0.02 260)` dark.
+
+## Typography
+- Sans: Inter / Geist (system-ui fallback). Mono: Geist Mono / ui-monospace.
+- Scale (rem): 0.8125, 0.875, 1, 1.125, 1.5, 2, 2.75. Tight tracking on display.
+- Weights: 400 body, 500 UI labels, 600 headings. Avoid 700+.
+
+## Components
+**Do**
+- Buttons: solid accent primary, subtle neutral secondary, ghost tertiary. 36–40px height.
+- Cards: surface bg + 1px hairline, no shadow (or `0 1px 2px` at 4% alpha).
+- Inputs: 1px border, accent focus ring (2px, 40% alpha), generous padding.
+- Tables: zebra-free, hairline row dividers, muted headers.
+
+**Don't**
+- No drop shadows stacked on borders. No gradients. No more than one accent.
+- No full-width hero gradients — keep it editorial and quiet.
+
+## Motion
+- Subtle: 120–180ms ease-out. Hover = 8% bg tint shift; press = 1px translate.
+- Page/route: fade + 4px rise. Honor reduced-motion (opacity only).
+
+## Stack: web
+- Tailwind v4 `@theme` with OKLCH variables; shadcn/ui "new-york" with neutral base.
+```css
+@theme {
+  --color-bg: oklch(99% 0 0);
+  --color-fg: oklch(20% 0.02 260);
+  --color-primary: oklch(58% 0.16 264);
+  --color-border: oklch(92% 0.004 260);
+  --radius: 0.5rem;
+}
+.dark { --color-bg: oklch(18% 0.01 260); --color-fg: oklch(95% 0.01 260); }
+```
+- Buttons via shadcn `<Button variant="default|secondary|ghost">`; Motion for route fades.
+
+## Stack: react-native
+- NativeWind tokens mirroring the web `@theme`; `Pressable` with `active:opacity-80`.
+- Use `react-native-reanimated` `FadeIn`/`FadeInUp` (8px) entrances; thin `hairlineWidth` dividers.
+
+## Stack: flutter
+- `ColorScheme.fromSeed(seedColor: Color(0xFF5B5BD6))`, `useMaterial3: true`, small
+  `RoundedRectangleBorder` radii; `FilledButton` primary, `OutlinedButton` secondary.
+
+## Stack: swiftui
+- Accent via asset-catalog color; `.buttonStyle(.borderedProminent)` primary, `.bordered`
+  secondary; `Divider()` hairlines; generous `.padding()`; SF Pro + Dynamic Type.
+
+## Stack: compose
+- Material 3 with a neutral `ColorScheme`, indigo primary; `FilledTonalButton` secondary,
+  `Card` with 1.dp outline; small `RoundedCornerShape(8.dp)`.

--- a/packages/core/design-kits/minimal-clarity/tokens.json
+++ b/packages/core/design-kits/minimal-clarity/tokens.json
@@ -1,0 +1,30 @@
+{
+  "light": {
+    "bg": "oklch(99% 0 0)",
+    "surface": "oklch(98% 0.002 260)",
+    "fg": "oklch(20% 0.02 260)",
+    "muted": "oklch(55% 0.02 260)",
+    "primary": "oklch(58% 0.16 264)",
+    "accent": "oklch(58% 0.16 264)",
+    "border": "oklch(92% 0.004 260)",
+    "ring": "oklch(58% 0.16 264)",
+    "radius": "0.5rem",
+    "fontSans": "Inter, Geist, system-ui, sans-serif",
+    "fontMono": "Geist Mono, ui-monospace, monospace",
+    "shadow": "0 1px 2px oklch(0% 0 0 / 0.04)"
+  },
+  "dark": {
+    "bg": "oklch(18% 0.01 260)",
+    "surface": "oklch(22% 0.012 260)",
+    "fg": "oklch(95% 0.01 260)",
+    "muted": "oklch(68% 0.02 260)",
+    "primary": "oklch(68% 0.15 264)",
+    "accent": "oklch(68% 0.15 264)",
+    "border": "oklch(30% 0.012 260)",
+    "ring": "oklch(68% 0.15 264)",
+    "radius": "0.5rem",
+    "fontSans": "Inter, Geist, system-ui, sans-serif",
+    "fontMono": "Geist Mono, ui-monospace, monospace",
+    "shadow": "0 1px 2px oklch(0% 0 0 / 0.4)"
+  }
+}

--- a/packages/core/design-kits/neo-brutalist/KIT.md
+++ b/packages/core/design-kits/neo-brutalist/KIT.md
@@ -1,0 +1,70 @@
+---
+id: neo-brutalist
+name: Neo-Brutalist
+aesthetic: Raw, bold, anti-design — hard borders, blunt shadows, mono type, high contrast.
+tags: [brutalism, bold, edgy, expressive, anti-design]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: Creative portfolios, subculture brands, dev tools with attitude, launch/landing pages that must stand out.
+version: 1.0.0
+---
+
+# Neo-Brutalist
+
+## Overview
+Loud, honest, and confident. Thick black borders, flat blocks of saturated color,
+chunky offset "hard" shadows, and unapologetic typography. Nothing is soft — corners
+are sharp or barely rounded, shadows don't blur, and contrast is maximal. Done well
+it reads as designed-on-purpose, not unfinished.
+
+## Rules
+1. Thick borders everywhere: 2–4px solid, near-black (or near-white in dark).
+2. Hard offset shadows: `4px 4px 0 #000` — zero blur. Shadow is a design element.
+3. Flat, saturated color blocks. No gradients, no soft shadows.
+4. Big, tight, confident type — often uppercase, mono or grotesque.
+5. Visible structure: show the grid, let elements collide and overlap intentionally.
+6. Interactions are physical: press = shift toward the shadow (translate + remove shadow).
+
+## Color
+- Light: paper `oklch(97% 0.02 95)` (warm off-white), ink `oklch(15% 0 0)`,
+  primary electric `oklch(72% 0.2 145)` (lime), accent `oklch(70% 0.2 25)` (red-orange),
+  pops of `oklch(80% 0.18 200)` (cyan) / `oklch(85% 0.19 95)` (yellow).
+- Dark: bg `oklch(16% 0 0)`, ink `oklch(96% 0 0)`, same saturated accents.
+
+## Typography
+- Display: Space Grotesk / Archivo / a heavy grotesque. Mono: JetBrains Mono / Space Mono.
+- Big jumps in scale, tight tracking, heavy weights (700–900) for headings; uppercase labels.
+
+## Components
+**Do**
+- Buttons/cards/inputs: solid fill + 3px border + `4px 4px 0` hard shadow.
+- On hover: translate(-2px,-2px) + grow shadow to `6px 6px 0`; on press: translate to shadow, remove it.
+- Tag/badge chips with borders; sticker-like overlapping layout.
+
+**Don't**
+- No blur, no soft shadows, no subtle grays-on-grays. No timid pastel-only palettes.
+- Keep contrast high — borders and text must hit AAA where possible.
+
+## Motion
+- Snappy, mechanical: 80–140ms, `steps()` or sharp ease. Things "clack" into place.
+- Reduced-motion: keep the shadow/translate state changes instant.
+
+## Stack: web
+- Tailwind v4 utility set: `border-[3px] border-black shadow-[4px_4px_0_#000] rounded-none active:translate-x-1 active:translate-y-1 active:shadow-none`.
+- Use CSS vars for the accent blocks; avoid shadcn's soft defaults — override radius/shadow tokens.
+
+## Stack: react-native
+- NativeWind borders + a manually-drawn offset shadow `View` (RN has no hard-shadow primitive):
+  stack a black `View` offset by 4px behind the element. `Pressable` shifts it on press.
+
+## Stack: flutter
+- `Container(decoration: BoxDecoration(border: Border.all(width:3), boxShadow:[BoxShadow(offset: Offset(4,4), blurRadius: 0)]))`,
+  `Colors`-flat fills, `RoundedRectangleBorder(0)`; press animates offset.
+
+## Stack: swiftui
+- `RoundedRectangle(cornerRadius: 0).stroke(.black, lineWidth: 3)` + a `.offset` black shadow rect;
+  bold `.font(.system(.title, design: .monospaced).weight(.black))`.
+
+## Stack: compose
+- `Modifier.border(3.dp, Color.Black)` + custom offset shadow `Box`; flat `Color` fills;
+  `RoundedCornerShape(0.dp)`; mono `FontFamily.Monospace`, `FontWeight.Black`.

--- a/packages/core/design-kits/neo-brutalist/tokens.json
+++ b/packages/core/design-kits/neo-brutalist/tokens.json
@@ -1,0 +1,30 @@
+{
+  "light": {
+    "bg": "oklch(97% 0.02 95)",
+    "surface": "oklch(100% 0 0)",
+    "fg": "oklch(15% 0 0)",
+    "muted": "oklch(40% 0 0)",
+    "primary": "oklch(72% 0.2 145)",
+    "accent": "oklch(70% 0.2 25)",
+    "border": "oklch(15% 0 0)",
+    "ring": "oklch(70% 0.2 25)",
+    "radius": "0rem",
+    "fontSans": "Space Grotesk, Archivo, system-ui, sans-serif",
+    "fontMono": "JetBrains Mono, Space Mono, monospace",
+    "shadow": "4px 4px 0 oklch(15% 0 0)"
+  },
+  "dark": {
+    "bg": "oklch(16% 0 0)",
+    "surface": "oklch(20% 0 0)",
+    "fg": "oklch(96% 0 0)",
+    "muted": "oklch(70% 0 0)",
+    "primary": "oklch(75% 0.2 145)",
+    "accent": "oklch(72% 0.2 25)",
+    "border": "oklch(96% 0 0)",
+    "ring": "oklch(75% 0.2 145)",
+    "radius": "0rem",
+    "fontSans": "Space Grotesk, Archivo, system-ui, sans-serif",
+    "fontMono": "JetBrains Mono, Space Mono, monospace",
+    "shadow": "4px 4px 0 oklch(96% 0 0)"
+  }
+}

--- a/packages/core/design-kits/playful-rounded/KIT.md
+++ b/packages/core/design-kits/playful-rounded/KIT.md
@@ -1,0 +1,66 @@
+---
+id: playful-rounded
+name: Playful Rounded
+aesthetic: Friendly & warm — soft rounded shapes, cozy colors, approachable and human.
+tags: [friendly, rounded, consumer, warm, approachable, mobile]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: Consumer mobile apps, onboarding, education, wellness, communities — anything that should feel kind.
+version: 1.0.0
+---
+
+# Playful Rounded
+
+## Overview
+Soft and welcoming. Big border radii, pillowy cards, warm friendly colors, rounded
+typography, and gentle illustrations/mascots. Reads approachable and human — great
+for consumer mobile where the product should feel like a friend, not a tool.
+
+## Rules
+1. Generous radii everywhere (16–28px); pillowy cards with soft, diffuse shadows.
+2. Warm, slightly desaturated palette; soft pastel surfaces with a friendly primary.
+3. Rounded sans typography; comfortable sizes; emoji/illustration accents welcome.
+4. Big, tappable, obvious controls — mobile-first ergonomics, thumb-reachable CTAs.
+5. Soft depth: layered soft shadows + tints, never hard edges.
+6. Encouraging microcopy + delightful but gentle micro-interactions.
+
+## Color
+- Light: bg `oklch(98% 0.01 80)` (warm cream), surface white, fg `oklch(30% 0.03 40)`,
+  primary coral `oklch(70% 0.16 40)`, secondary mint `oklch(80% 0.1 160)`, sky `oklch(80% 0.1 230)`.
+- Dark: bg `oklch(24% 0.02 40)`, surface `oklch(28% 0.02 40)`, fg `oklch(94% 0.01 60)`.
+
+## Typography
+- Rounded sans: Nunito / Quicksand / Baloo / SF Rounded. Friendly weights 500–700.
+
+## Components
+**Do**
+- Pillowy cards: big radius + soft shadow + subtle tint. Pill buttons; large rounded inputs.
+- Bottom-nav / FAB for mobile; soft segmented controls; rounded avatars; gentle empty-state illustrations.
+- Tap feedback: soft scale + spring; success states with friendly checkmarks.
+
+**Don't**
+- No sharp corners or hard shadows. Avoid clinical grays. Don't crowd — keep it airy and tappable.
+
+## Motion
+- Gentle springs (low overshoot) 200–300ms; soft scale on tap; playful but calm transitions.
+- Reduced-motion: simple fades.
+
+## Stack: web
+- Tailwind v4 `rounded-3xl`, soft `shadow-lg shadow-<accent>/20`; rounded font var; Motion gentle springs;
+  large touch targets; mobile bottom-nav pattern.
+
+## Stack: react-native
+- NativeWind big radii + soft shadows; `Pressable` spring scale (Reanimated); bottom tab navigator;
+  SF Rounded / custom rounded font; haptics on tap.
+
+## Stack: flutter
+- M3 with warm seed; `Card(shape: RoundedRectangleBorder(28))`; `FilledButton.tonal` pills;
+  `NavigationBar` bottom nav; soft `BoxShadow`; gentle `AnimatedScale`.
+
+## Stack: swiftui
+- `RoundedRectangle(cornerRadius: 24)` cards with soft `.shadow`; SF Rounded `.fontDesign(.rounded)`;
+  `TabView` bottom tabs; spring `.animation(.snappy)` taps; sensory feedback.
+
+## Stack: compose
+- M3 warm scheme; `RoundedCornerShape(24.dp)` cards; `NavigationBar`; soft shadow via `Modifier.shadow`;
+  `spring()` tap scale; rounded `FontFamily`.

--- a/packages/core/design-kits/playful-rounded/tokens.json
+++ b/packages/core/design-kits/playful-rounded/tokens.json
@@ -1,0 +1,30 @@
+{
+  "light": {
+    "bg": "oklch(98% 0.01 80)",
+    "surface": "oklch(100% 0 0)",
+    "fg": "oklch(30% 0.03 40)",
+    "muted": "oklch(58% 0.03 40)",
+    "primary": "oklch(70% 0.16 40)",
+    "accent": "oklch(80% 0.1 160)",
+    "accent2": "oklch(80% 0.1 230)",
+    "border": "oklch(92% 0.02 60)",
+    "ring": "oklch(70% 0.16 40)",
+    "radius": "1.5rem",
+    "fontSans": "Nunito, Quicksand, SF Rounded, system-ui, sans-serif",
+    "shadow": "0 10px 24px oklch(70% 0.16 40 / 0.18)"
+  },
+  "dark": {
+    "bg": "oklch(24% 0.02 40)",
+    "surface": "oklch(28% 0.02 40)",
+    "fg": "oklch(94% 0.01 60)",
+    "muted": "oklch(74% 0.02 50)",
+    "primary": "oklch(74% 0.15 40)",
+    "accent": "oklch(80% 0.1 160)",
+    "accent2": "oklch(80% 0.1 230)",
+    "border": "oklch(36% 0.02 40)",
+    "ring": "oklch(74% 0.15 40)",
+    "radius": "1.5rem",
+    "fontSans": "Nunito, Quicksand, SF Rounded, system-ui, sans-serif",
+    "shadow": "0 10px 28px oklch(0% 0 0 / 0.45)"
+  }
+}

--- a/packages/core/design-kits/soft-glass/KIT.md
+++ b/packages/core/design-kits/soft-glass/KIT.md
@@ -1,0 +1,71 @@
+---
+id: soft-glass
+name: Soft Glass
+aesthetic: Refined glassmorphism — frosted translucent layers, depth, vibrant-but-tasteful.
+tags: [glassmorphism, depth, modern, premium, blur]
+stacks: [web, react-native, flutter, swiftui, compose]
+themes: [light, dark]
+bestFor: Premium consumer apps, dashboards over imagery, OS-like surfaces, Apple-adjacent products.
+version: 1.0.0
+---
+
+# Soft Glass
+
+## Overview
+2026 glassmorphism done with restraint: translucent frosted panels floating over a
+soft, colorful backdrop, with real depth from layered blur, thin luminous borders,
+and gentle inner glow. The trick is **intent** — glass for elevated surfaces only
+(nav, cards, modals), never for body text containers where contrast suffers.
+
+## Rules
+1. Glass = elevated layers only. Keep reading surfaces solid for contrast.
+2. Backdrop matters: a subtle gradient/mesh or imagery gives the blur something to do.
+3. Thin 1px border at ~30–50% white (light) / 12% white (dark) for the "edge of glass".
+4. Layer depth with blur + translucency + soft shadow, not heavy drop shadows.
+5. Keep text on glass at AA — add a translucent scrim behind text if needed.
+6. Rounded 16–24px corners; airy padding.
+
+## Color
+- Backdrop: soft gradient, e.g. `oklch(96% 0.03 280)` → `oklch(94% 0.05 230)` (light),
+  deep `oklch(22% 0.05 280)` → `oklch(18% 0.06 250)` (dark).
+- Glass fill: `oklch(100% 0 0 / 0.55)` light, `oklch(30% 0.02 270 / 0.45)` dark.
+- Accent: vivid violet `oklch(62% 0.2 290)`; secondary cyan `oklch(72% 0.13 220)`.
+
+## Typography
+- Sans: SF Pro / Inter. Medium weights read best on translucent surfaces.
+- Slightly larger body (16–17px) and increased letter-spacing on labels for legibility.
+
+## Components
+**Do**
+- Cards/nav/modals: `backdrop-blur` + translucent fill + 1px luminous border + soft shadow.
+- Buttons: frosted secondary, solid vivid primary; gentle inner highlight on top edge.
+- Use a faint top-edge highlight (`inset 0 1px 0 white/40%`) to fake light refraction.
+
+**Don't**
+- Don't stack glass on glass on glass — 2 depth levels max in view.
+- Don't put long-form text directly on busy blurred imagery without a scrim.
+
+## Motion
+- Smooth springy reveals (scale 0.96→1 + blur-in). 200–320ms. Parallax backdrop on scroll (subtle).
+- Reduced-motion: skip scale/parallax, fade only.
+
+## Stack: web
+- Tailwind v4: `bg-white/55 backdrop-blur-xl border border-white/40 shadow-xl rounded-3xl`.
+- Dark: `dark:bg-white/10 dark:border-white/15`. Provide a `--scrim` for text blocks.
+- Animate with Motion: `initial={{opacity:0, scale:0.96, filter:'blur(8px)'}}`.
+
+## Stack: react-native
+- `expo-blur` `<BlurView intensity={40} tint=...>` for frosted panels; NativeWind for tint/border.
+- Reanimated spring scale-in; gradient backdrop via `expo-linear-gradient`.
+
+## Stack: flutter
+- `BackdropFilter(ImageFilter.blur(sigmaX:20,sigmaY:20))` inside `ClipRRect`; translucent
+  `Container` color `Colors.white.withOpacity(0.5)`, 1px white24 border, M3 seed for accents.
+
+## Stack: swiftui
+- `.background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 24))` — native materials
+  are the canonical glass; `.overlay(stroke white.opacity(0.3))`; gradient `MeshGradient` backdrop.
+
+## Stack: compose
+- `Modifier.blur()`/`graphicsLayer` + translucent `Surface(color = ... .copy(alpha=0.5))`,
+  Material 3 accents, `Brush.linearGradient` backdrop, thin border via `border()`.

--- a/packages/core/design-kits/soft-glass/tokens.json
+++ b/packages/core/design-kits/soft-glass/tokens.json
@@ -1,0 +1,32 @@
+{
+  "light": {
+    "bg": "oklch(96% 0.03 280)",
+    "bgGradientTo": "oklch(94% 0.05 230)",
+    "surface": "oklch(100% 0 0 / 0.55)",
+    "fg": "oklch(25% 0.03 280)",
+    "muted": "oklch(50% 0.03 280)",
+    "primary": "oklch(62% 0.2 290)",
+    "accent": "oklch(72% 0.13 220)",
+    "border": "oklch(100% 0 0 / 0.4)",
+    "ring": "oklch(62% 0.2 290)",
+    "radius": "1.5rem",
+    "fontSans": "SF Pro, Inter, system-ui, sans-serif",
+    "shadow": "0 10px 30px oklch(50% 0.1 280 / 0.18)",
+    "blur": "20px"
+  },
+  "dark": {
+    "bg": "oklch(22% 0.05 280)",
+    "bgGradientTo": "oklch(18% 0.06 250)",
+    "surface": "oklch(30% 0.02 270 / 0.45)",
+    "fg": "oklch(95% 0.02 280)",
+    "muted": "oklch(72% 0.03 280)",
+    "primary": "oklch(70% 0.18 290)",
+    "accent": "oklch(76% 0.12 220)",
+    "border": "oklch(100% 0 0 / 0.15)",
+    "ring": "oklch(70% 0.18 290)",
+    "radius": "1.5rem",
+    "fontSans": "SF Pro, Inter, system-ui, sans-serif",
+    "shadow": "0 10px 30px oklch(0% 0 0 / 0.45)",
+    "blur": "20px"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,11 +97,13 @@
       "import": "./dist/skills/index.js"
     },
     "./package.json": "./package.json",
-    "./skills/*": "./skills/*"
+    "./skills/*": "./skills/*",
+    "./design-kits/*": "./design-kits/*"
   },
   "files": [
     "dist",
-    "skills"
+    "skills",
+    "design-kits"
   ],
   "wrongstackApiVersion": "0.1.10",
   "scripts": {

--- a/packages/core/src/coordination/index.ts
+++ b/packages/core/src/coordination/index.ts
@@ -193,12 +193,19 @@ export type {
   MailboxQuery,
   MailboxSendInput,
   MailboxAckInput,
+  MailboxAckBatchInput,
   MailboxAgentStatus,
   MailboxTaskContext,
   ReadReceipts,
   RegisteredAgent,
   AgentRegistrationInput,
   AgentHeartbeatInput,
+  ClientSource,
+  ClientStatus,
+  ClientRegistrationInput,
+  ClientHeartbeatInput,
+  PurgeOptions,
+  PurgeResult,
 } from './mailbox-types.js';
 // ── Dependency watcher — file-change → mailbox bridge ────────────────────
 export {

--- a/packages/core/src/coordination/mailbox-types.ts
+++ b/packages/core/src/coordination/mailbox-types.ts
@@ -130,7 +130,7 @@ export interface RegisteredAgent {
   /** Which process registered this agent (PID). */
   pid: number;
   /** Where the agent is running (e.g. "cli", "webui"). */
-  source?: 'cli' | 'webui' | 'mcp' | 'acp' | undefined;
+  source?: 'cli' | 'webui' | 'mcp' | 'acp' | 'http' | undefined;
 }
 
 // ── Agent status entry (for discovery) ───────────────────────────────────
@@ -163,7 +163,7 @@ export interface MailboxAgentStatus {
   /** Which process. */
   pid: number;
   /** Source. */
-  source?: 'cli' | 'webui' | 'mcp' | 'acp' | undefined;
+  source?: 'cli' | 'webui' | 'mcp' | 'acp' | 'http' | undefined;
 }
 
 // ── Mailbox query ────────────────────────────────────────────────────────
@@ -253,12 +253,12 @@ export interface AgentRegistrationInput {
   name: string;
   role?: string | undefined;
   pid: number;
-  source?: 'cli' | 'webui' | 'mcp' | 'acp' | undefined;
+  source?: 'cli' | 'webui' | 'mcp' | 'acp' | 'http' | undefined;
 }
 
 // ── Client (REPL/TUI/WebUI) registration ─────────────────────────────────
 
-export type ClientSource = 'repl' | 'tui' | 'webui';
+export type ClientSource = 'repl' | 'tui' | 'webui' | 'http';
 
 export interface RegisteredClient {
   /** Unique client id. */

--- a/packages/core/src/defaults/index.ts
+++ b/packages/core/src/defaults/index.ts
@@ -21,323 +21,339 @@
 //
 // =============================================================================
 
-// ---- Infrastructure (was core/) ----
 export {
-  DefaultLogger,
-  type DefaultLoggerOptions,
-  type LogFormat,
-} from '../infrastructure/logger.js';
-
-// ---- Storage ----
+  createMessage,
+  InMemoryAgentBridge,
+  InMemoryBridgeTransport,
+} from '../coordination/agent-bridge.js';
 export {
-  DefaultSessionStore,
-  type SessionStoreOptions,
-} from '../storage/session-store.js';
+  type AgentFactory,
+  type AgentFactoryResult,
+  type AgentRunnerOptions,
+  makeAgentSubagentRunner,
+} from '../coordination/agent-subagent-runner.js';
 export {
-  QueueStore,
-  type PersistedQueueItem,
-} from '../storage/queue-store.js';
+  AGENT_CATALOG,
+  AGENTS_BY_PHASE,
+  type AgentBudgetTier,
+  type AgentCapability,
+  type AgentDefinition,
+  type AgentPhase,
+  ALL_AGENT_DEFINITIONS,
+  getAgentDefinition,
+} from '../coordination/agents/index.js';
 export {
-  DefaultAttachmentStore,
-  type AttachmentStoreOptions,
-} from '../storage/attachment-store.js';
+  type AutoExtendCeiling,
+  type AutoExtendPolicy,
+  attachAutoExtend,
+} from '../coordination/auto-extend.js';
 export {
-  DefaultMemoryStore,
-  type MemoryStoreOptions,
-} from '../storage/memory-store.js';
-export { DefaultConfigStore } from '../storage/config-store.js';
-export {
-  DefaultConfigLoader,
-  type ConfigLoaderOptions,
-  type ConfigSource,
-} from '../storage/config-loader.js';
-export {
-  runConfigMigrations,
-  ConfigMigrationError,
-  DEFAULT_CONFIG_MIGRATIONS,
-  type ConfigMigration,
-  type MigrationContext,
-  type MigrationResult,
-} from '../storage/config-migration.js';
-export {
-  RecoveryLock,
-  type RecoveryLockOptions,
-  type AbandonedSession,
-} from '../storage/recovery-lock.js';
-export { DefaultSessionReader } from '../storage/session-reader.js';
-export { SessionAnalyzer } from '../storage/session-analyzer.js';
-
-export {
-  createSessionEventBridge,
-  resolveAuditLevel,
-  resolveSessionLoggingConfig,
-  type SessionEventBridge,
-  type AuditLevel,
-  type SessionEventBridgeOptions,
-  type SessionSamplingOptions,
-  type ToolProgressSamplingOptions,
-} from '../storage/session-event-bridge.js';
-export {
-  attachTodosCheckpoint,
-  loadTodosCheckpoint,
-  saveTodosCheckpoint,
-  type TodosCheckpointFile,
-} from '../storage/todos-checkpoint.js';
-export {
-  attachPlanCheckpoint,
-  loadPlan,
-  savePlan,
-  emptyPlan,
-  addPlanItem,
-  removePlanItem,
-  setPlanItemStatus,
-  clearPlan,
-  formatPlan,
-  deriveTodosFromPlanItem,
-  type PlanItem,
-  type PlanFile,
-} from '../storage/plan-store.js';
-export {
-  listPlanTemplates,
-  getPlanTemplate,
-  formatPlanTemplates,
-  type PlanTemplate,
-} from '../storage/plan-templates.js';
-export {
-  DirectorStateCheckpoint,
-  loadDirectorState,
-  type DirectorStateSnapshot,
-  type DirectorTaskState,
-  type DirectorSubagentState,
-} from '../storage/director-state.js';
-
-// ---- Security ----
-export { DefaultSecretScrubber } from '../security/secret-scrubber.js';
-export {
-  DefaultSecretVault,
-  type SecretVaultOptions,
-  decryptConfigSecrets,
-  encryptConfigSecrets,
-  rewriteConfigEncrypted,
-  migratePlaintextSecrets,
-} from '../security/secret-vault.js';
-export {
-  DefaultPermissionPolicy,
-  AutoApprovePermissionPolicy,
-  type PermissionPolicyOptions,
-} from '../security/permission-policy.js';
-
-// ---- Execution ----
-export { DefaultRetryPolicy } from '../execution/retry-policy.js';
-export { DefaultErrorHandler } from '../execution/error-handler.js';
-export { DefaultSkillLoader, type SkillLoaderOptions } from '../execution/skill-loader.js';
-export { DefaultProviderRunner } from '../execution/provider-runner-impl.js';
-export {
-  HybridCompactor,
-  type CompactorOptions,
-  DEFAULT_TOOLS_CONFIG,
-  DEFAULT_CONTEXT_CONFIG,
-  DEFAULT_AUTONOMY_CONFIG,
-} from '../execution/compactor.js';
-export {
-  IntelligentCompactor,
-  type IntelligentCompactorOptions,
-} from '../execution/intelligent-compactor.js';
-export {
-  SelectiveCompactor,
-  type SelectiveCompactorOptions,
-} from '../execution/selective-compactor.js';
-export {
-  createStrategyCompactor,
-  type CompactorStrategy,
-  type StrategyCompactorOptions,
-} from '../execution/strategy-compactor.js';
-export { AutoCompactionMiddleware } from '../execution/auto-compaction-middleware.js';
-export { ToolExecutor } from '../execution/tool-executor.js';
-export {
-  AutonomousRunner,
-  DoneConditionChecker,
-  type DoneCheckResult,
-  type AutonomousRunnerOptions,
-} from '../execution/autonomous-runner.js';
-export {
-  EternalAutonomyEngine,
-  type EternalAutonomyOptions,
-  type EternalEngineState,
-  type IterationStage,
-} from '../execution/eternal-autonomy.js';
-export {
-  ParallelEternalEngine,
-  type ParallelEternalOptions,
-  type ParallelEngineState,
-  type ParallelIterationStage,
-} from '../execution/parallel-eternal-engine.js';
-export {
-  makeAutonomyPromptContributor,
-  type AutonomyPromptContributorOptions,
-} from '../execution/autonomy-prompt-contributor.js';
-export { buildGoalPreamble } from '../execution/goal-preamble.js';
-
+  type CreateDelegateToolOptions,
+  createDelegateTool,
+  type DelegateHost,
+} from '../coordination/delegate-tool.js';
 // ---- Coordination (multi-agent) ----
 export {
   Director,
   FleetSpawnBudgetError,
 } from '../coordination/director.js';
 export {
-  makeSpawnTool,
+  composeDirectorPrompt,
+  composeSubagentPrompt,
+  DEFAULT_DIRECTOR_PREAMBLE,
+  DEFAULT_SUBAGENT_BASELINE,
+  type DirectorPromptParts,
+  rosterSummaryFromConfigs,
+  type SubagentPromptParts,
+} from '../coordination/director-prompts.js';
+export {
+  type DirectorSessionFactory,
+  type DirectorSessionFactoryOptions,
+  makeDirectorSessionFactory,
+} from '../coordination/director-session.js';
+export {
+  makeAskTool,
   makeAssignTool,
   makeAwaitTasksTool,
-  makeAskTool,
-  makeRollUpTool,
-  makeTerminateTool,
-  makeFleetStatusTool,
-  makeFleetUsageTool,
-  makeFleetSessionTool,
-  makeFleetHealthTool,
   makeCollabDebugTool,
   makeFleetEmitTool,
+  makeFleetHealthTool,
+  makeFleetSessionTool,
+  makeFleetStatusTool,
+  makeFleetUsageTool,
+  makeRollUpTool,
+  makeSpawnTool,
+  makeTerminateTool,
 } from '../coordination/director-tools.js';
 export {
-  createDelegateTool,
-  type DelegateHost,
-  type CreateDelegateToolOptions,
-} from '../coordination/delegate-tool.js';
+  DEFAULT_DISPATCH_ROLE,
+  type DispatchCandidate,
+  type DispatchClassifier,
+  type DispatchMethod,
+  type DispatchOptions,
+  type DispatchResult,
+  dispatchAgent,
+  makeLLMClassifier,
+  scoreAgents,
+} from '../coordination/dispatcher.js';
+export {
+  ALL_FLEET_AGENTS,
+  AUDIT_LOG_AGENT,
+  applyRosterBudget,
+  BUG_HUNTER_AGENT,
+  FLEET_ROSTER,
+  FLEET_ROSTER_BUDGETS,
+  type FleetRosterBudget,
+  REFACTOR_PLANNER_AGENT,
+  SECURITY_SCANNER_AGENT,
+} from '../coordination/fleet.js';
+export {
+  FleetBus,
+  type FleetEvent,
+  type FleetHandler,
+  type FleetUsage,
+  FleetUsageAggregator,
+  type SubagentUsageSnapshot,
+} from '../coordination/fleet-bus.js';
+export type { ICoordinator } from '../coordination/icoordinator.js';
+export type { IFleetManager } from '../coordination/ifleet-manager.js';
 export {
   DefaultMultiAgentCoordinator,
   type MultiAgentCoordinatorOptions,
 } from '../coordination/multi-agent-coordinator.js';
+export { NULL_FLEET_BUS } from '../coordination/null-fleet-bus.js';
 export {
-  SubagentBudget,
   BudgetExceededError,
   type BudgetKind,
   type BudgetLimits,
   type BudgetUsage,
+  SubagentBudget,
 } from '../coordination/subagent-budget.js';
+export { AutoCompactionMiddleware } from '../execution/auto-compaction-middleware.js';
 export {
-  makeAgentSubagentRunner,
-  type AgentFactory,
-  type AgentFactoryResult,
-  type AgentRunnerOptions,
-} from '../coordination/agent-subagent-runner.js';
+  AutonomousRunner,
+  type AutonomousRunnerOptions,
+  type DoneCheckResult,
+  DoneConditionChecker,
+} from '../execution/autonomous-runner.js';
 export {
-  FleetBus,
-  FleetUsageAggregator,
-  type FleetEvent,
-  type FleetHandler,
-  type FleetUsage,
-  type SubagentUsageSnapshot,
-} from '../coordination/fleet-bus.js';
+  type AutonomyPromptContributorOptions,
+  makeAutonomyPromptContributor,
+} from '../execution/autonomy-prompt-contributor.js';
 export {
-  makeDirectorSessionFactory,
-  type DirectorSessionFactory,
-  type DirectorSessionFactoryOptions,
-} from '../coordination/director-session.js';
+  type CompactorOptions,
+  DEFAULT_AUTONOMY_CONFIG,
+  DEFAULT_CONTEXT_CONFIG,
+  DEFAULT_TOOLS_CONFIG,
+  HybridCompactor,
+} from '../execution/compactor.js';
 export {
-  composeDirectorPrompt,
-  composeSubagentPrompt,
-  rosterSummaryFromConfigs,
-  DEFAULT_DIRECTOR_PREAMBLE,
-  DEFAULT_SUBAGENT_BASELINE,
-  type DirectorPromptParts,
-  type SubagentPromptParts,
-} from '../coordination/director-prompts.js';
+  activateDesign,
+  clearActiveKit,
+  detectFrontendFile,
+  detectFrontendIntent,
+  getDesignState,
+  installDesignStudioMiddleware,
+  makeDesignDetectToolCallMiddleware,
+  makeDesignDetectUserInputMiddleware,
+  makeDesignStudioRequestMiddleware,
+  setActiveKit,
+} from '../execution/design-detect.js';
 export {
-  InMemoryAgentBridge,
-  InMemoryBridgeTransport,
-  createMessage,
-} from '../coordination/agent-bridge.js';
+  _resetDesignKitLoaderMemo,
+  DefaultDesignKitLoader,
+  type DesignKitLoaderOptions,
+  getDesignKitLoader,
+  resolveBundledDesignKitsDir,
+} from '../execution/design-kit-loader.js';
 export {
-  AUDIT_LOG_AGENT,
-  BUG_HUNTER_AGENT,
-  REFACTOR_PLANNER_AGENT,
-  SECURITY_SCANNER_AGENT,
-  FLEET_ROSTER,
-  FLEET_ROSTER_BUDGETS,
-  applyRosterBudget,
-  ALL_FLEET_AGENTS,
-  type FleetRosterBudget,
-} from '../coordination/fleet.js';
+  _resetDesignRulesCache,
+  clearPersistedActiveKit,
+  designProjectDir,
+  loadActiveKit,
+  loadProjectDesignRules,
+  type PersistedActiveKit,
+  recordKitChoice,
+} from '../execution/design-project-store.js';
+export { DefaultErrorHandler } from '../execution/error-handler.js';
 export {
-  ALL_AGENT_DEFINITIONS,
-  AGENT_CATALOG,
-  AGENTS_BY_PHASE,
-  getAgentDefinition,
-  type AgentDefinition,
-  type AgentCapability,
-  type AgentBudgetTier,
-  type AgentPhase,
-} from '../coordination/agents/index.js';
+  EternalAutonomyEngine,
+  type EternalAutonomyOptions,
+  type EternalEngineState,
+  type IterationStage,
+} from '../execution/eternal-autonomy.js';
+export { buildGoalPreamble } from '../execution/goal-preamble.js';
 export {
-  dispatchAgent,
-  scoreAgents,
-  makeLLMClassifier,
-  DEFAULT_DISPATCH_ROLE,
-  type DispatchResult,
-  type DispatchCandidate,
-  type DispatchClassifier,
-  type DispatchOptions,
-  type DispatchMethod,
-} from '../coordination/dispatcher.js';
+  IntelligentCompactor,
+  type IntelligentCompactorOptions,
+} from '../execution/intelligent-compactor.js';
 export {
-  attachAutoExtend,
-  type AutoExtendPolicy,
-  type AutoExtendCeiling,
-} from '../coordination/auto-extend.js';
-export type { ICoordinator } from '../coordination/icoordinator.js';
-export type { IFleetManager } from '../coordination/ifleet-manager.js';
-export { NULL_FLEET_BUS } from '../coordination/null-fleet-bus.js';
-
-// ---- Models ----
+  type ParallelEngineState,
+  ParallelEternalEngine,
+  type ParallelEternalOptions,
+  type ParallelIterationStage,
+} from '../execution/parallel-eternal-engine.js';
+export { DefaultProviderRunner } from '../execution/provider-runner-impl.js';
+// ---- Execution ----
+export { DefaultRetryPolicy } from '../execution/retry-policy.js';
 export {
-  DefaultModelsRegistry,
-  classifyFamily,
-  type DefaultModelsRegistryOptions,
-} from '../models/models-registry.js';
+  SelectiveCompactor,
+  type SelectiveCompactorOptions,
+} from '../execution/selective-compactor.js';
+export { DefaultSkillLoader, type SkillLoaderOptions } from '../execution/skill-loader.js';
+export {
+  type CompactorStrategy,
+  createStrategyCompactor,
+  type StrategyCompactorOptions,
+} from '../execution/strategy-compactor.js';
+export { ToolExecutor } from '../execution/tool-executor.js';
+// ---- Context manager (tool) ----
+export {
+  type ContextManagerAction,
+  type ContextManagerInput,
+  type ContextManagerResult,
+  type ContextManagerToolOptions,
+  contextManagerTool,
+  createContextManagerTool,
+} from '../infrastructure/context-manager.js';
+// ---- Infrastructure (was core/) ----
+export {
+  DefaultLogger,
+  type DefaultLoggerOptions,
+  type LogFormat,
+} from '../infrastructure/logger.js';
+// ---- MCP servers ----
+export {
+  allServers,
+  awsServer,
+  blockServer,
+  braveSearchServer,
+  context7Server,
+  everArtServer,
+  filesystemServer,
+  githubServer,
+  googleMapsServer,
+  miniMaxVisionServer,
+  playwrightServer,
+  sentinelServer,
+  slackServer,
+  sshManagerServer,
+  zaiVisionServer,
+} from '../infrastructure/mcp-servers.js';
+export { CODEX_MODELS, type CodexModelMeta, codexModelMeta } from '../models/codex-catalog.js';
+export { LLMSelector, type LLMSelectorOptions } from '../models/llm-selector.js';
 export {
   DefaultModeStore,
   loadProjectModes,
   loadUserModes,
   type ModeLoaderOptions,
 } from '../models/mode-store.js';
-export { LLMSelector, type LLMSelectorOptions } from '../models/llm-selector.js';
+// ---- Models ----
 export {
-  resolveProviderModelList,
+  classifyFamily,
+  DefaultModelsRegistry,
+  type DefaultModelsRegistryOptions,
+} from '../models/models-registry.js';
+export {
   describeCatalogModel,
   type ProviderModelDescriptor,
+  resolveProviderModelList,
 } from '../models/provider-model-resolve.js';
-export { CODEX_MODELS, codexModelMeta, type CodexModelMeta } from '../models/codex-catalog.js';
-
-// ---- SDD ----
-export { SpecParser } from '../sdd/spec-parser.js';
+// ---- Observability ----
 export {
-  TaskGenerator,
-  DefaultTaskStore,
-  extractVerificationCommand,
-  type TaskGeneratorOptions,
-  type GeneratedTask,
-} from '../sdd/task-generator.js';
+  buildOtlpMetricsRequest,
+  buildOtlpTracesRequest,
+  DefaultHealthRegistry,
+  InMemoryMetricsSink,
+  type MetricsServerHandle,
+  type MetricsServerOptions,
+  NoopMetricsSink,
+  NoopTracer,
+  OTelTracer,
+  type OtlpMetricsExporterHandle,
+  type OtlpMetricsExporterOptions,
+  type OtlpTraceExporterHandle,
+  type OtlpTraceExporterOptions,
+  PROMETHEUS_CONTENT_TYPE,
+  renderPrometheus,
+  startMetricsServer,
+  startOtlpMetricsExporter,
+  startOtlpTraceExporter,
+  wireMetricsToEvents,
+} from '../observability/index.js';
 export {
-  TaskTracker,
-  type TaskStore,
-  type TaskTrackerOptions,
-  type TaskTransition,
-} from '../sdd/task-tracker.js';
+  AutoExecutor,
+  type AutoExecutorOptions,
+  createAutoExecutor,
+  type ExecutionSummary,
+  type TaskExecutionContext,
+  type TaskExecutionResult,
+} from '../sdd/auto-executor.js';
+// Live SDD board: model, persistence, projector, run registry.
 export {
-  TaskFlow,
-  SpecDrivenDev,
-  type TaskFlowPhase,
-  type TaskFlowOptions,
-  type TaskFlowExecutionContext,
-  type TaskFlowEventMap,
-  type TaskFlowEventName,
-  type SpecDrivenDevOptions,
-} from '../sdd/task-flow.js';
-export { SpecStore, type SpecStoreOptions, type SpecIndexEntry } from '../sdd/spec-store.js';
+  buildBoardSnapshot,
+  buildBoardTasks,
+  type SddBoardColumn,
+  type SddBoardFeedEntry,
+  type SddBoardSnapshot,
+  type SddBoardStatus,
+  type SddBoardTask,
+  type SddDeadlockChain,
+  type SddTaskDisplayStatus,
+  shortIdMap,
+} from '../sdd/board-types.js';
 export {
-  TaskGraphStore,
-  type TaskGraphStoreOptions,
-  type TaskGraphIndexEntry,
-} from '../sdd/task-graph-store.js';
+  type ConflictSide,
+  hasConflictMarkers,
+  type LlmConflictResolverOptions,
+  makeLlmConflictResolver,
+  makePreferSideConflictResolver,
+  resolveConflictText,
+} from '../sdd/conflict-resolver.js';
+export {
+  analyzeCriticalPath,
+  type BottleneckTask,
+  type CriticalPathAnalysis,
+} from '../sdd/critical-path.js';
+export { makeLlmSubtaskGenerator, type SubtaskGeneratorOptions } from '../sdd/decompose-task.js';
+export { SddBoardProjector, type SddBoardProjectorOptions } from '../sdd/sdd-board-projector.js';
+export {
+  type SddBoardEvent,
+  type SddBoardIndexEntry,
+  SddBoardStore,
+  type SddBoardStoreOptions,
+} from '../sdd/sdd-board-store.js';
+export {
+  isExplanatoryText,
+  type SddIngestResult,
+  SddInterviewDriver,
+  type SddInterviewDriverOptions,
+  type SddInterviewSnapshot,
+} from '../sdd/sdd-interview-driver.js';
+export {
+  cleanupSddWorktrees,
+  type DestroySddProjectOptions,
+  type DestroySddProjectResult,
+  destroySddProject,
+  type RollbackFromDiskOptions,
+  rollbackSddRunFromDisk,
+} from '../sdd/sdd-lifecycle.js';
+export {
+  type RunResult,
+  SddParallelRun,
+  type SddParallelRunOptions,
+  type SddProgress,
+  type SddSubtaskSpec,
+  type SddSupervisorVerdict,
+  type WaveResult,
+} from '../sdd/sdd-parallel-run.js';
+export { type SddRunControl, SddRunRegistry } from '../sdd/sdd-run-registry.js';
+export { SddSupervisor, type SddSupervisorOptions } from '../sdd/sdd-supervisor.js';
+export {
+  SddTaskDecomposer,
+  type SddTaskDecomposerOptions,
+  type TaskBatch,
+} from '../sdd/sdd-task-decomposer.js';
 export {
   AISpecBuilder,
   type AISpecBuilderOptions,
@@ -345,147 +361,149 @@ export {
   type AISpecSession,
   type CollectedAnswer,
 } from '../sdd/spec-builder.js';
+// ---- SDD ----
+export { SpecParser } from '../sdd/spec-parser.js';
+export { type SpecIndexEntry, SpecStore, type SpecStoreOptions } from '../sdd/spec-store.js';
 export {
-  SPEC_TEMPLATES,
   getTemplate,
   listTemplates,
+  SPEC_TEMPLATES,
   templateToMarkdown,
 } from '../sdd/spec-templates.js';
+export { type SpecDiff, type SpecVersion, SpecVersioning } from '../sdd/spec-versioning.js';
 export {
-  renderTaskGraph,
-  renderProgress,
-  renderTaskList,
-  renderSpecAnalysis,
-} from '../sdd/task-visualizer.js';
-export {
-  analyzeCriticalPath,
-  type CriticalPathAnalysis,
-  type BottleneckTask,
-} from '../sdd/critical-path.js';
-export { SpecVersioning, type SpecVersion, type SpecDiff } from '../sdd/spec-versioning.js';
-export {
-  AutoExecutor,
-  createAutoExecutor,
-  type AutoExecutorOptions,
-  type TaskExecutionContext,
-  type TaskExecutionResult,
-  type ExecutionSummary,
-} from '../sdd/auto-executor.js';
-export {
-  SddTaskDecomposer,
-  type SddTaskDecomposerOptions,
-  type TaskBatch,
-} from '../sdd/sdd-task-decomposer.js';
-export {
-  SddParallelRun,
-  type SddParallelRunOptions,
-  type SddProgress,
-  type WaveResult,
-  type RunResult,
-  type SddSubtaskSpec,
-  type SddSupervisorVerdict,
-} from '../sdd/sdd-parallel-run.js';
-export { SddSupervisor, type SddSupervisorOptions } from '../sdd/sdd-supervisor.js';
-export { makeCommandVerifier, type CommandVerifierOptions } from '../sdd/verify-task.js';
-export { makeLlmSubtaskGenerator, type SubtaskGeneratorOptions } from '../sdd/decompose-task.js';
-export {
-  makePreferSideConflictResolver,
-  makeLlmConflictResolver,
-  resolveConflictText,
-  hasConflictMarkers,
-  type ConflictSide,
-  type LlmConflictResolverOptions,
-} from '../sdd/conflict-resolver.js';
-// Live SDD board: model, persistence, projector, run registry.
-export {
-  buildBoardTasks,
-  buildBoardSnapshot,
-  shortIdMap,
-  type SddBoardSnapshot,
-  type SddBoardTask,
-  type SddBoardColumn,
-  type SddBoardStatus,
-  type SddTaskDisplayStatus,
-  type SddDeadlockChain,
-  type SddBoardFeedEntry,
-} from '../sdd/board-types.js';
-export {
-  SddBoardStore,
-  type SddBoardStoreOptions,
-  type SddBoardIndexEntry,
-  type SddBoardEvent,
-} from '../sdd/sdd-board-store.js';
-export { SddBoardProjector, type SddBoardProjectorOptions } from '../sdd/sdd-board-projector.js';
-export { SddRunRegistry, type SddRunControl } from '../sdd/sdd-run-registry.js';
-export {
-  SddInterviewDriver,
-  isExplanatoryText,
-  type SddInterviewDriverOptions,
-  type SddInterviewSnapshot,
-  type SddIngestResult,
-} from '../sdd/sdd-interview-driver.js';
-export {
-  startSddRun,
-  type StartSddRunOptions,
   type SddRunHandle,
+  type StartSddRunOptions,
+  startSddRun,
 } from '../sdd/start-sdd-run.js';
 export {
-  cleanupSddWorktrees,
-  rollbackSddRunFromDisk,
-  destroySddProject,
-  type RollbackFromDiskOptions,
-  type DestroySddProjectOptions,
-  type DestroySddProjectResult,
-} from '../sdd/sdd-lifecycle.js';
-
-// ---- Observability ----
+  SpecDrivenDev,
+  type SpecDrivenDevOptions,
+  TaskFlow,
+  type TaskFlowEventMap,
+  type TaskFlowEventName,
+  type TaskFlowExecutionContext,
+  type TaskFlowOptions,
+  type TaskFlowPhase,
+} from '../sdd/task-flow.js';
 export {
-  InMemoryMetricsSink,
-  NoopMetricsSink,
-  DefaultHealthRegistry,
-  NoopTracer,
-  OTelTracer,
-  wireMetricsToEvents,
-  renderPrometheus,
-  startMetricsServer,
-  PROMETHEUS_CONTENT_TYPE,
-  type MetricsServerOptions,
-  type MetricsServerHandle,
-  buildOtlpMetricsRequest,
-  startOtlpMetricsExporter,
-  type OtlpMetricsExporterOptions,
-  type OtlpMetricsExporterHandle,
-  buildOtlpTracesRequest,
-  startOtlpTraceExporter,
-  type OtlpTraceExporterOptions,
-  type OtlpTraceExporterHandle,
-} from '../observability/index.js';
-
-// ---- Context manager (tool) ----
+  DefaultTaskStore,
+  extractVerificationCommand,
+  type GeneratedTask,
+  TaskGenerator,
+  type TaskGeneratorOptions,
+} from '../sdd/task-generator.js';
 export {
-  contextManagerTool,
-  createContextManagerTool,
-  type ContextManagerInput,
-  type ContextManagerResult,
-  type ContextManagerAction,
-  type ContextManagerToolOptions,
-} from '../infrastructure/context-manager.js';
-
-// ---- MCP servers ----
+  type TaskGraphIndexEntry,
+  TaskGraphStore,
+  type TaskGraphStoreOptions,
+} from '../sdd/task-graph-store.js';
 export {
-  filesystemServer,
-  githubServer,
-  context7Server,
-  braveSearchServer,
-  blockServer,
-  everArtServer,
-  slackServer,
-  awsServer,
-  googleMapsServer,
-  sentinelServer,
-  zaiVisionServer,
-  miniMaxVisionServer,
-  playwrightServer,
-  sshManagerServer,
-  allServers,
-} from '../infrastructure/mcp-servers.js';
+  type TaskStore,
+  TaskTracker,
+  type TaskTrackerOptions,
+  type TaskTransition,
+} from '../sdd/task-tracker.js';
+export {
+  renderProgress,
+  renderSpecAnalysis,
+  renderTaskGraph,
+  renderTaskList,
+} from '../sdd/task-visualizer.js';
+export { type CommandVerifierOptions, makeCommandVerifier } from '../sdd/verify-task.js';
+export {
+  AutoApprovePermissionPolicy,
+  DefaultPermissionPolicy,
+  type PermissionPolicyOptions,
+} from '../security/permission-policy.js';
+// ---- Security ----
+export { DefaultSecretScrubber } from '../security/secret-scrubber.js';
+export {
+  DefaultSecretVault,
+  decryptConfigSecrets,
+  encryptConfigSecrets,
+  migratePlaintextSecrets,
+  rewriteConfigEncrypted,
+  type SecretVaultOptions,
+} from '../security/secret-vault.js';
+export {
+  type AttachmentStoreOptions,
+  DefaultAttachmentStore,
+} from '../storage/attachment-store.js';
+export {
+  type ConfigLoaderOptions,
+  type ConfigSource,
+  DefaultConfigLoader,
+} from '../storage/config-loader.js';
+export {
+  type ConfigMigration,
+  ConfigMigrationError,
+  DEFAULT_CONFIG_MIGRATIONS,
+  type MigrationContext,
+  type MigrationResult,
+  runConfigMigrations,
+} from '../storage/config-migration.js';
+export { DefaultConfigStore } from '../storage/config-store.js';
+export {
+  DirectorStateCheckpoint,
+  type DirectorStateSnapshot,
+  type DirectorSubagentState,
+  type DirectorTaskState,
+  loadDirectorState,
+} from '../storage/director-state.js';
+export {
+  DefaultMemoryStore,
+  type MemoryStoreOptions,
+} from '../storage/memory-store.js';
+export {
+  addPlanItem,
+  attachPlanCheckpoint,
+  clearPlan,
+  deriveTodosFromPlanItem,
+  emptyPlan,
+  formatPlan,
+  loadPlan,
+  type PlanFile,
+  type PlanItem,
+  removePlanItem,
+  savePlan,
+  setPlanItemStatus,
+} from '../storage/plan-store.js';
+export {
+  formatPlanTemplates,
+  getPlanTemplate,
+  listPlanTemplates,
+  type PlanTemplate,
+} from '../storage/plan-templates.js';
+export {
+  type PersistedQueueItem,
+  QueueStore,
+} from '../storage/queue-store.js';
+export {
+  type AbandonedSession,
+  RecoveryLock,
+  type RecoveryLockOptions,
+} from '../storage/recovery-lock.js';
+export { SessionAnalyzer } from '../storage/session-analyzer.js';
+export {
+  type AuditLevel,
+  createSessionEventBridge,
+  resolveAuditLevel,
+  resolveSessionLoggingConfig,
+  type SessionEventBridge,
+  type SessionEventBridgeOptions,
+  type SessionSamplingOptions,
+  type ToolProgressSamplingOptions,
+} from '../storage/session-event-bridge.js';
+export { DefaultSessionReader } from '../storage/session-reader.js';
+// ---- Storage ----
+export {
+  DefaultSessionStore,
+  type SessionStoreOptions,
+} from '../storage/session-store.js';
+export {
+  attachTodosCheckpoint,
+  loadTodosCheckpoint,
+  saveTodosCheckpoint,
+  type TodosCheckpointFile,
+} from '../storage/todos-checkpoint.js';

--- a/packages/core/src/execution/design-detect.ts
+++ b/packages/core/src/execution/design-detect.ts
@@ -1,0 +1,289 @@
+/**
+ * Design Studio detection + injection middleware.
+ *
+ * The system prompt is built ONCE per session (boot / project-switch), so a
+ * system-prompt contributor cannot react to "the model just started building a
+ * UI" mid-session. Instead, detection and injection ride the per-turn pipelines:
+ *
+ *   - userInput  middleware → detect UI intent in the user's message
+ *   - toolCall   middleware → detect a frontend file being written
+ *       (both set `ctx.meta.designStudio`)
+ *   - request    middleware → on every turn, read `ctx.meta.designStudio` and
+ *       append an ephemeral block to `req.system`: the kit menu (until a kit is
+ *       chosen) or a one-line adherence reminder (once chosen).
+ *
+ * Keeping the heavy kit body out of this path — the model loads it on demand via
+ * the `design` tool — is what keeps per-turn token cost low.
+ */
+
+import type {
+  AgentPipelines,
+  ToolCallPipelinePayload,
+  UserInputPayload,
+} from '../core/agent-types.js';
+import type { Context } from '../core/context.js';
+import type { Middleware } from '../kernel/pipeline.js';
+import type { TextBlock } from '../types/blocks.js';
+import type { DesignKitLoader, DesignStack, DesignStudioState } from '../types/design-kit.js';
+import { isDesignStack } from '../types/design-kit.js';
+import type { Request } from '../types/provider.js';
+import { getDesignKitLoader } from './design-kit-loader.js';
+import { loadActiveKit, loadProjectDesignRules } from './design-project-store.js';
+
+const META_KEY = 'designStudio';
+
+export function getDesignState(ctx: {
+  meta: Record<string, unknown>;
+}): DesignStudioState | undefined {
+  const v = ctx.meta[META_KEY];
+  return v && typeof v === 'object' ? (v as DesignStudioState) : undefined;
+}
+
+function ensureState(ctx: { meta: Record<string, unknown> }): DesignStudioState {
+  let s = getDesignState(ctx);
+  if (!s) {
+    s = { active: false, signals: [] };
+    ctx.meta[META_KEY] = s;
+  }
+  return s;
+}
+
+/** Mark Design Studio active and merge in detected signals/stack. */
+export function activateDesign(
+  ctx: { meta: Record<string, unknown> },
+  signals: string[],
+  stack?: DesignStack,
+): DesignStudioState {
+  const s = ensureState(ctx);
+  s.active = true;
+  for (const sig of signals) if (!s.signals.includes(sig)) s.signals.push(sig);
+  if (stack && !s.stack) s.stack = stack;
+  return s;
+}
+
+/** Record the kit the model/user committed to. */
+export function setActiveKit(
+  ctx: { meta: Record<string, unknown> },
+  kitId: string,
+  stack?: DesignStack,
+): void {
+  const s = ensureState(ctx);
+  s.active = true;
+  s.activeKit = kitId;
+  if (stack) s.stack = stack;
+}
+
+/** Clear the active kit (e.g. `/design off`), leaving detection state intact. */
+export function clearActiveKit(ctx: { meta: Record<string, unknown> }): void {
+  const s = getDesignState(ctx);
+  if (s) s.activeKit = undefined;
+}
+
+// ── Detection ──────────────────────────────────────────────────────────────
+
+const STACK_HINTS: { re: RegExp; stack: DesignStack; label: string }[] = [
+  { re: /\b(flutter|dart)\b/i, stack: 'flutter', label: 'flutter' },
+  { re: /\bjetpack\s*compose\b|\bcompose\b/i, stack: 'compose', label: 'compose' },
+  { re: /\bswift\s*ui\b|\bswiftui\b/i, stack: 'swiftui', label: 'swiftui' },
+  { re: /\b(react\s*native|expo|nativewind)\b/i, stack: 'react-native', label: 'react-native' },
+];
+
+const WEB_INTENT_RE =
+  /\b(ui|ux|frontend|front-end|landing\s*page|web\s*site|website|web\s*app|webapp|dashboard|screen|design\s*system|component|react|next\.?js|vue|svelte|tailwind|shadcn|css|theme|redesign|style|interface|hero\s*section|navbar|sidebar|button|modal|form\s*design)\b/i;
+
+const GENERIC_UI_RE = /\b(ui|interface|screen|page|app|component|design)\b/i;
+
+/**
+ * Inspect user text for UI/design intent. Returns the strongest stack hint and
+ * the matched signals, or `null` when nothing UI-ish was found.
+ */
+export function detectFrontendIntent(
+  text: string,
+): { stack?: DesignStack; signals: string[] } | null {
+  if (!text) return null;
+  const signals: string[] = [];
+  let stack: DesignStack | undefined;
+  for (const h of STACK_HINTS) {
+    if (h.re.test(text)) {
+      signals.push(`intent:${h.label}`);
+      stack ??= h.stack;
+    }
+  }
+  const webMatch = WEB_INTENT_RE.exec(text);
+  if (webMatch) {
+    signals.push(`intent:${webMatch[0].toLowerCase().replace(/\s+/g, '-')}`);
+    stack ??= 'web';
+  } else if (
+    stack === undefined &&
+    GENERIC_UI_RE.test(text) &&
+    /\b(build|make|create|design|implement|add)\b/i.test(text)
+  ) {
+    // Weak generic signal — only when paired with a build verb.
+    signals.push('intent:ui');
+    stack = 'web';
+  }
+  if (signals.length === 0) return null;
+  return stack ? { stack, signals } : { signals };
+}
+
+const FRONTEND_EXT_STACK: { re: RegExp; stack?: DesignStack }[] = [
+  { re: /\.(tsx|jsx)$/i, stack: 'web' },
+  { re: /\.(css|scss|sass|less)$/i, stack: 'web' },
+  { re: /\.(vue|svelte|astro)$/i, stack: 'web' },
+  { re: /\.html?$/i, stack: 'web' },
+  { re: /\.dart$/i, stack: 'flutter' },
+  { re: /\.swift$/i, stack: 'swiftui' },
+];
+
+/** Detect whether a written/edited file path is a frontend file. */
+export function detectFrontendFile(filePath: string): { stack?: DesignStack } | null {
+  if (!filePath) return null;
+  for (const { re, stack } of FRONTEND_EXT_STACK) {
+    if (re.test(filePath)) return stack ? { stack } : {};
+  }
+  return null;
+}
+
+// ── Middleware ───────────────────────────────────────────────────────────────
+
+/** userInput middleware: detect UI intent from the user's message. */
+export function makeDesignDetectUserInputMiddleware(): Middleware<UserInputPayload> {
+  return {
+    name: 'DesignStudioDetectIntent',
+    owner: 'core',
+    async handler(payload, next) {
+      const hit = detectFrontendIntent(payload.text);
+      if (hit) activateDesign(payload.ctx, hit.signals, hit.stack);
+      return next(payload);
+    },
+  };
+}
+
+/** toolCall middleware: detect frontend file writes/edits. */
+export function makeDesignDetectToolCallMiddleware(): Middleware<ToolCallPipelinePayload> {
+  return {
+    name: 'DesignStudioDetectFile',
+    owner: 'core',
+    async handler(payload, next) {
+      const name = payload.toolUse?.name;
+      if (name === 'write' || name === 'edit' || name === 'replace' || name === 'patch') {
+        const input = payload.toolUse.input as { path?: unknown } | undefined;
+        const p = typeof input?.path === 'string' ? input.path : '';
+        const hit = detectFrontendFile(p);
+        if (hit) activateDesign(payload.ctx, [`file:${p}`], hit.stack);
+      }
+      return next(payload);
+    },
+  };
+}
+
+const BASELINE = [
+  '**Non-negotiable baseline (every UI you write):**',
+  '- Mobile-first & fully responsive; respect safe-area insets on native.',
+  '- Ship BOTH light and dark themes from one token set (no hard-coded colors).',
+  '- WCAG 2.2 AA: semantic markup, focus-visible, 4.5:1 contrast, labelled controls, hit targets ≥44px.',
+  '- Tasteful motion with `prefers-reduced-motion` honored.',
+  '- Use current stack defaults (e.g. web: React 19 + Tailwind v4 `@theme`/OKLCH + shadcn/ui + Motion).',
+].join('\n');
+
+/**
+ * request middleware: per-turn, inject the kit menu (until a kit is chosen) or a
+ * compact adherence reminder (once chosen). No-op when Design Studio is inactive.
+ *
+ * Closes over the live `Context` because the `request` pipeline payload is just
+ * the `Request` — it carries no ctx. `req.system` shares the array reference
+ * with `ctx.systemPrompt`, so we return a NEW array rather than mutating it.
+ */
+export function makeDesignStudioRequestMiddleware(deps: {
+  ctx: Context;
+  loader: DesignKitLoader;
+  enabled?: () => boolean;
+}): Middleware<Request> {
+  const { ctx, loader } = deps;
+  return {
+    name: 'DesignStudioInject',
+    owner: 'core',
+    async handler(req, next) {
+      if (deps.enabled && !deps.enabled()) return next(req);
+      const state = getDesignState(ctx);
+      if (!state?.active) return next(req);
+
+      let text: string;
+      if (state.activeKit) {
+        text =
+          `## Active design kit: ${state.activeKit}\n` +
+          `Adhere strictly to its tokens, components, and patterns. Keep light/dark + ` +
+          `responsive + WCAG AA. Re-load the full spec with \`design use ${state.activeKit}\` if unsure.`;
+      } else {
+        const menu = await loader.menuText().catch(() => '');
+        const stackLine = state.stack ? ` (detected stack: ${state.stack})` : '';
+        const parts = [
+          `## Design Studio — UI work detected${stackLine}`,
+          'Before writing UI code, COMMIT to ONE coherent design direction. Do NOT produce generic, ' +
+            'default-framework, unstyled output.',
+          '',
+          menu || '(no kits installed)',
+          '',
+          BASELINE,
+          '',
+          'Next: call `design list` to review, then `design use <kit-id> --stack <stack>` to load the ' +
+            'full spec, then implement it faithfully. A user can also pin one with `/design <kit-id>`.',
+        ];
+        text = parts.join('\n');
+      }
+
+      // Project-local design rules (.design/rules.md) override kit defaults.
+      const rules = await loadProjectDesignRules(ctx.projectRoot).catch(() => undefined);
+      if (rules) {
+        text += `\n\n## Project design rules (.design/rules.md) — these OVERRIDE kit defaults on conflict\n${rules}`;
+      }
+
+      const block: TextBlock = {
+        type: 'text',
+        text,
+        cache_control: { type: 'ephemeral' },
+      };
+      const system = Array.isArray(req.system) ? [...req.system, block] : [block];
+      return next({ ...req, system });
+    },
+  };
+}
+
+/**
+ * Install the Design Studio per-turn middleware onto an agent's pipelines.
+ * Shared by every host (CLI/TUI + both WebUI servers) so auto-detection behaves
+ * identically everywhere. All three are PREPENDED:
+ *   - detection runs first so a short-circuiting middleware can't suppress it;
+ *   - the request injector must sit ahead of `ModelRuntimeSettings`, which does
+ *     not call `next` and would otherwise end the chain before us.
+ *
+ * The `design` tool and `/design` command are wired separately (builtin pack +
+ * slash registry); this only installs the activation behavior.
+ */
+export function installDesignStudioMiddleware(deps: {
+  pipelines: AgentPipelines;
+  ctx: Context;
+  /** When false, nothing is installed (tool + /design stay manual). */
+  enabled?: boolean | undefined;
+}): void {
+  if (deps.enabled === false) return;
+  const loader = getDesignKitLoader(deps.ctx.projectRoot);
+  deps.pipelines.userInput.prepend(makeDesignDetectUserInputMiddleware());
+  deps.pipelines.toolCall.prepend(makeDesignDetectToolCallMiddleware());
+  deps.pipelines.request.prepend(makeDesignStudioRequestMiddleware({ ctx: deps.ctx, loader }));
+
+  // Restore a previously pinned kit from `.design/active.json` so a design
+  // direction survives across sessions. Fire-and-forget — a missing/old file
+  // simply leaves Design Studio idle until detection or an explicit pick.
+  void loadActiveKit(deps.ctx.projectRoot)
+    .then((persisted) => {
+      if (persisted && !getDesignState(deps.ctx)?.activeKit) {
+        const stack =
+          persisted.stack && isDesignStack(persisted.stack) ? persisted.stack : undefined;
+        setActiveKit(deps.ctx, persisted.kit, stack);
+      }
+    })
+    .catch(() => {
+      // best-effort restore
+    });
+}

--- a/packages/core/src/execution/design-kit-loader.ts
+++ b/packages/core/src/execution/design-kit-loader.ts
@@ -1,0 +1,336 @@
+import { existsSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DESIGN_STACKS,
+  type DesignKitEntry,
+  type DesignKitLoader,
+  type DesignKitManifest,
+  type DesignKitTokens,
+  type DesignStack,
+  isDesignStack,
+} from '../types/design-kit.js';
+import { resolveWstackPaths } from '../utils/wstack-paths.js';
+
+const KIT_FILE = 'KIT.md';
+const TOKENS_FILE = 'tokens.json';
+const FOUNDATIONS_ID = '_foundations';
+
+/** Strip leading YAML frontmatter, returning the markdown body. */
+function stripFrontmatter(raw: string): string {
+  if (!raw.startsWith('---')) return raw;
+  const end = raw.indexOf('\n---', 4);
+  if (end === -1) return raw;
+  let body = raw.slice(end + 4);
+  if (body.startsWith('\n')) body = body.slice(1);
+  return body;
+}
+
+interface KitFrontmatter {
+  id?: string;
+  name?: string;
+  aesthetic?: string;
+  bestFor?: string;
+  version?: string;
+  tags: string[];
+  stacks: DesignStack[];
+  themes: string[];
+}
+
+function parseList(value: string): string[] {
+  const trimmed = value.trim();
+  const inner = trimmed.startsWith('[') && trimmed.endsWith(']') ? trimmed.slice(1, -1) : trimmed;
+  return inner
+    .split(',')
+    .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+    .filter(Boolean);
+}
+
+/**
+ * Minimal frontmatter parser supporting scalar fields and both inline
+ * (`tags: [a, b]`) and block (`tags:\n  - a`) list syntax. Kit frontmatter is
+ * authored by us (bundled) or trusted project owners, so we keep it small
+ * rather than pulling in a full YAML dependency.
+ */
+function parseKitFrontmatter(raw: string): KitFrontmatter {
+  const out: KitFrontmatter = { tags: [], stacks: [], themes: [] };
+  if (!raw.startsWith('---')) return out;
+  const end = raw.indexOf('\n---', 4);
+  if (end === -1) return out;
+  const block = raw.slice(4, end);
+  const lines = block.split('\n');
+  let listKey: 'tags' | 'stacks' | 'themes' | null = null;
+  const setScalar = (key: string, value: string) => {
+    const v = value.trim().replace(/^["']|["']$/g, '');
+    if (key === 'id') out.id = v;
+    else if (key === 'name') out.name = v;
+    else if (key === 'aesthetic') out.aesthetic = v;
+    else if (key === 'bestFor') out.bestFor = v;
+    else if (key === 'version') out.version = v;
+  };
+  const setList = (key: 'tags' | 'stacks' | 'themes', items: string[]) => {
+    if (key === 'stacks') out.stacks = items.filter(isDesignStack);
+    else out[key] = items;
+  };
+  for (const line of lines) {
+    // Block-list item under an open list key.
+    const item = /^\s*-\s+(.*)$/.exec(line);
+    if (listKey && item) {
+      const parsed = parseList(item[1] ?? '');
+      if (listKey === 'stacks') out.stacks.push(...parsed.filter(isDesignStack));
+      else out[listKey].push(...parsed);
+      continue;
+    }
+    const m = /^([a-zA-Z_]+):\s*(.*)$/.exec(line);
+    if (!m) continue;
+    const key = m[1] ?? '';
+    const rest = (m[2] ?? '').trim();
+    if (key === 'tags' || key === 'stacks' || key === 'themes') {
+      if (rest) {
+        setList(key, parseList(rest));
+        listKey = null;
+      } else {
+        listKey = key;
+      }
+      continue;
+    }
+    listKey = null;
+    setScalar(key, rest);
+  }
+  return out;
+}
+
+/**
+ * Keep cross-cutting sections plus only the requested stack's `## Stack: <id>`
+ * section. When no stack is given, return the body unchanged. Stack sections
+ * are delimited by `## Stack: <stack-id>` headings.
+ */
+function narrowStackSections(body: string, stack?: DesignStack): string {
+  if (!stack) return body;
+  const re = /^##\s+Stack:\s*([a-z-]+)\s*$/gim;
+  const matches: { id: string; start: number }[] = [];
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((m = re.exec(body)) !== null) {
+    matches.push({ id: (m[1] ?? '').trim(), start: m.index });
+  }
+  if (matches.length === 0) return body;
+  const firstStart = matches[0]?.start ?? body.length;
+  let result = body.slice(0, firstStart).trimEnd();
+  for (let i = 0; i < matches.length; i++) {
+    const cur = matches[i];
+    if (!cur) continue;
+    const next = matches[i + 1];
+    const sectionEnd = next ? next.start : body.length;
+    if (cur.id === stack) {
+      result += `\n\n${body.slice(cur.start, sectionEnd).trimEnd()}`;
+    }
+  }
+  return `${result}\n`;
+}
+
+export interface DesignKitLoaderOptions {
+  /** <project>/.wrongstack/design-kits */
+  inProjectDir: string;
+  /** ~/.wrongstack/design-kits */
+  globalDir: string;
+  /** Bundled kits shipped with @wrongstack/core (packages/core/design-kits). */
+  bundledDir?: string | undefined;
+}
+
+/**
+ * Discovery order (highest priority first; later layers are shadowed by name):
+ *   1. Project-committed:  <project>/.wrongstack/design-kits/
+ *   2. User-global:        ~/.wrongstack/design-kits/
+ *   3. Bundled with build: packages/core/design-kits/
+ *
+ * The `_foundations` directory is a reserved kit id holding the mandatory
+ * cross-cutting baseline; it is excluded from the selectable menu.
+ */
+export class DefaultDesignKitLoader implements DesignKitLoader {
+  private readonly dirs: { dir: string; source: DesignKitManifest['source'] }[];
+  private cache?: DesignKitManifest[] | undefined;
+  private readonly bodyCache = new Map<string, string>();
+  private readonly tokenCache = new Map<string, DesignKitTokens | undefined>();
+
+  constructor(opts: DesignKitLoaderOptions) {
+    this.dirs = [
+      { dir: opts.inProjectDir, source: 'project' },
+      { dir: opts.globalDir, source: 'user' },
+    ];
+    if (opts.bundledDir) this.dirs.push({ dir: opts.bundledDir, source: 'bundled' });
+  }
+
+  async list(): Promise<DesignKitManifest[]> {
+    if (this.cache) return this.cache;
+    const found: DesignKitManifest[] = [];
+    const seen = new Set<string>();
+    for (const { dir, source } of this.dirs) {
+      let entries: import('node:fs').Dirent[];
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+      } catch {
+        continue; // directory may not exist
+      }
+      for (const e of entries) {
+        if (!e.isDirectory()) continue;
+        const kitFile = path.join(dir, e.name, KIT_FILE);
+        try {
+          const raw = await fs.readFile(kitFile, 'utf8');
+          const fm = parseKitFrontmatter(raw);
+          const id = fm.id ?? e.name;
+          if (!fm.name) continue;
+          if (seen.has(id)) continue;
+          seen.add(id);
+          found.push({
+            id,
+            name: fm.name,
+            aesthetic: fm.aesthetic ?? '',
+            tags: fm.tags,
+            stacks: fm.stacks.length > 0 ? fm.stacks : [...DESIGN_STACKS],
+            themes: fm.themes.length > 0 ? fm.themes : ['light', 'dark'],
+            bestFor: fm.bestFor ?? '',
+            version: fm.version,
+            path: kitFile,
+            source,
+          });
+        } catch {
+          // skip malformed kit
+        }
+      }
+    }
+    this.cache = found;
+    return found;
+  }
+
+  /** Selectable kits only (excludes the reserved `_foundations` entry). */
+  private async selectable(): Promise<DesignKitManifest[]> {
+    return (await this.list()).filter((k) => k.id !== FOUNDATIONS_ID);
+  }
+
+  async listEntries(): Promise<DesignKitEntry[]> {
+    return (await this.selectable()).map((k) => ({
+      id: k.id,
+      name: k.name,
+      aesthetic: k.aesthetic,
+      bestFor: k.bestFor,
+      stacks: k.stacks,
+      source: k.source,
+    }));
+  }
+
+  async find(id: string): Promise<DesignKitManifest | undefined> {
+    const all = await this.list();
+    const lower = id.toLowerCase();
+    return all.find((k) => k.id.toLowerCase() === lower);
+  }
+
+  async menuText(): Promise<string> {
+    const entries = await this.listEntries();
+    if (entries.length === 0) return '';
+    const lines = ['## Design kits (pick ONE)'];
+    for (const e of entries) {
+      const stacks = e.stacks.join('/');
+      lines.push(`- **${e.id}** — ${e.aesthetic}`);
+      lines.push(`  Best for: ${e.bestFor} · Stacks: ${stacks}`);
+    }
+    return lines.join('\n');
+  }
+
+  async readBody(id: string, stack?: DesignStack): Promise<string> {
+    const key = `${id.toLowerCase()}:${stack ?? '*'}`;
+    const cached = this.bodyCache.get(key);
+    if (cached !== undefined) return cached;
+    const m = await this.find(id);
+    if (!m) throw new Error(`Design kit "${id}" not found`);
+    const raw = await fs.readFile(m.path, 'utf8');
+    const body = narrowStackSections(stripFrontmatter(raw), stack);
+    this.bodyCache.set(key, body);
+    return body;
+  }
+
+  async readTokens(id: string): Promise<DesignKitTokens | undefined> {
+    const key = id.toLowerCase();
+    if (this.tokenCache.has(key)) return this.tokenCache.get(key);
+    const m = await this.find(id);
+    let tokens: DesignKitTokens | undefined;
+    if (m) {
+      const tokensPath = path.join(path.dirname(m.path), TOKENS_FILE);
+      try {
+        const raw = await fs.readFile(tokensPath, 'utf8');
+        const parsed = JSON.parse(raw) as DesignKitTokens;
+        tokens = parsed;
+      } catch {
+        tokens = undefined;
+      }
+    }
+    this.tokenCache.set(key, tokens);
+    return tokens;
+  }
+
+  async foundationsText(stack?: DesignStack): Promise<string> {
+    try {
+      return await this.readBody(FOUNDATIONS_ID, stack);
+    } catch {
+      return '';
+    }
+  }
+
+  invalidateCache(): void {
+    this.cache = undefined;
+    this.bodyCache.clear();
+    this.tokenCache.clear();
+  }
+}
+
+/**
+ * Resolve the bundled `design-kits/` directory shipped alongside this module.
+ * The directory is a sibling of `src/` (dev) and `dist/` (built), so we probe a
+ * few candidate depths relative to the compiled module location and return the
+ * first that exists. Returns `undefined` if none is found (treated as "no
+ * bundled kits this run").
+ */
+export function resolveBundledDesignKitsDir(): string | undefined {
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+      path.join(here, 'design-kits'),
+      path.join(here, '..', 'design-kits'),
+      path.join(here, '..', '..', 'design-kits'),
+      path.join(here, '..', '..', '..', 'design-kits'),
+    ];
+    for (const c of candidates) {
+      if (existsSync(c)) return c;
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+const loaderMemo = new Map<string, DefaultDesignKitLoader>();
+
+/**
+ * Memoized per-project loader. Used by the `design` tool and the Design Studio
+ * middleware/slash-command so they share one cached instance without threading
+ * the loader through every boot path. The loader is a pure disk reader (no
+ * injected services), so a module-level memo is safe.
+ */
+export function getDesignKitLoader(projectRoot: string): DefaultDesignKitLoader {
+  const existing = loaderMemo.get(projectRoot);
+  if (existing) return existing;
+  const paths = resolveWstackPaths({ projectRoot });
+  const loader = new DefaultDesignKitLoader({
+    inProjectDir: paths.inProjectDesignKits,
+    globalDir: paths.globalDesignKits,
+    bundledDir: resolveBundledDesignKitsDir(),
+  });
+  loaderMemo.set(projectRoot, loader);
+  return loader;
+}
+
+/** Test helper — clears the per-project loader memo. */
+export function _resetDesignKitLoaderMemo(): void {
+  loaderMemo.clear();
+}

--- a/packages/core/src/execution/design-project-store.ts
+++ b/packages/core/src/execution/design-project-store.ts
@@ -1,0 +1,125 @@
+/**
+ * Project-local Design Studio store — a gitignored `<project>/.design/` directory
+ * that persists design DECISIONS and project-specific design RULES across
+ * sessions, separate from the committed `.wrongstack/design-kits/` (shared
+ * custom kits). Layout:
+ *
+ *   .design/.gitignore   `*`  — self-ignores so the dir is untracked in ANY repo
+ *   .design/rules.md     project design rules (always injected when UI work is active)
+ *   .design/active.json  { kit, stack } — the pinned kit, restored on session start
+ *   .design/decisions.md append-only log of kit choices (timestamp · kit · stack · via)
+ *
+ * All writes are best-effort: a failure here must never break the tool, slash
+ * command, or a turn.
+ */
+
+import { existsSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+const DESIGN_DIR = '.design';
+
+export function designProjectDir(projectRoot: string): string {
+  return path.join(projectRoot, DESIGN_DIR);
+}
+
+const RULE_FILES = ['rules.md', 'RULES.md', 'design.md'];
+
+const rulesCache = new Map<string, string | undefined>();
+
+/** Read `.design/rules.md` (or RULES.md / design.md). Cached per project root. */
+export async function loadProjectDesignRules(projectRoot: string): Promise<string | undefined> {
+  if (rulesCache.has(projectRoot)) return rulesCache.get(projectRoot);
+  let rules: string | undefined;
+  for (const name of RULE_FILES) {
+    try {
+      const txt = await fs.readFile(path.join(designProjectDir(projectRoot), name), 'utf8');
+      if (txt.trim()) {
+        rules = txt.trim();
+        break;
+      }
+    } catch {
+      // file absent — try next
+    }
+  }
+  rulesCache.set(projectRoot, rules);
+  return rules;
+}
+
+export interface PersistedActiveKit {
+  kit: string;
+  stack?: string | undefined;
+}
+
+/** Read the persisted active kit from `.design/active.json`, if any. */
+export async function loadActiveKit(projectRoot: string): Promise<PersistedActiveKit | undefined> {
+  try {
+    const raw = await fs.readFile(path.join(designProjectDir(projectRoot), 'active.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { kit?: unknown; stack?: unknown };
+    if (parsed && typeof parsed.kit === 'string') {
+      return {
+        kit: parsed.kit,
+        stack: typeof parsed.stack === 'string' ? parsed.stack : undefined,
+      };
+    }
+  } catch {
+    // absent or malformed — no persisted kit
+  }
+  return undefined;
+}
+
+async function ensureDesignDir(projectRoot: string): Promise<string> {
+  const dir = designProjectDir(projectRoot);
+  await fs.mkdir(dir, { recursive: true });
+  // Self-ignore: a `.gitignore` of `*` makes the whole directory untracked in
+  // any project, so design decisions never pollute the repo and we don't have
+  // to edit the project's root .gitignore.
+  const gi = path.join(dir, '.gitignore');
+  if (!existsSync(gi)) {
+    try {
+      await fs.writeFile(gi, '*\n');
+    } catch {
+      // best-effort
+    }
+  }
+  return dir;
+}
+
+/**
+ * Persist a kit choice: update `active.json` and append to `decisions.md`.
+ * `isoTime` is passed in so callers control the timestamp (and tests stay
+ * deterministic). Best-effort — swallows all errors.
+ */
+export async function recordKitChoice(
+  projectRoot: string,
+  kit: string,
+  stack: string | undefined,
+  source: string,
+  isoTime: string,
+): Promise<void> {
+  try {
+    const dir = await ensureDesignDir(projectRoot);
+    await fs.writeFile(
+      path.join(dir, 'active.json'),
+      `${JSON.stringify({ kit, stack: stack ?? null }, null, 2)}\n`,
+    );
+    const line = `- ${isoTime} · kit=${kit}${stack ? ` stack=${stack}` : ''} · via=${source}\n`;
+    await fs.appendFile(path.join(dir, 'decisions.md'), line);
+  } catch {
+    // best-effort: never break the caller
+  }
+}
+
+/** Clear the persisted active kit (e.g. `/design off`). Best-effort. */
+export async function clearPersistedActiveKit(projectRoot: string): Promise<void> {
+  try {
+    await fs.rm(path.join(designProjectDir(projectRoot), 'active.json'), { force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+/** Test helper — clears the rules cache. */
+export function _resetDesignRulesCache(): void {
+  rulesCache.clear();
+}

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -1,56 +1,85 @@
 // Execution domain: compaction, tool execution, error handling, retry, skill loading
-export { HybridCompactor, type CompactorOptions } from './compactor.js';
-export { IntelligentCompactor, type IntelligentCompactorOptions } from './intelligent-compactor.js';
-export { SelectiveCompactor, type SelectiveCompactorOptions } from './selective-compactor.js';
-export {
-  createStrategyCompactor,
-  type CompactorStrategy,
-  type StrategyCompactorOptions,
-} from './strategy-compactor.js';
+
 export {
   AutoCompactionMiddleware,
   type ContextWindowBudgetSnapshot,
 } from './auto-compaction-middleware.js';
-export { ToolExecutor } from './tool-executor.js';
 export {
   AutonomousRunner,
-  DoneConditionChecker,
-  type DoneCheckResult,
   type AutonomousRunnerOptions,
+  type DoneCheckResult,
+  DoneConditionChecker,
 } from './autonomous-runner.js';
+export {
+  type AutonomyBrainOptions,
+  type BrainAutoRisk,
+  createAutonomyBrain,
+  createTieredBrainArbiter,
+  formatDecisionSummary,
+  type TieredBrainArbiterOptions,
+} from './autonomy-brain.js';
+export {
+  type AutonomyPromptContributorOptions,
+  makeAutonomyPromptContributor,
+} from './autonomy-prompt-contributor.js';
+export { type CompactorOptions, HybridCompactor } from './compactor.js';
+export {
+  activateDesign,
+  clearActiveKit,
+  detectFrontendFile,
+  detectFrontendIntent,
+  getDesignState,
+  installDesignStudioMiddleware,
+  makeDesignDetectToolCallMiddleware,
+  makeDesignDetectUserInputMiddleware,
+  makeDesignStudioRequestMiddleware,
+  setActiveKit,
+} from './design-detect.js';
+export {
+  _resetDesignKitLoaderMemo,
+  DefaultDesignKitLoader,
+  type DesignKitLoaderOptions,
+  getDesignKitLoader,
+  resolveBundledDesignKitsDir,
+} from './design-kit-loader.js';
+export {
+  _resetDesignRulesCache,
+  clearPersistedActiveKit,
+  designProjectDir,
+  loadActiveKit,
+  loadProjectDesignRules,
+  type PersistedActiveKit,
+  recordKitChoice,
+} from './design-project-store.js';
+export { DefaultErrorHandler } from './error-handler.js';
 export {
   EternalAutonomyEngine,
   type EternalAutonomyOptions,
   type EternalEngineState,
   type IterationStage,
 } from './eternal-autonomy.js';
-export {
-  ParallelEternalEngine,
-  type ParallelEternalOptions,
-  type ParallelEngineState,
-  type ParallelIterationStage,
-} from './parallel-eternal-engine.js';
-export {
-  makeAutonomyPromptContributor,
-  type AutonomyPromptContributorOptions,
-} from './autonomy-prompt-contributor.js';
 export { buildGoalPreamble } from './goal-preamble.js';
-export {
-  createAutonomyBrain,
-  createTieredBrainArbiter,
-  formatDecisionSummary,
-  type AutonomyBrainOptions,
-  type TieredBrainArbiterOptions,
-  type BrainAutoRisk,
-} from './autonomy-brain.js';
-export { DefaultRetryPolicy } from './retry-policy.js';
-export { DefaultErrorHandler } from './error-handler.js';
-export { DefaultSkillLoader, type SkillLoaderOptions } from './skill-loader.js';
+export { IntelligentCompactor, type IntelligentCompactorOptions } from './intelligent-compactor.js';
 export {
   applyModelRuntime,
-  resolveModelRuntime,
-  resolveReasoningForRequest,
-  resolveCacheForRequest,
   type ModelRuntimeMiddlewareOptions,
   type ResolvedModelRuntime,
+  resolveCacheForRequest,
+  resolveModelRuntime,
+  resolveReasoningForRequest,
 } from './model-runtime.js';
+export {
+  type ParallelEngineState,
+  ParallelEternalEngine,
+  type ParallelEternalOptions,
+  type ParallelIterationStage,
+} from './parallel-eternal-engine.js';
+export { DefaultRetryPolicy } from './retry-policy.js';
+export { SelectiveCompactor, type SelectiveCompactorOptions } from './selective-compactor.js';
+export { DefaultSkillLoader, type SkillLoaderOptions } from './skill-loader.js';
+export {
+  type CompactorStrategy,
+  createStrategyCompactor,
+  type StrategyCompactorOptions,
+} from './strategy-compactor.js';
+export { ToolExecutor } from './tool-executor.js';

--- a/packages/core/src/hq/protocol.ts
+++ b/packages/core/src/hq/protocol.ts
@@ -355,7 +355,7 @@ export interface HqMailboxAgentSummary {
   lastActivityAt: string;
   lastSeenAt: string;
   online: boolean;
-  source?: 'cli' | 'webui' | 'mcp' | 'acp';
+  source?: 'cli' | 'webui' | 'mcp' | 'acp' | 'http';
 }
 
 export interface HqMailboxSnapshotPayload {

--- a/packages/core/src/types/design-kit.ts
+++ b/packages/core/src/types/design-kit.ts
@@ -1,0 +1,95 @@
+/**
+ * Design Studio — curated frontend/mobile UI design kits.
+ *
+ * A "design kit" is a self-contained, selectable design direction (an aesthetic
+ * + concrete design tokens + per-stack implementation guidance) that the model
+ * commits to BEFORE writing UI code. Kits are surfaced progressively: a compact
+ * menu is injected when frontend work is detected, and the heavy kit body is
+ * only loaded once the model (or user) picks one — keeping per-turn tokens low.
+ *
+ * This mirrors the skills subsystem (`types/skill.ts` + `execution/skill-loader.ts`)
+ * but adds the per-stack body selection and a token snapshot for visual pickers.
+ */
+
+/** Target implementation stacks a kit can speak to. */
+export const DESIGN_STACKS = ['web', 'react-native', 'flutter', 'swiftui', 'compose'] as const;
+
+export type DesignStack = (typeof DESIGN_STACKS)[number];
+
+export function isDesignStack(v: string): v is DesignStack {
+  return (DESIGN_STACKS as readonly string[]).includes(v);
+}
+
+export interface DesignKitManifest {
+  id: string;
+  name: string;
+  /** One-line vibe shown in the menu, e.g. "Restrained, Linear-style minimalism". */
+  aesthetic: string;
+  /** Free-form tags for filtering. */
+  tags: string[];
+  /** Stacks this kit provides guidance for. */
+  stacks: DesignStack[];
+  /** Whether the kit ships light + dark themes (almost always true). */
+  themes: string[];
+  /** "Best for…" one-liner used in menu + pickers. */
+  bestFor: string;
+  version?: string | undefined;
+  path: string;
+  source: 'project' | 'user' | 'bundled';
+}
+
+/** A single theme's concrete token values (OKLCH strings, font names, etc.). */
+export interface DesignTokenSet {
+  [token: string]: string;
+}
+
+/** Parsed `tokens.json` — light + dark token snapshots used by visual pickers. */
+export interface DesignKitTokens {
+  light?: DesignTokenSet | undefined;
+  dark?: DesignTokenSet | undefined;
+}
+
+/** Compact menu entry rendered into the request when frontend work is detected. */
+export interface DesignKitEntry {
+  id: string;
+  name: string;
+  aesthetic: string;
+  bestFor: string;
+  stacks: DesignStack[];
+  source: DesignKitManifest['source'];
+}
+
+/**
+ * Live Design Studio state stashed on `ctx.meta.designStudio`. Set by the
+ * detection middleware (user intent + frontend file writes); read by the
+ * request middleware that injects the menu / active-kit reminder.
+ */
+export interface DesignStudioState {
+  /** True once frontend/UI work has been detected this session. */
+  active: boolean;
+  /** Detected target stack, if any. */
+  stack?: DesignStack | undefined;
+  /** What triggered activation (for transparency / debugging). */
+  signals: string[];
+  /** Kit id the model/user committed to, if any. */
+  activeKit?: string | undefined;
+}
+
+export interface DesignKitLoader {
+  list(): Promise<DesignKitManifest[]>;
+  /** Structured entries for the compact menu. */
+  listEntries(): Promise<DesignKitEntry[]>;
+  find(id: string): Promise<DesignKitManifest | undefined>;
+  /** Compact, model-facing menu of every available kit. */
+  menuText(): Promise<string>;
+  /**
+   * Full kit body for a given stack. Strips frontmatter and, when `stack` is
+   * provided, narrows stack-specific sections to that stack.
+   */
+  readBody(id: string, stack?: DesignStack | undefined): Promise<string>;
+  /** Parsed `tokens.json` for a kit (light/dark snapshots), if present. */
+  readTokens(id: string): Promise<DesignKitTokens | undefined>;
+  /** The mandatory cross-cutting baseline (responsive / a11y / theming / motion). */
+  foundationsText(stack?: DesignStack | undefined): Promise<string>;
+  invalidateCache(): void;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -21,6 +21,7 @@ export * from '../infrastructure/path-resolver.js';
 export * from '../execution/error-handler.js';
 export * from '../execution/retry-policy.js';
 export * from './skill.js';
+export * from './design-kit.js';
 export * from './system-prompt.js';
 export * from '../security/secret-scrubber.js';
 export * from './renderer.js';

--- a/packages/core/src/types/mode.ts
+++ b/packages/core/src/types/mode.ts
@@ -173,6 +173,24 @@ When refactoring code:
     suggestedSkills: ['refactor-planner', 'typescript-strict', 'node-modern', 'testing'],
   },
   {
+    id: 'ui-design',
+    name: 'UI Design',
+    description: 'Design-first frontend & mobile UI work (Design Studio)',
+    prompt: `## UI Design Mode
+
+You are building user interfaces. Design quality is a first-class requirement, not an afterthought:
+- BEFORE writing UI code, commit to ONE coherent design direction. Use the \`design\` tool:
+  \`design list\` to review curated kits, then \`design use <kit-id> --stack <stack>\` to load the full spec.
+- Never ship generic, default-framework, unstyled output.
+- Always: mobile-first responsive, BOTH light and dark themes from one token set, WCAG 2.2 AA,
+  tasteful motion that honors \`prefers-reduced-motion\`, and current stack defaults
+  (web: React 19 + Tailwind v4 \`@theme\`/OKLCH + shadcn/ui + Motion; RN: Expo + NativeWind; etc.).
+- Implement the chosen kit faithfully — its tokens, components, and patterns.`,
+    tags: ['ui', 'frontend', 'mobile', 'design'],
+    toolPreferences: ['design', 'write', 'edit', 'read', 'scaffold'],
+    suggestedSkills: ['react-modern'],
+  },
+  {
     id: 'brief',
     name: 'Brief',
     description: 'Fast, no-nonsense — get to the point',

--- a/packages/core/src/utils/wstack-paths.ts
+++ b/packages/core/src/utils/wstack-paths.ts
@@ -29,6 +29,8 @@ export interface WstackPaths {
   globalMemory: string;
   /** ~/.wrongstack/skills — user-global skills. */
   globalSkills: string;
+  /** ~/.wrongstack/design-kits — user-global Design Studio kits. */
+  globalDesignKits: string;
   /** ~/.wrongstack/prompts — user-global prompt library. */
   globalPrompts: string;
   /** ~/.wrongstack/cache — fetched data (models.dev, etc.). */
@@ -66,6 +68,8 @@ export interface WstackPaths {
   inProjectAgentsFile: string;
   /** <project>/.wrongstack/skills — committed project skills. */
   inProjectSkills: string;
+  /** <project>/.wrongstack/design-kits — committed project Design Studio kits. */
+  inProjectDesignKits: string;
   /** <project>/.wrongstack/worktrees — git worktrees for per-phase isolation (gitignored). */
   inProjectWorktrees: string;
   /** Stable hash for the project root. */
@@ -158,6 +162,7 @@ export function resolveWstackPaths(opts: WstackPathOptions): WstackPaths {
     secretsKey: path.join(globalRoot, '.key'),
     globalMemory: path.join(globalRoot, 'memory.md'),
     globalSkills: path.join(globalRoot, 'skills'),
+    globalDesignKits: path.join(globalRoot, 'design-kits'),
     globalPrompts: path.join(globalRoot, 'prompts'),
     cacheDir: path.join(globalRoot, 'cache'),
     modelsCache: path.join(globalRoot, 'cache', 'models.dev.json'),
@@ -174,6 +179,7 @@ export function resolveWstackPaths(opts: WstackPathOptions): WstackPaths {
     inProjectConfig: path.join(opts.projectRoot, '.wrongstack', 'config.json'),
     inProjectAgentsFile: path.join(opts.projectRoot, '.wrongstack', 'AGENTS.md'),
     inProjectSkills: path.join(opts.projectRoot, '.wrongstack', 'skills'),
+    inProjectDesignKits: path.join(opts.projectRoot, '.wrongstack', 'design-kits'),
     inProjectWorktrees: path.join(opts.projectRoot, '.wrongstack', 'worktrees'),
     projectHash: hash,
     projectSlug: slug,

--- a/packages/core/tests/execution/design-detect.test.ts
+++ b/packages/core/tests/execution/design-detect.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import type { Context } from '../../src/core/context.js';
+import type { Request } from '../../src/types/provider.js';
+import type { DesignKitLoader } from '../../src/types/design-kit.js';
+import {
+  activateDesign,
+  clearActiveKit,
+  detectFrontendFile,
+  detectFrontendIntent,
+  getDesignState,
+  makeDesignDetectToolCallMiddleware,
+  makeDesignDetectUserInputMiddleware,
+  makeDesignStudioRequestMiddleware,
+  setActiveKit,
+} from '../../src/execution/design-detect.js';
+
+function fakeCtx(): { meta: Record<string, unknown> } {
+  return { meta: {} };
+}
+
+const fakeLoader: DesignKitLoader = {
+  list: async () => [],
+  listEntries: async () => [],
+  find: async () => undefined,
+  menuText: async () => '## Design kits (pick ONE)\n- **minimal-clarity** — calm',
+  readBody: async () => '',
+  readTokens: async () => undefined,
+  foundationsText: async () => '',
+  invalidateCache: () => {},
+};
+
+describe('detectFrontendIntent', () => {
+  it('detects web UI intent and infers the web stack', () => {
+    const hit = detectFrontendIntent('Build me a landing page with a hero section');
+    expect(hit).not.toBeNull();
+    expect(hit?.stack).toBe('web');
+  });
+
+  it('infers specific native stacks from keywords', () => {
+    expect(detectFrontendIntent('make a flutter screen')?.stack).toBe('flutter');
+    expect(detectFrontendIntent('an Expo react native app')?.stack).toBe('react-native');
+    expect(detectFrontendIntent('a SwiftUI settings view')?.stack).toBe('swiftui');
+    expect(detectFrontendIntent('a Jetpack Compose list')?.stack).toBe('compose');
+  });
+
+  it('returns null for non-UI prompts', () => {
+    expect(detectFrontendIntent('fix the database migration script')).toBeNull();
+    expect(detectFrontendIntent('refactor the retry policy')).toBeNull();
+  });
+});
+
+describe('detectFrontendFile', () => {
+  it('flags frontend file extensions and infers stack', () => {
+    expect(detectFrontendFile('src/App.tsx')?.stack).toBe('web');
+    expect(detectFrontendFile('styles/theme.css')?.stack).toBe('web');
+    expect(detectFrontendFile('lib/home.dart')?.stack).toBe('flutter');
+    expect(detectFrontendFile('Views/Home.swift')?.stack).toBe('swiftui');
+  });
+
+  it('ignores non-frontend files', () => {
+    expect(detectFrontendFile('server/db.ts')).toBeNull();
+    expect(detectFrontendFile('README.md')).toBeNull();
+  });
+});
+
+describe('state helpers', () => {
+  it('activate + setActiveKit + clearActiveKit mutate ctx.meta', () => {
+    const ctx = fakeCtx();
+    activateDesign(ctx, ['intent:ui'], 'web');
+    let s = getDesignState(ctx);
+    expect(s?.active).toBe(true);
+    expect(s?.stack).toBe('web');
+
+    setActiveKit(ctx, 'neo-brutalist', 'web');
+    s = getDesignState(ctx);
+    expect(s?.activeKit).toBe('neo-brutalist');
+
+    clearActiveKit(ctx);
+    expect(getDesignState(ctx)?.activeKit).toBeUndefined();
+    expect(getDesignState(ctx)?.active).toBe(true); // detection survives
+  });
+});
+
+describe('userInput middleware', () => {
+  it('activates design state when the message has UI intent', async () => {
+    const ctx = fakeCtx() as unknown as Context;
+    const mw = makeDesignDetectUserInputMiddleware();
+    await mw.handler(
+      { text: 'design a dashboard UI', content: [], ctx },
+      async (p) => p,
+    );
+    expect(getDesignState(ctx as unknown as { meta: Record<string, unknown> })?.active).toBe(true);
+  });
+});
+
+describe('toolCall middleware', () => {
+  it('activates when a frontend file is written', async () => {
+    const ctx = fakeCtx() as unknown as Context;
+    const mw = makeDesignDetectToolCallMiddleware();
+    await mw.handler(
+      {
+        toolUse: { type: 'tool_use', id: 'x', name: 'write', input: { path: 'ui/Card.tsx' } },
+        result: { type: 'tool_result', tool_use_id: 'x', content: [] },
+        ctx,
+      } as never,
+      async (p) => p,
+    );
+    expect(getDesignState(ctx as unknown as { meta: Record<string, unknown> })?.active).toBe(true);
+  });
+});
+
+describe('request inject middleware', () => {
+  function baseReq(): Request {
+    return { model: 'm', system: [{ type: 'text', text: 'BASE' }], messages: [] } as Request;
+  }
+
+  it('is a no-op when Design Studio is inactive', async () => {
+    const ctx = fakeCtx() as unknown as Context;
+    const mw = makeDesignStudioRequestMiddleware({ ctx, loader: fakeLoader });
+    const out = await mw.handler(baseReq(), async (r) => r);
+    expect(out.system).toHaveLength(1);
+    expect(out.system?.[0]?.text).toBe('BASE');
+  });
+
+  it('injects the kit menu when active without a chosen kit', async () => {
+    const ctx = fakeCtx() as unknown as Context;
+    activateDesign(ctx as unknown as { meta: Record<string, unknown> }, ['intent:ui'], 'web');
+    const mw = makeDesignStudioRequestMiddleware({ ctx, loader: fakeLoader });
+    const out = await mw.handler(baseReq(), async (r) => r);
+    expect(out.system).toHaveLength(2);
+    const injected = out.system?.[1]?.text ?? '';
+    expect(injected).toMatch(/Design Studio/i);
+    expect(injected).toContain('minimal-clarity');
+    expect(injected).toMatch(/WCAG/);
+    // Does not mutate the shared base array.
+    expect(out.system?.[0]?.text).toBe('BASE');
+  });
+
+  it('shrinks to a one-line reminder once a kit is active', async () => {
+    const ctx = fakeCtx() as unknown as Context;
+    setActiveKit(ctx as unknown as { meta: Record<string, unknown> }, 'neo-brutalist', 'web');
+    const mw = makeDesignStudioRequestMiddleware({ ctx, loader: fakeLoader });
+    const out = await mw.handler(baseReq(), async (r) => r);
+    const injected = out.system?.[1]?.text ?? '';
+    expect(injected).toMatch(/Active design kit: neo-brutalist/);
+  });
+
+  it('respects the enabled() gate', async () => {
+    const ctx = fakeCtx() as unknown as Context;
+    activateDesign(ctx as unknown as { meta: Record<string, unknown> }, ['intent:ui'], 'web');
+    const mw = makeDesignStudioRequestMiddleware({ ctx, loader: fakeLoader, enabled: () => false });
+    const out = await mw.handler(baseReq(), async (r) => r);
+    expect(out.system).toHaveLength(1);
+  });
+});

--- a/packages/core/tests/execution/design-kit-loader.test.ts
+++ b/packages/core/tests/execution/design-kit-loader.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DefaultDesignKitLoader,
+  resolveBundledDesignKitsDir,
+} from '../../src/execution/design-kit-loader.js';
+
+function bundledLoader(): DefaultDesignKitLoader {
+  const bundledDir = resolveBundledDesignKitsDir();
+  expect(bundledDir, 'bundled design-kits dir should resolve').toBeTruthy();
+  return new DefaultDesignKitLoader({
+    inProjectDir: '/nonexistent/project/.wrongstack/design-kits',
+    globalDir: '/nonexistent/global/design-kits',
+    bundledDir,
+  });
+}
+
+describe('DefaultDesignKitLoader', () => {
+  it('discovers the bundled kits and excludes _foundations from the menu', async () => {
+    const loader = bundledLoader();
+    const all = await loader.list();
+    const ids = all.map((k) => k.id);
+    expect(ids).toContain('minimal-clarity');
+    expect(ids).toContain('neo-brutalist');
+    expect(ids).toContain('material-expressive');
+    expect(ids).toContain('_foundations'); // present in list()
+
+    const entries = await loader.listEntries();
+    const entryIds = entries.map((e) => e.id);
+    expect(entryIds).not.toContain('_foundations'); // excluded from selectable menu
+    expect(entryIds.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('parses frontmatter (name, aesthetic, stacks) for a kit', async () => {
+    const loader = bundledLoader();
+    const kit = await loader.find('minimal-clarity');
+    expect(kit).toBeDefined();
+    expect(kit?.name).toBe('Minimal Clarity');
+    expect(kit?.aesthetic).toMatch(/minimal/i);
+    expect(kit?.stacks).toContain('web');
+    expect(kit?.source).toBe('bundled');
+  });
+
+  it('renders a compact menu listing kit ids + best-for', async () => {
+    const loader = bundledLoader();
+    const menu = await loader.menuText();
+    expect(menu).toMatch(/Design kits/i);
+    expect(menu).toContain('minimal-clarity');
+    expect(menu).not.toContain('_foundations');
+  });
+
+  it('readBody narrows to the requested stack section', async () => {
+    const loader = bundledLoader();
+    const web = await loader.readBody('minimal-clarity', 'web');
+    expect(web).toContain('## Stack: web');
+    expect(web).not.toContain('## Stack: flutter');
+    // Cross-cutting sections survive narrowing.
+    expect(web).toMatch(/## Overview/);
+
+    const all = await loader.readBody('minimal-clarity');
+    expect(all).toContain('## Stack: web');
+    expect(all).toContain('## Stack: flutter');
+  });
+
+  it('readTokens returns light + dark token snapshots', async () => {
+    const loader = bundledLoader();
+    const tokens = await loader.readTokens('minimal-clarity');
+    expect(tokens?.light?.['primary']).toMatch(/oklch/);
+    expect(tokens?.dark?.['bg']).toMatch(/oklch/);
+  });
+
+  it('foundationsText returns the baseline doc', async () => {
+    const loader = bundledLoader();
+    const text = await loader.foundationsText('web');
+    expect(text).toMatch(/WCAG/i);
+    expect(text).toMatch(/responsive/i);
+  });
+
+  it('throws for an unknown kit id', async () => {
+    const loader = bundledLoader();
+    await expect(loader.readBody('does-not-exist')).rejects.toThrow(/not found/i);
+  });
+});

--- a/packages/core/tests/execution/design-project-store.test.ts
+++ b/packages/core/tests/execution/design-project-store.test.ts
@@ -1,0 +1,73 @@
+import { existsSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  _resetDesignRulesCache,
+  clearPersistedActiveKit,
+  designProjectDir,
+  loadActiveKit,
+  loadProjectDesignRules,
+  recordKitChoice,
+} from '../../src/execution/design-project-store.js';
+
+let root: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-design-'));
+  _resetDesignRulesCache();
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe('design-project-store', () => {
+  it('recordKitChoice writes active.json, decisions.md, and a self-ignoring .gitignore', async () => {
+    await recordKitChoice(root, 'neo-brutalist', 'web', 'design-tool', '2026-06-27T10:00:00.000Z');
+    const dir = designProjectDir(root);
+    expect(existsSync(path.join(dir, '.gitignore'))).toBe(true);
+    expect(await fs.readFile(path.join(dir, '.gitignore'), 'utf8')).toBe('*\n');
+
+    const active = await loadActiveKit(root);
+    expect(active).toEqual({ kit: 'neo-brutalist', stack: 'web' });
+
+    const decisions = await fs.readFile(path.join(dir, 'decisions.md'), 'utf8');
+    expect(decisions).toContain('kit=neo-brutalist');
+    expect(decisions).toContain('stack=web');
+    expect(decisions).toContain('via=design-tool');
+  });
+
+  it('appends successive decisions to the log', async () => {
+    await recordKitChoice(root, 'minimal-clarity', 'web', 'webui', '2026-06-27T10:00:00.000Z');
+    await recordKitChoice(root, 'soft-glass', undefined, 'design-tool', '2026-06-27T10:05:00.000Z');
+    const decisions = await fs.readFile(path.join(designProjectDir(root), 'decisions.md'), 'utf8');
+    expect(decisions.match(/^- /gm)?.length).toBe(2);
+    // Latest choice wins in active.json.
+    expect((await loadActiveKit(root))?.kit).toBe('soft-glass');
+  });
+
+  it('loadActiveKit returns undefined when nothing is persisted', async () => {
+    expect(await loadActiveKit(root)).toBeUndefined();
+  });
+
+  it('clearPersistedActiveKit removes active.json (keeps decisions log)', async () => {
+    await recordKitChoice(root, 'dark-pro', 'web', 'slash', '2026-06-27T10:00:00.000Z');
+    await clearPersistedActiveKit(root);
+    expect(await loadActiveKit(root)).toBeUndefined();
+    expect(existsSync(path.join(designProjectDir(root), 'decisions.md'))).toBe(true);
+  });
+
+  it('loadProjectDesignRules reads .design/rules.md (cached per root)', async () => {
+    const dir = designProjectDir(root);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'rules.md'), '# Brand\n- Always use 8px grid.\n');
+    const rules = await loadProjectDesignRules(root);
+    expect(rules).toContain('8px grid');
+  });
+
+  it('loadProjectDesignRules returns undefined when no rules file exists', async () => {
+    expect(await loadProjectDesignRules(root)).toBeUndefined();
+  });
+});

--- a/packages/tools/src/builtin.ts
+++ b/packages/tools/src/builtin.ts
@@ -3,6 +3,7 @@ import { auditTool } from './audit.js';
 import { bashTool } from './bash.js';
 import { batchToolUseTool } from './batch-tool-use.js';
 import { codebaseIndexTool, codebaseSearchTool, codebaseStatsTool } from './codebase-index/index.js';
+import { designTool } from './design.js';
 import { diffTool } from './diff.js';
 import { documentTool } from './document.js';
 import { editTool } from './edit.js';
@@ -109,6 +110,7 @@ export const TIER2_TOOLS: Tool[] = [
   taskTool,
   installTool,
   auditTool,
+  designTool,
 ];
 
 /**
@@ -164,6 +166,7 @@ export const builtinTools: Tool[] = [
   logsTool,
   documentTool,
   scaffoldTool,
+  designTool,
   toolSearchTool,
   toolUseTool,
   batchToolUseTool,

--- a/packages/tools/src/design.ts
+++ b/packages/tools/src/design.ts
@@ -1,0 +1,129 @@
+import type { DesignStack, Tool } from '@wrongstack/core';
+import { getDesignKitLoader, isDesignStack, recordKitChoice, setActiveKit } from '@wrongstack/core';
+
+interface DesignInput {
+  action?: 'list' | 'use' | 'foundations' | undefined;
+  kit?: string | undefined;
+  stack?: string | undefined;
+}
+
+interface DesignOutput {
+  action: string;
+  kit?: string | undefined;
+  stack?: string | undefined;
+  output: string;
+}
+
+/**
+ * Design Studio tool — progressive disclosure of curated UI design kits.
+ *
+ * The model is nudged toward this tool by the Design Studio request middleware
+ * once frontend work is detected. `list` shows the menu (cheap); `use` loads the
+ * full, stack-specific kit spec into context and pins it as the active kit;
+ * `foundations` returns the mandatory cross-cutting baseline.
+ */
+export const designTool: Tool<DesignInput, DesignOutput> = {
+  name: 'design',
+  category: 'Design',
+  description:
+    'Browse and load curated frontend/mobile UI design kits (selectable, production-grade design ' +
+    'directions with concrete tokens + per-stack guidance). Use BEFORE writing UI code to commit to ' +
+    'one coherent, modern, responsive, dark/light, accessible design — instead of generic default output. ' +
+    'Actions: "list" (menu), "use" (load a kit\'s full spec for a stack and pin it active), ' +
+    '"foundations" (mandatory responsive/a11y/theming/motion baseline).',
+  usageHint:
+    'Typical flow: `design {action:"list"}` → pick a kit → ' +
+    '`design {action:"use", kit:"minimal-clarity", stack:"web"}` → implement faithfully.\n' +
+    'Stacks: web | react-native | flutter | swiftui | compose.',
+  permission: 'auto',
+  mutating: false,
+  capabilities: [],
+  timeoutMs: 10_000,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      action: {
+        type: 'string',
+        enum: ['list', 'use', 'foundations'],
+        description:
+          'list = show the kit menu; use = load a kit; foundations = baseline rules. Default: list.',
+      },
+      kit: {
+        type: 'string',
+        description: 'Kit id (required for action "use"), e.g. "minimal-clarity", "neo-brutalist".',
+      },
+      stack: {
+        type: 'string',
+        enum: ['web', 'react-native', 'flutter', 'swiftui', 'compose'],
+        description: 'Target stack — narrows guidance to that platform. Default: web.',
+      },
+    },
+    required: [],
+  },
+  async execute(input, ctx): Promise<DesignOutput> {
+    const loader = getDesignKitLoader(ctx.projectRoot);
+    const action = input.action ?? 'list';
+    const stack: DesignStack | undefined =
+      input.stack && isDesignStack(input.stack) ? input.stack : undefined;
+
+    if (action === 'foundations') {
+      const text = await loader.foundationsText(stack);
+      return {
+        action,
+        stack,
+        output: text || 'No foundations document is installed.',
+      };
+    }
+
+    if (action === 'use') {
+      const kitId = input.kit?.trim();
+      if (!kitId) {
+        const menu = await loader.menuText();
+        return { action, output: `No kit id provided.\n\n${menu}` };
+      }
+      const manifest = await loader.find(kitId);
+      if (!manifest) {
+        const menu = await loader.menuText();
+        return { action, kit: kitId, output: `Kit "${kitId}" not found.\n\n${menu}` };
+      }
+      const resolvedStack = stack ?? manifest.stacks[0] ?? 'web';
+      const body = await loader.readBody(manifest.id, resolvedStack);
+      const tokens = await loader.readTokens(manifest.id);
+      // Pin the chosen kit so the request middleware switches from "pick a kit"
+      // to a compact adherence reminder, and UI pickers reflect the selection.
+      setActiveKit(ctx, manifest.id, resolvedStack);
+      // Persist the decision to the gitignored `.design/` dir (active.json +
+      // decisions.md) so it survives across sessions. Best-effort.
+      await recordKitChoice(
+        ctx.projectRoot,
+        manifest.id,
+        resolvedStack,
+        'design-tool',
+        new Date().toISOString(),
+      );
+
+      const header =
+        `# Active design kit: ${manifest.name} (${manifest.id}) — stack: ${resolvedStack}\n` +
+        `${manifest.aesthetic}\n\n` +
+        'Implement the UI faithfully to this spec. Keep light/dark, responsive, and WCAG AA.\n';
+      const tokenBlock = tokens
+        ? `\n## Token snapshot (tokens.json)\n\`\`\`json\n${JSON.stringify(tokens, null, 2)}\n\`\`\`\n`
+        : '';
+      return {
+        action,
+        kit: manifest.id,
+        stack: resolvedStack,
+        output: `${header}${tokenBlock}\n${body}`,
+      };
+    }
+
+    // Default: list
+    const menu = await loader.menuText();
+    return {
+      action: 'list',
+      output:
+        (menu || 'No design kits are installed.') +
+        '\n\nLoad one with `design {action:"use", kit:"<id>", stack:"<stack>"}`.',
+    };
+  },
+};

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -39,6 +39,7 @@ export { outdatedTool } from './outdated.js';
 export { logsTool } from './logs.js';
 export { documentTool } from './document.js';
 export { scaffoldTool } from './scaffold.js';
+export { designTool } from './design.js';
 export { toolSearchTool } from './tool-search.js';
 export { toolUseTool } from './tool-use.js';
 export { batchToolUseTool } from './batch-tool-use.js';

--- a/packages/tools/tests/design.test.ts
+++ b/packages/tools/tests/design.test.ts
@@ -1,0 +1,59 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { designTool } from '../src/design.js';
+
+let root: string;
+beforeAll(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-design-tool-'));
+});
+afterAll(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+const makeCtx = () => ({ cwd: root, tools: [], projectRoot: root, meta: {} }) as any;
+const opts = { signal: new AbortController().signal };
+
+describe('designTool', () => {
+  it('lists the bundled kit menu by default', async () => {
+    const ctx = makeCtx();
+    const res = await designTool.execute({}, ctx, opts);
+    expect(res.action).toBe('list');
+    expect(res.output).toContain('minimal-clarity');
+    expect(res.output).not.toContain('_foundations');
+  });
+
+  it('loads a kit body for a stack and pins it active on ctx.meta', async () => {
+    const ctx = makeCtx();
+    const res = await designTool.execute(
+      { action: 'use', kit: 'neo-brutalist', stack: 'web' },
+      ctx,
+      opts,
+    );
+    expect(res.action).toBe('use');
+    expect(res.kit).toBe('neo-brutalist');
+    expect(res.stack).toBe('web');
+    expect(res.output).toMatch(/Active design kit/i);
+    expect(res.output).toContain('## Stack: web');
+    expect(res.output).not.toContain('## Stack: flutter');
+    // tokens snapshot included
+    expect(res.output).toMatch(/oklch/);
+    // active kit recorded for the request middleware / UI pickers
+    expect((ctx.meta.designStudio as any)?.activeKit).toBe('neo-brutalist');
+  });
+
+  it('returns the menu when an unknown kit is requested', async () => {
+    const ctx = makeCtx();
+    const res = await designTool.execute({ action: 'use', kit: 'nope' }, ctx, opts);
+    expect(res.output).toMatch(/not found/i);
+    expect(res.output).toContain('minimal-clarity');
+  });
+
+  it('returns the mandatory foundations baseline', async () => {
+    const ctx = makeCtx();
+    const res = await designTool.execute({ action: 'foundations', stack: 'web' }, ctx, opts);
+    expect(res.action).toBe('foundations');
+    expect(res.output).toMatch(/WCAG/);
+  });
+});

--- a/packages/tui/src/app-reducer.ts
+++ b/packages/tui/src/app-reducer.ts
@@ -564,6 +564,36 @@ export function reducer(state: State, action: Action): State {
         ...state,
         autonomyPicker: { ...state.autonomyPicker, hint: action.text },
       };
+    case 'designPickerOpen':
+      return {
+        ...state,
+        ...closePanels(state),
+        designPicker: {
+          open: true,
+          kits: action.kits,
+          selected: 0,
+          stack: state.designPicker.stack || 'web',
+        },
+      };
+    case 'designPickerClose':
+      return {
+        ...state,
+        designPicker: { ...state.designPicker, open: false },
+      };
+    case 'designPickerMove': {
+      const n = state.designPicker.kits.length;
+      if (n === 0) return state;
+      const next = (state.designPicker.selected + action.delta + n) % n;
+      return {
+        ...state,
+        designPicker: { ...state.designPicker, selected: next },
+      };
+    }
+    case 'designPickerStack':
+      return {
+        ...state,
+        designPicker: { ...state.designPicker, stack: action.stack },
+      };
     case 'resumePickerOpen':
       return {
         ...state,

--- a/packages/tui/src/app-state.ts
+++ b/packages/tui/src/app-state.ts
@@ -1,6 +1,6 @@
 // State, Action, and supporting types extracted from app-reducer.ts.
 // This file has NO React or Ink dependencies — pure type definitions.
-import type { AutonomyStage, ContentBlock, SddBoardSnapshot, TokenSavingTier } from '@wrongstack/core';
+import type { AutonomyStage, ContentBlock, DesignKitEntry, SddBoardSnapshot, TokenSavingTier } from '@wrongstack/core';
 import type { AutonomyOption } from './components/autonomy-picker.js';
 import type { HistoryEntry } from './components/history.js';
 import type { ProviderOption } from './components/model-picker.js';
@@ -244,6 +244,14 @@ export type State = {
     options: AutonomyOption[];
     selected: number;
     hint?: string | undefined;
+  };
+  /** Design Studio kit picker — opened by `/design`. */
+  designPicker: {
+    open: boolean;
+    kits: DesignKitEntry[];
+    selected: number;
+    /** Target stack applied on selection. */
+    stack: string;
   };
   /** Session resume picker — opened by `/resume`. Lists recent sessions with metadata. */
   resumePicker: {
@@ -750,6 +758,10 @@ export type Action =
   | { type: 'autonomyPickerClose' }
   | { type: 'autonomyPickerMove'; delta: number }
   | { type: 'autonomyPickerHint'; text?: string | undefined }
+  | { type: 'designPickerOpen'; kits: DesignKitEntry[] }
+  | { type: 'designPickerClose' }
+  | { type: 'designPickerMove'; delta: number }
+  | { type: 'designPickerStack'; stack: string }
   | { type: 'resumePickerOpen'; sessions: ResumeSessionEntry[] }
   | { type: 'resumePickerClose' }
   | { type: 'resumePickerMove'; delta: number }

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -17,6 +17,7 @@ import type {
 } from '@wrongstack/core';
 import { type AutonomyStage, DefaultSessionRewinder } from '@wrongstack/core';
 import { loadGoal, resolveWstackPaths } from '@wrongstack/core';
+import { clearActiveKit, clearPersistedActiveKit, getDesignKitLoader, isDesignStack, setActiveKit } from '@wrongstack/core';
 import { InputBuilder, buildGoalPreamble, formatTodosList, writeOut } from '@wrongstack/core';
 import { enhanceUserPrompt, normalizedEqual, recentTextTurns, shouldEnhance } from '@wrongstack/core';
 import { type VisionAdapters, routeImagesForModel } from '@wrongstack/runtime/vision';
@@ -34,6 +35,7 @@ import React, {
 import { readClipboardImage, readClipboardText } from './clipboard.js';
 import { AgentsMonitor } from './components/agents-monitor.js';
 import { AUTONOMY_OPTIONS, AutonomyPicker } from './components/autonomy-picker.js';
+import { DesignPicker } from './components/design-picker.js';
 import { BrainDecisionPrompt } from './components/brain-decision-prompt.js';
 import { CheckpointTimeline } from './components/checkpoint-timeline.js';
 import { type ConfirmDecision, ConfirmPrompt } from './components/confirm-prompt.js';
@@ -1059,6 +1061,7 @@ export function App({
       searchQuery: '',
     },
     autonomyPicker: { open: false, options: [], selected: 0 },
+    designPicker: { open: false, kits: [], selected: 0, stack: 'web' },
     resumePicker: { open: false, sessions: [], selected: 0, busy: false, hint: undefined, error: undefined },
     settingsPicker: { open: false, field: 0, lastSettingsField: 0, filter: '', mode: 'off', delayMs: 0, titleAnimation: true, yolo: false, streamFleet: true, chime: false, confirmExit: true, nextPrediction: false, featureMcp: true, featurePlugins: true, featureMemory: true, featureSkills: true, featureModelsRegistry: true, tokenSavingTier: 'off' as TokenSavingTier, allowOutsideProjectRoot: true, contextAutoCompact: true, contextStrategy: 'hybrid', contextMode: 'balanced' as ContextMode, maxConcurrent: 10, logLevel: 'info', auditLevel: 'standard', indexOnStart: true, multiDiffSummaryThreshold: 5, maxIterations: 500, autoProceedMaxIterations: 50, enhanceDelayMs: 60_000, enhanceEnabled: true, enhanceLanguage: 'original', debugStream: false, statuslineMode: 'detailed' as StatuslineMode, reasoningMode: 'auto' as 'auto', reasoningEffort: 'high', reasoningPreserve: false, thinkingWord: 'thinking', thinkingWordEditing: false, thinkingWordDraft: '', cacheTtl: 'default', configScope: 'global' },
     statuslinePicker: { open: false, field: 0, hiddenItems: [], visibleChips: [], hint: undefined },
@@ -1356,6 +1359,7 @@ export function App({
   const pickerOverlayOpen =
     state.modelPicker.open ||
     state.autonomyPicker.open ||
+    state.designPicker.open ||
     state.settingsPicker.open ||
     state.projectPicker.open ||
     state.slashPicker.open ||
@@ -1988,6 +1992,7 @@ export function App({
       state.slashPicker.open ||
       state.modelPicker.open ||
       state.autonomyPicker.open ||
+      state.designPicker.open ||
       state.resumePicker.open ||
       state.settingsPicker.open ||
       state.enhanceBusy ||
@@ -2010,6 +2015,7 @@ export function App({
     state.slashPicker.open,
     state.modelPicker.open,
     state.autonomyPicker.open,
+    state.designPicker.open,
     state.settingsPicker.open,
     state.enhanceBusy,
     state.enhance,
@@ -2075,6 +2081,7 @@ export function App({
       if (stateRef.current.projectPicker.open) dispatch({ type: 'projectPickerClose' });
       if (stateRef.current.modelPicker.open) dispatch({ type: 'modelPickerClose' });
       if (stateRef.current.autonomyPicker.open) dispatch({ type: 'autonomyPickerClose' });
+      if (stateRef.current.designPicker.open) dispatch({ type: 'designPickerClose' });
       if (stateRef.current.resumePicker.open) dispatch({ type: 'resumePickerClose' });
       if (stateRef.current.slashPicker.open) dispatch({ type: 'slashPickerClose' });
       if (stateRef.current.picker.open) dispatch({ type: 'pickerClose' });
@@ -2972,6 +2979,48 @@ export function App({
       slashRegistry.unregister('f');
     };
   }, [slashRegistry, openFKeyPicker]);
+
+  // Register the TUI-only `/design` command. With no args it opens the visual
+  // kit picker; with args it pins/clears like the CLI command. The picker's
+  // Enter routes back through `/design <id> <stack>`, so this one handler
+  // serves both the visual and typed paths.
+  useEffect(() => {
+    const cmd = {
+      name: 'design',
+      description: 'Open the Design Studio kit picker (or /design <kit> [stack] | off | foundations).',
+      async run(args: string) {
+        const loader = getDesignKitLoader(projectRoot);
+        const tokens = (args ?? '').trim().split(/\s+/).filter(Boolean);
+        const sub = tokens[0]?.toLowerCase();
+        if (!sub) {
+          const kits = await loader.listEntries();
+          dispatch({ type: 'designPickerOpen', kits });
+          return { message: undefined };
+        }
+        if (sub === 'off') {
+          clearActiveKit(agent.ctx);
+          await clearPersistedActiveKit(projectRoot);
+          return { message: 'Cleared the active design kit.' };
+        }
+        if (sub === 'foundations') {
+          return { runText: 'design foundations' };
+        }
+        const kit = await loader.find(sub);
+        if (!kit) {
+          const menu = await loader.menuText();
+          return { message: `Unknown kit "${sub}".\n\n${menu}` };
+        }
+        const stackArg = tokens[1]?.toLowerCase();
+        const stack = stackArg && isDesignStack(stackArg) ? stackArg : undefined;
+        setActiveKit(agent.ctx, kit.id, stack);
+        return { runText: `design use ${kit.id}${stack ? ` --stack ${stack}` : ''}` };
+      },
+    };
+    slashRegistry.register(cmd, 'tui', { official: true });
+    return () => {
+      slashRegistry.unregister('design');
+    };
+  }, [slashRegistry, projectRoot, agent]);
 
   // Register the TUI-only `/settings` command — opens the interactive
   // SettingsPicker immediately, same as Ctrl+S. Accepts an optional
@@ -4018,6 +4067,7 @@ export function App({
     const overlaySelectable =
       state.modelPicker.open ||
       state.autonomyPicker.open ||
+      state.designPicker.open ||
       state.resumePicker.open ||
       state.settingsPicker.open ||
       state.projectPicker.open ||
@@ -4039,6 +4089,8 @@ export function App({
         );
       } else if (state.autonomyPicker.open) {
         dispatch({ type: 'autonomyPickerClose' });
+      } else if (state.designPicker.open) {
+        dispatch({ type: 'designPickerClose' });
       } else if (state.resumePicker.open) {
         dispatch({ type: 'resumePickerClose' });
       } else if (state.settingsPicker.open) {
@@ -4171,6 +4223,46 @@ export function App({
           return;
         }
         dispatch({ type: 'autonomyPickerClose' });
+        return;
+      }
+      return;
+    }
+
+    // Design Studio kit picker — arrows navigate, ←/→ cycle the target stack,
+    // Enter applies the kit by running `/design <id> <stack>` (pins + loads it).
+    if (state.designPicker.open) {
+      if (key.escape) {
+        dispatch({ type: 'designPickerClose' });
+        return;
+      }
+      if (key.mouse?.kind === 'wheel') {
+        dispatch({ type: 'designPickerMove', delta: key.mouse.wheel > 0 ? -1 : 1 });
+        return;
+      }
+      if (key.upArrow) {
+        dispatch({ type: 'designPickerMove', delta: -1 });
+        return;
+      }
+      if (key.downArrow) {
+        dispatch({ type: 'designPickerMove', delta: 1 });
+        return;
+      }
+      if (key.leftArrow || key.rightArrow) {
+        const stacks = ['web', 'react-native', 'flutter', 'swiftui', 'compose'];
+        const cur = stacks.indexOf(state.designPicker.stack);
+        const delta = key.rightArrow ? 1 : -1;
+        const next = stacks[(cur + delta + stacks.length) % stacks.length] ?? 'web';
+        dispatch({ type: 'designPickerStack', stack: next });
+        return;
+      }
+      if (isEnter) {
+        const now = Date.now();
+        if (now - lastEnterAtRef.current < 50) return;
+        lastEnterAtRef.current = now;
+        const kit = state.designPicker.kits[state.designPicker.selected];
+        const stack = state.designPicker.stack;
+        dispatch({ type: 'designPickerClose' });
+        if (kit) void submit(`/design ${kit.id} ${stack}`);
         return;
       }
       return;
@@ -6621,6 +6713,13 @@ export function App({
               hint={state.autonomyPicker.hint}
             />
           ) : null}
+          {state.designPicker.open ? (
+            <DesignPicker
+              kits={state.designPicker.kits}
+              selected={state.designPicker.selected}
+              stack={state.designPicker.stack}
+            />
+          ) : null}
           {state.resumePicker.open ? (
             <ResumePicker
               sessions={state.resumePicker.sessions}
@@ -7001,7 +7100,7 @@ export function App({
             const ctx: KeyHintContext = {
               monitor: anyMonitorOpen,
               managed: state.scrollOffset > 0,
-              picker: state.settingsPicker.open || state.modelPicker.open || state.autonomyPicker.open,
+              picker: state.settingsPicker.open || state.modelPicker.open || state.autonomyPicker.open || state.designPicker.open,
               nextPanelHint,
             };
             return <KeyHintBar context={ctx} />;

--- a/packages/tui/src/components/design-picker.tsx
+++ b/packages/tui/src/components/design-picker.tsx
@@ -1,0 +1,38 @@
+import type { DesignKitEntry } from '@wrongstack/core';
+import type React from 'react';
+import { Box, Text } from '../ink.js';
+
+export interface DesignPickerProps {
+  kits: DesignKitEntry[];
+  selected: number;
+  stack: string;
+}
+
+/**
+ * Design Studio kit picker overlay (opened by `/design`). Presentational only —
+ * navigation/selection state lives in the reducer; Enter runs `/design <id>
+ * <stack>` through the normal submit path, which pins the kit + loads its spec.
+ */
+export function DesignPicker({ kits, selected, stack }: DesignPickerProps): React.ReactElement {
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="magenta" paddingX={1}>
+      <Text color="magenta" bold>
+        ━━ Design Studio · pick a kit ━━
+      </Text>
+      <Text dimColor>↑/↓ navigate · ←/→ stack:{stack} · Enter apply · Esc cancel</Text>
+      {kits.length === 0 ? (
+        <Text dimColor>No design kits installed.</Text>
+      ) : (
+        kits.map((kit, i) => (
+          <Box key={kit.id} flexDirection="column">
+            <Text inverse={i === selected} {...(i === selected ? { color: 'cyan' } : {})}>
+              {i === selected ? '› ' : '  '}
+              <Text bold>{kit.id.padEnd(20)}</Text>
+              <Text dimColor>{kit.aesthetic}</Text>
+            </Text>
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/packages/webui/src/components/ActivityBar.tsx
+++ b/packages/webui/src/components/ActivityBar.tsx
@@ -31,6 +31,7 @@ import {
   Activity as ActivityIconSvg,
   Building2,
   Wand2,
+  Palette,
 } from 'lucide-react';
 import type { ReactElement } from 'react';
 import { useTheme } from './ThemeProvider';
@@ -89,6 +90,7 @@ const PANELS: PanelDef[] = [
   { id: 'projects', icon: <Folders size={16} />, label: 'Projects', shortcut: 'Ctrl+6' },
   { id: 'mailbox', icon: <Mail size={16} />, label: 'Mailbox', shortcut: 'Ctrl+7', pairedView: 'mailbox' },
   { id: 'skills', icon: <Sparkles size={16} />, label: 'Skills', shortcut: 'Ctrl+8', pairedView: 'skill' },
+  { id: 'design', icon: <Palette size={16} />, label: 'Design Studio', shortcut: 'Ctrl+0' },
   { id: 'officemap', icon: <Building2 size={16} />, label: 'Office Map', shortcut: 'Ctrl+9', pairedView: 'officemap' },
 ];
 

--- a/packages/webui/src/components/SidePanel/DesignStudioPanel.tsx
+++ b/packages/webui/src/components/SidePanel/DesignStudioPanel.tsx
@@ -1,0 +1,187 @@
+/**
+ * DesignStudioPanel — visual browser for curated UI design kits.
+ *
+ * Lists every bundled/project/user kit with light + dark token swatches and a
+ * "Use" button that pins the kit on the live agent (via the `design.use` WS
+ * message), so the model adheres to it on the next turn. Mirrors SkillsList's
+ * WS pattern (client.on / client.send / client.off).
+ */
+
+import { Check, Loader2, Palette } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useWebSocket } from '@/hooks/useWebSocket';
+import { cn } from '@/lib/utils';
+
+interface KitSummary {
+  id: string;
+  name: string;
+  aesthetic: string;
+  bestFor: string;
+  stacks: string[];
+  tags: string[];
+  light: Record<string, string>;
+  dark: Record<string, string>;
+}
+
+const STACKS = ['web', 'react-native', 'flutter', 'swiftui', 'compose'] as const;
+const SWATCH_KEYS = ['bg', 'surface', 'primary', 'accent', 'fg', 'border'];
+
+function Swatches({ tokens, label }: { tokens: Record<string, string>; label: string }) {
+  const keys = SWATCH_KEYS.filter((k) => tokens[k]);
+  if (keys.length === 0) return null;
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-[9px] uppercase tracking-wide text-muted-foreground w-7">{label}</span>
+      <div className="flex gap-0.5">
+        {keys.map((k) => (
+          <div
+            key={k}
+            className="w-4 h-4 rounded-sm border border-black/10 dark:border-white/10"
+            style={{ backgroundColor: tokens[k] }}
+            title={`${k}: ${tokens[k]}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DesignStudioPanel({ className }: { className?: string }) {
+  const { client } = useWebSocket();
+  const [kits, setKits] = useState<KitSummary[]>([]);
+  const [activeKit, setActiveKit] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [stack, setStack] = useState<string>('web');
+  const [busyKit, setBusyKit] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!client) return;
+    const onList = (msg: unknown) => {
+      const p = (msg as { payload?: { kits?: KitSummary[]; activeKit?: string | null } }).payload;
+      setKits(p?.kits ?? []);
+      setActiveKit(p?.activeKit ?? null);
+      setLoading(false);
+    };
+    const onUse = (msg: unknown) => {
+      const p = (msg as { payload?: { ok?: boolean; kit?: string } }).payload;
+      setBusyKit(null);
+      if (p?.ok && p.kit) setActiveKit(p.kit);
+    };
+    client.on('design.list', onList);
+    client.on('design.use', onUse);
+    client.send({ type: 'design.list' });
+    return () => {
+      client.off('design.list', onList);
+      client.off('design.use', onUse);
+    };
+  }, [client]);
+
+  const useKit = useCallback(
+    (id: string) => {
+      if (!client) return;
+      setBusyKit(id);
+      client.send({ type: 'design.use', payload: { kit: id, stack } });
+    },
+    [client, stack],
+  );
+
+  const sortedKits = useMemo(() => [...kits].sort((a, b) => a.name.localeCompare(b.name)), [kits]);
+
+  return (
+    <div className={cn('flex flex-col h-full', className)}>
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50">
+        <Palette className="w-4 h-4 text-muted-foreground" />
+        <span className="text-xs text-muted-foreground flex-1">
+          Pick a kit — the agent will adhere to it.
+        </span>
+        <select
+          value={stack}
+          onChange={(e) => setStack(e.target.value)}
+          className="text-[11px] bg-transparent border border-border/60 rounded px-1 py-0.5"
+          title="Target stack"
+        >
+          {STACKS.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-2 space-y-2">
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground p-3">
+            <Loader2 className="w-4 h-4 animate-spin" /> Loading kits…
+          </div>
+        )}
+        {!loading && sortedKits.length === 0 && (
+          <p className="text-sm text-muted-foreground p-3">No design kits found.</p>
+        )}
+        {sortedKits.map((kit) => {
+          const isActive = activeKit === kit.id;
+          return (
+            <div
+              key={kit.id}
+              className={cn(
+                'rounded-lg border p-3 transition-colors',
+                isActive
+                  ? 'border-primary/60 bg-primary/5'
+                  : 'border-border/60 hover:border-border',
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <h3 className="text-sm font-semibold truncate">{kit.name}</h3>
+                    {isActive && (
+                      <span className="inline-flex items-center gap-0.5 text-[9px] font-semibold uppercase text-primary">
+                        <Check className="w-3 h-3" /> Active
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-[11px] text-muted-foreground leading-snug mt-0.5">
+                    {kit.aesthetic}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => useKit(kit.id)}
+                  disabled={busyKit === kit.id}
+                  className={cn(
+                    'shrink-0 text-[11px] px-2 py-1 rounded font-medium',
+                    isActive
+                      ? 'bg-primary/10 text-primary'
+                      : 'bg-primary text-primary-foreground hover:opacity-90',
+                  )}
+                >
+                  {busyKit === kit.id ? '…' : isActive ? 'Reapply' : 'Use'}
+                </button>
+              </div>
+
+              <div className="mt-2 space-y-1">
+                <Swatches tokens={kit.light} label="Light" />
+                <Swatches tokens={kit.dark} label="Dark" />
+              </div>
+
+              {kit.bestFor && (
+                <p className="text-[10px] text-muted-foreground mt-2 leading-snug">
+                  <span className="font-medium">Best for:</span> {kit.bestFor}
+                </p>
+              )}
+              <div className="flex flex-wrap gap-1 mt-1.5">
+                {kit.stacks.map((s) => (
+                  <span
+                    key={s}
+                    className="text-[9px] px-1 py-0.5 rounded bg-muted text-muted-foreground"
+                  >
+                    {s}
+                  </span>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/webui/src/components/SidePanel/index.tsx
+++ b/packages/webui/src/components/SidePanel/index.tsx
@@ -26,6 +26,7 @@ import { ChangesPanel } from './ChangesPanel';
 import { HistoryPanel } from './HistoryPanel';
 import { SessionPanel } from './SessionPanel';
 import { SkillsList } from './SkillsList';
+import { DesignStudioPanel } from './DesignStudioPanel';
 import { OfficeMapSettingsPanel } from '../OfficeMapSettingsPanel';
 
 const PANEL_TITLE: Record<Activity, string> = {
@@ -37,6 +38,7 @@ const PANEL_TITLE: Record<Activity, string> = {
   projects: 'Projects',
   mailbox: 'Mailbox',
   skills: 'Skills',
+  design: 'Design Studio',
   officemap: 'Office Map',
 };
 
@@ -129,6 +131,11 @@ export function SidePanel() {
         {activeActivity === 'skills' && (
           <div className="flex-1 overflow-hidden">
             <SkillsList className="h-full" />
+          </div>
+        )}
+        {activeActivity === 'design' && (
+          <div className="flex-1 overflow-hidden">
+            <DesignStudioPanel className="h-full" />
           </div>
         )}
         {activeActivity === 'officemap' && (

--- a/packages/webui/src/server/design-handlers.ts
+++ b/packages/webui/src/server/design-handlers.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared Design Studio WebSocket handlers for both the standalone WebUI server
+ * (`packages/webui/src/server/index.ts`) and the CLI's `--webui` embedded
+ * server (`packages/cli/src/webui-server.ts`). One source of truth keeps the two
+ * servers at parity (enforced by ws-handler-parity.test.ts).
+ *
+ *   case 'design.list':  return handleDesignList(ws, designCtx);
+ *   case 'design.use':   return handleDesignUse(ws, designCtx, msg);
+ *   case 'design.state': return handleDesignState(ws, designCtx);
+ *
+ * Read-only browsing of curated UI design kits; `design.use` pins the active
+ * kit on the live agent context (so the per-turn injector switches to the
+ * adherence reminder) and returns the loaded spec + tokens for preview.
+ */
+
+import type { DesignStack } from '@wrongstack/core';
+import {
+  getDesignKitLoader,
+  getDesignState,
+  isDesignStack,
+  recordKitChoice,
+  setActiveKit,
+} from '@wrongstack/core';
+import type { WebSocket } from 'ws';
+import { send } from './ws-utils.js';
+
+export interface DesignContext {
+  projectRoot: string;
+  /** Live agent context whose `meta.designStudio` we read/pin. Optional. */
+  agentMeta?: { meta: Record<string, unknown> } | undefined;
+}
+
+const FOUNDATIONS_ID = '_foundations';
+
+async function buildListPayload(ctx: DesignContext): Promise<{
+  kits: Array<{
+    id: string;
+    name: string;
+    aesthetic: string;
+    bestFor: string;
+    stacks: string[];
+    tags: string[];
+    light: Record<string, string>;
+    dark: Record<string, string>;
+  }>;
+  activeKit: string | null;
+  stack: string | null;
+}> {
+  const loader = getDesignKitLoader(ctx.projectRoot);
+  const manifests = (await loader.list()).filter((k) => k.id !== FOUNDATIONS_ID);
+  const kits = [];
+  for (const m of manifests) {
+    const tokens = await loader.readTokens(m.id);
+    kits.push({
+      id: m.id,
+      name: m.name,
+      aesthetic: m.aesthetic,
+      bestFor: m.bestFor,
+      stacks: m.stacks,
+      tags: m.tags,
+      light: tokens?.light ?? {},
+      dark: tokens?.dark ?? {},
+    });
+  }
+  const state = ctx.agentMeta ? getDesignState(ctx.agentMeta) : undefined;
+  return { kits, activeKit: state?.activeKit ?? null, stack: state?.stack ?? null };
+}
+
+export async function handleDesignList(ws: WebSocket, ctx: DesignContext): Promise<void> {
+  try {
+    send(ws, { type: 'design.list', payload: await buildListPayload(ctx) });
+  } catch (err) {
+    send(ws, {
+      type: 'design.list',
+      payload: { kits: [], activeKit: null, stack: null, error: String(err) },
+    });
+  }
+}
+
+export async function handleDesignState(ws: WebSocket, ctx: DesignContext): Promise<void> {
+  const state = ctx.agentMeta ? getDesignState(ctx.agentMeta) : undefined;
+  send(ws, {
+    type: 'design.state',
+    payload: { activeKit: state?.activeKit ?? null, stack: state?.stack ?? null },
+  });
+}
+
+export async function handleDesignUse(
+  ws: WebSocket,
+  ctx: DesignContext,
+  msg: { payload?: unknown },
+): Promise<void> {
+  const payload = (msg.payload ?? {}) as { kit?: unknown; stack?: unknown };
+  const kitId = typeof payload.kit === 'string' ? payload.kit.trim() : '';
+  if (!kitId) {
+    send(ws, { type: 'design.use', payload: { ok: false, error: 'No kit id provided' } });
+    return;
+  }
+  try {
+    const loader = getDesignKitLoader(ctx.projectRoot);
+    const kit = await loader.find(kitId);
+    if (!kit) {
+      send(ws, { type: 'design.use', payload: { ok: false, kit: kitId, error: 'Kit not found' } });
+      return;
+    }
+    const stackArg = typeof payload.stack === 'string' ? payload.stack : undefined;
+    const stack: DesignStack =
+      stackArg && isDesignStack(stackArg) ? stackArg : (kit.stacks[0] ?? 'web');
+    if (ctx.agentMeta) setActiveKit(ctx.agentMeta, kit.id, stack);
+    await recordKitChoice(ctx.projectRoot, kit.id, stack, 'webui', new Date().toISOString());
+    const body = await loader.readBody(kit.id, stack);
+    const tokens = await loader.readTokens(kit.id);
+    send(ws, {
+      type: 'design.use',
+      payload: {
+        ok: true,
+        kit: kit.id,
+        name: kit.name,
+        aesthetic: kit.aesthetic,
+        stack,
+        body,
+        light: tokens?.light ?? {},
+        dark: tokens?.dark ?? {},
+      },
+    });
+  } catch (err) {
+    send(ws, { type: 'design.use', payload: { ok: false, kit: kitId, error: String(err) } });
+  }
+}

--- a/packages/webui/src/server/index.ts
+++ b/packages/webui/src/server/index.ts
@@ -67,6 +67,11 @@ import {
   handleSkillsExport,
 } from './skills-handlers.js';
 import {
+  handleDesignList,
+  handleDesignUse,
+  handleDesignState,
+} from './design-handlers.js';
+import {
   Agent,
   AutoCompactionMiddleware,
   Context,
@@ -91,6 +96,7 @@ import {
   ToolRegistry,
   atomicWrite,
   createDefaultPipelines,
+  installDesignStudioMiddleware,
   createSessionEventBridge,
   resolveSessionLoggingConfig,
   DEFAULT_CONTEXT_WINDOW_MODE_ID,
@@ -338,6 +344,13 @@ export {
   handleSkillsEdit,
   handleSkillsExport,
 } from './skills-handlers.js';
+// Design Studio handlers — shared so the CLI's embedded server reaches parity.
+export {
+  type DesignContext,
+  handleDesignList,
+  handleDesignUse,
+  handleDesignState,
+} from './design-handlers.js';
 
 // Message + client shapes now live in ./types.ts (shared with the CLI's
 // embedded server). Imported here for internal use; re-exported above for
@@ -1100,6 +1113,9 @@ export async function startWebUI(
   const collabInject = collabInjectMiddleware(collabBus, { logger });
   Object.defineProperty(collabInject, 'name', { value: 'collab-inject' });
   pipelines.toolCall.prepend(collabInject as never);
+  // Design Studio — per-turn UI-intent detection + kit-menu injection, so the
+  // WebUI host gets the same auto-trigger behavior as the CLI/TUI.
+  installDesignStudioMiddleware({ pipelines, ctx: context });
   const codebaseIndexing = setupWebUICodebaseIndexing({
     config,
     context,
@@ -2058,6 +2074,18 @@ export async function startWebUI(
         break;
       case 'skills.export':
         await handleSkillsExport(ws, { skillLoader, skillInstaller, projectRoot });
+        break;
+
+      // Design Studio — shared handlers (design-handlers.ts). agentMeta is the
+      // live context so design.use pins the active kit for the next turn.
+      case 'design.list':
+        await handleDesignList(ws, { projectRoot, agentMeta: context });
+        break;
+      case 'design.use':
+        await handleDesignUse(ws, { projectRoot, agentMeta: context }, msg);
+        break;
+      case 'design.state':
+        await handleDesignState(ws, { projectRoot, agentMeta: context });
         break;
 
       case 'diag.get': {

--- a/packages/webui/src/stores/ui-store.ts
+++ b/packages/webui/src/stores/ui-store.ts
@@ -9,7 +9,7 @@ import type { MailboxMessage } from './mailbox-store';
 // Activity types shown in the ActivityBar (secondary panel content).
 // One icon = one full panel. 'context' and 'sessions' were folded into
 // 'chat' and 'history' — coerceActivity maps persisted legacy values.
-export type Activity = 'chat' | 'agents' | 'history' | 'files' | 'changes' | 'projects' | 'mailbox' | 'skills' | 'officemap';
+export type Activity = 'chat' | 'agents' | 'history' | 'files' | 'changes' | 'projects' | 'mailbox' | 'skills' | 'design' | 'officemap';
 
 const ACTIVITIES: readonly Activity[] = ['chat', 'agents', 'history', 'files', 'changes', 'projects', 'mailbox', 'skills', 'officemap'];
 

--- a/packages/webui/src/types.ts
+++ b/packages/webui/src/types.ts
@@ -443,6 +443,50 @@ export interface WSSkillContent {
   };
 }
 
+export interface WSDesignKitSummary {
+  id: string;
+  name: string;
+  aesthetic: string;
+  bestFor: string;
+  stacks: string[];
+  tags: string[];
+  light: Record<string, string>;
+  dark: Record<string, string>;
+}
+
+export interface WSDesignList {
+  type: 'design.list';
+  payload: {
+    kits: WSDesignKitSummary[];
+    activeKit: string | null;
+    stack: string | null;
+    error?: string | undefined;
+  };
+}
+
+export interface WSDesignUse {
+  type: 'design.use';
+  payload: {
+    ok: boolean;
+    kit?: string | undefined;
+    name?: string | undefined;
+    aesthetic?: string | undefined;
+    stack?: string | undefined;
+    body?: string | undefined;
+    light?: Record<string, string> | undefined;
+    dark?: Record<string, string> | undefined;
+    error?: string | undefined;
+  };
+}
+
+export interface WSDesignState {
+  type: 'design.state';
+  payload: {
+    activeKit: string | null;
+    stack: string | null;
+  };
+}
+
 export interface WSSkillsInstalled {
   type: 'skills.installed';
   payload: {
@@ -1034,6 +1078,10 @@ export type WSClientMessage =
   | { type: 'skills.create'; payload: { name: string; description: string; scope: 'project' | 'global' } }
   | { type: 'skills.export'; payload?: Record<string, unknown> }
   | { type: 'skills.edit'; payload: { name: string; body: string } }
+  // ── Design Studio client messages ────────────────────────────────────────────
+  | { type: 'design.list' }
+  | { type: 'design.use'; payload: { kit: string; stack?: string | undefined } }
+  | { type: 'design.state' }
   // ── MCP client messages (requests to server) ─────────────────────────────────
   | { type: 'mcp.list' }
   | { type: 'mcp.add'; payload: { name: string; transport: string; description?: string; enabled?: boolean; command?: string; args?: string[]; env?: Record<string, string>; allowedTools?: string[] } }
@@ -1092,6 +1140,9 @@ export type WSServerMessage =
   | WSMemoryList
   | WSSkillsList
   | WSSkillContent
+  | WSDesignList
+  | WSDesignUse
+  | WSDesignState
   | WSSkillsInstalled
   | WSSkillsUninstalled
   | WSSkillsUpdated


### PR DESCRIPTION
## Summary

Adds a thin loopback HTTP façade over the project-level `GlobalMailbox` so external coding agents (Claude Code, Aider, custom scripts) can read and send messages on the same channel that WrongStack-internal agents use — without implementing the file-lock protocol.

```
wstack mailbox serve             # binds 127.0.0.1:7788 by default
wstack mailbox serve --port 9000 --strict-port
```

## Routes (all require `Authorization: Bearer <token>`)

| Method | Path | Wraps |
|--------|------|-------|
| POST | `/mailbox/send` | `GlobalMailbox.send` |
| POST | `/mailbox/query` | `GlobalMailbox.query` |
| POST | `/mailbox/ack` | `GlobalMailbox.ack` |
| POST | `/mailbox/ack-many` | `GlobalMailbox.ackMany` |
| POST | `/mailbox/unread-count` | `GlobalMailbox.unreadCount` |
| POST | `/mailbox/agents/register` | `GlobalMailbox.registerAgent` (`source='http'`) |
| POST | `/mailbox/agents/heartbeat` | `GlobalMailbox.heartbeat` |
| POST | `/mailbox/register-client` | `GlobalMailbox.registerClient` (`source='http'`) |
| POST | `/mailbox/heartbeat` | `GlobalMailbox.clientHeartbeat` |
| GET | `/mailbox/agents` | `GlobalMailbox.getAgentStatuses` |
| GET | `/mailbox/agents/online` | `GlobalMailbox.getOnlineAgents` |
| GET | `/healthz` | liveness probe (no auth) |

## Security

- 32-byte random bearer token written to `~/.wrongstack/projects/<slug>/.mailbox.token` (mode 0600), rotated on every server start, unlinked on SIGINT/SIGTERM.
- Constant-time comparison via `timingSafeEqual`.
- Default bind is loopback only. `--host` exposes beyond loopback — caller is responsible for network-layer protection.
- Body cap: 256 KB.
- No body logging at the server; structured `mailbox_serve_started` / `mailbox_serve_stopping` events for log-shippers, never include the token.

## Source-enum widening

Added `'http'` to `RegisteredAgent.source`, `MailboxAgentStatus.source`, `AgentRegistrationInput.source`, `ClientSource`, and `HqMailboxAgentSummary.source` so external agents appear in the WebUI online-agents panel with the correct source label, indistinguishable in capability from WrongStack-internal agents.

## Files

- `packages/cli/src/subcommands/handlers/mailbox-serve.ts` (new, 573 LOC)
- `packages/cli/src/subcommands/index.ts` — wires `mailboxServeCmd`
- `packages/core/src/coordination/mailbox-types.ts` — source union widening
- `packages/core/src/coordination/index.ts` — exports extended for client/heartbeat types
- `packages/core/src/hq/protocol.ts` — `HqMailboxAgentSummary.source` widening

## Skill files (not in PR)

Skill files (`.wrongstack/skills/mailbox-bridge/SKILL.md` and `.wrongstack/skills/wrongstack-mailbox/SKILL.md`) are gitignored per project convention (skills live in the local working tree, not in version control). They are written locally when the user installs or upgrades skills.

## Design rationale

The mailbox is **internal to WrongStack** — not an email server. This PR does NOT introduce a parallel store. All external calls go through `GlobalMailbox` so file locking, mtime-cached reads, agent heartbeats, read receipts, and HQ telemetry work exactly as they do for WrongStack-internal callers. External agents are first-class participants in the project's shared coordination channel.

## Verification

- `typecheck` core + cli: 0 errors, 0 warnings.
- `lint` (Biome) on all touched files: clean.
- `pnpm -F @wrongstack/core build` and `pnpm -F @wrongstack/cli build`: success.
- Bundled `cli/dist/index.js` contains the full server code (all 12 routes, validators, `mailbox_serve_started` event, `/healthz` probe).
- `curl http://127.0.0.1:17788/healthz` returns `{"ok":true}` without auth; protected routes return `401 UNAUTHORIZED` without a valid bearer.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>