### PR TITLE
[codex] fix ACP registry auth handshake

### DIFF
--- a/apps/wrongstack/package.json
+++ b/apps/wrongstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wrongstack",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack — terminal AI coding agent. Installs `wrongstack` and `wstack` binaries (re-export of @wrongstack/cli).",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wrongstack-monorepo",
   "private": true,
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed",

--- a/packages/acp/package.json
+++ b/packages/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/acp",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "ACP (Agent Client Protocol) integration for WrongStack — client + agent support",
   "keywords": [

--- a/packages/acp/src/agent/protocol-handler.ts
+++ b/packages/acp/src/agent/protocol-handler.ts
@@ -55,7 +55,16 @@ function toWire(msg: WireMessage): ACPMessage {
   return msg as never as ACPMessage;
 }
 
-export const WRONGSTACK_VERSION = '0.263.0';
+export const WRONGSTACK_VERSION = '0.274.1';
+const WRONGSTACK_AUTH_METHODS = [
+  {
+    id: 'wrongstack-auth',
+    name: 'Run wstack auth',
+    description: 'Configure a WrongStack model provider in an interactive terminal.',
+    type: 'terminal',
+    args: ['auth'],
+  },
+];
 
 /** What kinds of content the agent accepts in a prompt. */
 export interface PromptCapabilities {
@@ -292,7 +301,7 @@ export class ACPProtocolHandler {
         // Static options advertised at handshake. They are also
         // re-sent on every `current_mode_update` / `config_option_update`
         // notification so late-joining clients see them.
-        authMethods: [],
+        authMethods: WRONGSTACK_AUTH_METHODS,
         modes: this.modes,
         configOptions: this.configOptions,
       },

--- a/packages/acp/src/agent/stdio-transport.ts
+++ b/packages/acp/src/agent/stdio-transport.ts
@@ -5,8 +5,8 @@
  *   client → agent:  JSON-RPC request/notification on stdin
  *   agent  → client: JSON-RPC response/notification on stdout
  *
- * Start message: clients look for the `[wstack-acp]` marker on stdout before
- * treating subsequent lines as protocol messages.
+ * Legacy startup marker support remains for older internal harnesses, but
+ * standard ACP agents must not write non-JSON data to stdout.
  */
 import { expectDefined, writeErr } from '@wrongstack/core';
 import type { ACPMessage } from '../types/acp-messages.js';

--- a/packages/acp/src/agent/wrongstack-acp-agent.ts
+++ b/packages/acp/src/agent/wrongstack-acp-agent.ts
@@ -20,10 +20,9 @@
  * a real core `Agent` (with the right provider, model, system prompt,
  * etc.) per session.
  *
- * Startup: prints the legacy `[wstack-acp]\n` marker (kept for backward
- * compatibility with the old `StdioTransport` handshake) so the client
- * knows the protocol boundary. v1 initialize is then sent by the client
- * and answered by `ACPProtocolHandler`.
+ * Startup: ACP v1 is newline-delimited JSON-RPC on stdout. The server
+ * therefore writes no non-JSON stdout by default. A legacy startup marker
+ * remains available for older internal harnesses via `legacyStartupMarker`.
  */
 import { fileURLToPath } from 'node:url';
 import { writeErr } from '@wrongstack/core';
@@ -47,11 +46,14 @@ export interface WrongStackACPServerOptions {
   defaultCwd?: string | undefined;
   /** Agent name advertised in initialize. */
   agentName?: string | undefined;
+  /** Emit the old non-standard startup marker. Defaults to false. */
+  legacyStartupMarker?: boolean | undefined;
 }
 
 export class WrongStackACPServer {
   private readonly transport: StdioTransport;
   private readonly handler: ACPProtocolHandler;
+  private readonly legacyStartupMarker: boolean;
   private running = false;
 
   constructor(opts: WrongStackACPServerOptions = {}) {
@@ -63,17 +65,18 @@ export class WrongStackACPServer {
       runTurn,
       agentName: opts.agentName,
     });
+    this.legacyStartupMarker = opts.legacyStartupMarker === true;
   }
 
   /**
    * Start the server. Blocks until the client disconnects.
    *
-   * 1. Print the legacy `[wstack-acp]\n` marker so the client knows the
-   *    process is the ACP server (the old `StdioTransport` handshake).
-   * 2. Loop: read messages, dispatch to the handler, until EOF / error.
+   * Loop: read JSON-RPC messages, dispatch to the handler, until EOF / error.
    */
   async start(): Promise<void> {
-    this.transport.sendStartupMarker();
+    if (this.legacyStartupMarker) {
+      this.transport.sendStartupMarker();
+    }
     this.running = true;
     while (this.running) {
       const msg = await this.transport.read();

--- a/packages/acp/tests/protocol-handler.test.ts
+++ b/packages/acp/tests/protocol-handler.test.ts
@@ -76,6 +76,14 @@ describe('ACPProtocolHandler', () => {
           loadSession: true,
           promptCapabilities: { image: false, audio: false, embeddedContext: true },
         },
+        authMethods: [
+          {
+            id: 'wrongstack-auth',
+            name: 'Run wstack auth',
+            type: 'terminal',
+            args: ['auth'],
+          },
+        ],
       });
     });
 

--- a/packages/acp/tests/wrongstack-acp-agent.test.ts
+++ b/packages/acp/tests/wrongstack-acp-agent.test.ts
@@ -60,7 +60,7 @@ describe('WrongStackACPServer', () => {
     expect(() => new WrongStackACPServer({ agentName: 'acme' })).not.toThrow();
   });
 
-  it('start sends the marker, dispatches messages, and stops at EOF', async () => {
+  it('start dispatches messages and stops at EOF without non-JSON stdout by default', async () => {
     const server = new WrongStackACPServer();
     const t = lastTransport();
     const handler = lastHandler();
@@ -71,9 +71,19 @@ describe('WrongStackACPServer', () => {
 
     await server.start();
 
-    expect(t.sendStartupMarker).toHaveBeenCalledTimes(1);
+    expect(t.sendStartupMarker).not.toHaveBeenCalled();
     expect(handler.handleMessage).toHaveBeenCalledTimes(2);
     expect(t.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('can emit the legacy startup marker when explicitly requested', async () => {
+    const server = new WrongStackACPServer({ legacyStartupMarker: true });
+    const t = lastTransport();
+    t.read.mockResolvedValueOnce(null);
+
+    await server.start();
+
+    expect(t.sendStartupMarker).toHaveBeenCalledTimes(1);
   });
 
   it('start stops when the handler reports a terminal message', async () => {

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/bench",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "Model-independent agentic benchmark harness for WrongStack (Aider polyglot + SWE-bench Verified) with deterministic graders and harness fingerprinting.",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/cli",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack CLI — terminal AI coding agent with provider catalog from models.dev. Provides `wrongstack` and `wstack` binaries.",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/core",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack core: kernel, types, defaults, and shared utilities for the WrongStack CLI agent.",
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/mcp",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack Model Context Protocol client and registry: stdio, SSE, and streamable HTTP transports.",
   "repository": {

--- a/packages/plug-lsp/package.json
+++ b/packages/plug-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/plug-lsp",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack plugin that exposes Language Server Protocol tools.",
   "repository": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/plugins",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "description": "Official WrongStack plugin collection — auto-doc, git-autocommit, shell-check, cost-tracker, file-watcher, web-search, json-path, cron, template-engine, semver-bump",
   "license": "MIT",
   "author": "ECOSTACK TECHNOLOGY OÜ",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/providers",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack LLM provider adapters (Anthropic, OpenAI, Google) built on declarative WireFormatConfig.",
   "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/runtime",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack default runtime implementations and host-level composition helpers built on @wrongstack/core.",
   "repository": {

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/skills",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/telegram",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack plugin — Telegram bridge: send messages, receive prompts, get notified.",
   "repository": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/tools",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack built-in tools: read/write/edit, bash/exec, grep/glob, git, fetch, test, lint, and more.",
   "repository": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/tui",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "WrongStack terminal UI: Ink-based interactive renderer with history, pickers, and slash menus.",
   "repository": {

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/webui",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "license": "MIT",
   "description": "Browser-based WebUI for WrongStack — React + Vite frontend with WebSocket backend that drives the same agent kernel as the CLI/TUI.",
   "keywords": [

--- a/scripts/acp-smoke-test.mts
+++ b/scripts/acp-smoke-test.mts
@@ -5,14 +5,13 @@
 //
 // What this test does:
 //  1. spawn the server as a child process
-//  2. read the [wstack-acp]\n startup marker
-//  3. send initialize, assert protocolVersion=1 + agentCapabilities
-//  4. send session/new, assert sessionId is returned
-//  5. send session/prompt, collect any session/update notifications
+//  2. send initialize, assert protocolVersion=1 + agentCapabilities
+//  3. send session/new, assert sessionId is returned
+//  4. send session/prompt, collect any session/update notifications
 //     and assert the stopReason
-//  6. send session/cancel notification
-//  7. send exit notification
-//  8. close stdin, expect the process to exit cleanly
+//  5. send session/cancel notification
+//  6. send exit notification
+//  7. close stdin, expect the process to exit cleanly
 //
 // Run: node scripts/acp-smoke-test.mts (from repo root)
 //
@@ -28,6 +27,10 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const serverEntry = join(__dirname, '..', 'packages', 'acp', 'dist', 'wrongstack-acp-agent.js');
 
+function writeError(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
 let child;
 try {
   child = spawn(process.execPath, [serverEntry], {
@@ -35,31 +38,18 @@ try {
     windowsHide: true,
   });
 } catch (err) {
-  console.error('Failed to spawn server:', err);
+  writeError(`Failed to spawn server: ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);
 }
 
 let nextId = 1;
 const inflight = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
 const notifications: unknown[] = [];
-let initDone = false;
 
 let lineBuffer = '';
 child.stdout.setEncoding('utf8');
 child.stdout.on('data', (chunk: string) => {
-  // First chunk is the [wstack-acp]\n marker. Consume it.
-  if (!initDone) {
-    if (chunk.includes('[wstack-acp]\n')) {
-      initDone = true;
-      // Strip the marker and any prefix content, keep the rest
-      const after = chunk.split('[wstack-acp]\n')[1] ?? '';
-      lineBuffer += after;
-    } else {
-      lineBuffer += chunk;
-    }
-  } else {
-    lineBuffer += chunk;
-  }
+  lineBuffer += chunk;
   // Process complete JSON-RPC lines.
   let nlIdx = lineBuffer.indexOf('\n');
   while (nlIdx !== -1) {
@@ -71,7 +61,8 @@ child.stdout.on('data', (chunk: string) => {
       const msg = JSON.parse(line);
       handleMessage(msg);
     } catch (err) {
-      console.error('Non-JSON line from server:', line, err);
+      const detail = err instanceof Error ? err.message : String(err);
+      writeError(`Non-JSON line from server: ${line} ${detail}`);
     }
   }
 });
@@ -112,7 +103,7 @@ function sendNotification(method: string, params: unknown): void {
 
 function assert(cond: unknown, msg: string): void {
   if (!cond) {
-    console.error('FAIL:', msg);
+    writeError(`FAIL: ${msg}`);
     child.kill();
     process.exit(1);
   }
@@ -182,7 +173,7 @@ async function main(): Promise<void> {
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
-      console.error('TIMEOUT: server did not exit within 5s');
+      writeError('TIMEOUT: server did not exit within 5s');
       child.kill();
       process.exit(1);
     }, 5000);
@@ -193,7 +184,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error('Smoke test error:', err);
+  writeError(`Smoke test error: ${err instanceof Error ? err.message : String(err)}`);
   child.kill();
   process.exit(1);
 });

--- a/website/index.html
+++ b/website/index.html
@@ -39,7 +39,7 @@
         "operatingSystem": "macOS, Linux, Windows",
         "description": "A CLI AI coding agent for the terminal — autonomous goal loops, multi-agent fleet (47 roles), 37 built-in tools, 17 bundled skills, 55 slash commands, ~110 providers, AES-256-GCM encrypted secrets. 15-package pnpm monorepo with lockstep versioning.",
         "url": "https://wrongstack.com",
-        "softwareVersion": "0.274.0",
+        "softwareVersion": "0.274.1",
         "dateModified": "2026-06-09",
         "license": "https://opensource.org/licenses/MIT",
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wrongstack-website",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wrongstack-website",
-      "version": "0.274.0",
+      "version": "0.274.1",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.13",
         "@radix-ui/react-dialog": "^1.1.16",

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wrongstack-website",
   "private": true,
-  "version": "0.274.0",
+  "version": "0.274.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/website/src/lib/utils.ts
+++ b/website/src/lib/utils.ts
@@ -11,7 +11,7 @@ export function cn(...inputs: ClassValue[]) {
    ========================================================================= */
 
 export const META = {
-  version: '0.274.0',
+  version: '0.274.1',
   repo: 'https://github.com/WrongStack/WrongStack',
   npm: 'wrongstack',
   node: '22',


### PR DESCRIPTION
## Summary

Adds an ACP `authMethods` declaration to the WrongStack ACP initialize response so the agent can satisfy the ACP Registry authentication gate.

The registry currently requires at least one auth method with `type: "agent"` or `type: "terminal"`. WrongStack already has an interactive terminal auth flow via `wstack auth`, so the ACP server now advertises that setup path.

This also bumps the monorepo/package version to `0.274.1` and updates the advertised ACP agent version to match, because `wrongstack@0.274.0` is already published with the old `authMethods: []` handshake.

Finally, the ACP server no longer writes the legacy `[wstack-acp]` startup marker by default. ACP Registry's validator reads the first stdout line as JSON-RPC and fails on non-JSON stdout, so default `wstack acp` output must be pure ACP JSON-RPC. The marker remains available only through an explicit `legacyStartupMarker` option for old internal harnesses.

## Why

`agentclientprotocol/registry` verifies published agents by launching their package and checking the ACP initialize response. The currently published `wrongstack@0.274.0` responds with `authMethods: []`, so a registry submission would fail auth validation until this fix is released as a new npm version.

The registry verifier also treats any non-JSON stdout line as an ACP spec violation. Removing the default startup marker keeps `wstack acp` compatible with strict ACP clients.

## Validation

- `pnpm -r build`
- `pnpm --filter @wrongstack/acp test`
- `pnpm --filter @wrongstack/acp smoke`
- `pnpm release:dry`
- raw server stdout check: `node packages/acp/dist/wrongstack-acp-agent.js` returns JSON-RPC as the first stdout line
- raw CLI stdout check: `node apps/wrongstack/src/index.js acp` returns JSON-RPC on stdout, with human diagnostics on stderr
- pre-commit hook: changed-package build + workspace typecheck, staged-file guard, staged-file console lint

Smoke initialize now includes:

```json
"agentInfo": { "name": "wrongstack", "title": "WrongStack", "version": "0.274.1" },
"authMethods": [
  {
    "id": "wrongstack-auth",
    "name": "Run wstack auth",
    "type": "terminal",
    "args": ["auth"]
  }
]
```

## Follow-up

After this lands and `wrongstack@0.274.1` is published to npm, submit the prepared `wrongstack` entry to `agentclientprotocol/registry` using `wrongstack@0.274.1`.
