### PR TITLE
fix(tools): guard POSIX process-group kills

### DIFF
--- a/packages/tools/src/bash.ts
+++ b/packages/tools/src/bash.ts
@@ -302,6 +302,7 @@ export const bashTool: Tool<BashInput, BashOutput> = {
           startedAt: Date.now(),
           sessionId: ctx.session?.id,
           child,
+          processGroupLeader: detached && child.pid === pid,
         });
         // Register the close handler on the same tick as spawn() so the
         // handler is guaranteed to be in place before Node's event loop
@@ -396,6 +397,7 @@ export const bashTool: Tool<BashInput, BashOutput> = {
         startedAt: Date.now(),
         sessionId: ctx.session?.id,
         child,
+        processGroupLeader: detached && child.pid === pid,
       });
     }
 
@@ -431,29 +433,24 @@ export const bashTool: Tool<BashInput, BashOutput> = {
         return;
       }
 
-      // Best-effort SIGTERM: try process-group kill first, fall back to child.kill.
-      try {
-        if (typeof child.pid === 'number') {
-          try { process.kill(-child.pid, 'SIGTERM'); }
-          catch { child.kill('SIGTERM'); }
-        } else {
-          child.kill('SIGTERM');
-        }
-      } catch { /* ignore */ }
-
-      // After timeoutMs, assert-kill with SIGKILL.
-      const killTimer = setTimeout(() => {
+      if (typeof child.pid === 'number') {
+        registry.kill(child.pid, { graceMs: timeoutMs });
+      } else {
         try {
-          if (typeof child.pid === 'number') {
-            try { process.kill(-child.pid, 'SIGKILL'); }
-            catch { child.kill('SIGKILL'); }
-          } else {
+          child.kill('SIGTERM');
+        } catch {
+          /* ignore */
+        }
+        const killTimer = setTimeout(() => {
+          try {
             child.kill('SIGKILL');
+          } catch {
+            /* ignore */
           }
-        } catch { /* ignore */ }
-      }, timeoutMs);
-      timers.push(killTimer);
-      killTimer.unref?.();
+        }, timeoutMs);
+        timers.push(killTimer);
+        killTimer.unref?.();
+      }
     }
 
     const timer = setTimeout(() => {

--- a/packages/tools/src/process-registry.ts
+++ b/packages/tools/src/process-registry.ts
@@ -29,6 +29,11 @@ export interface TrackedProcess {
    *  use `kill()` below which handles process groups correctly on POSIX
    *  and degrades gracefully on Windows. */
   child: ChildProcess;
+  /** True only when this child was spawned as a POSIX process-group/session
+   *  leader (for example `spawn(..., { detached: true })`) and `pid` is the
+   *  actual `child.pid`. Negative-PID signaling is host-wide dangerous for
+   *  values like -1, so tests and manually registered entries must not opt in. */
+  processGroupLeader?: boolean | undefined;
   /** True once the process has been kill()ed but not yet exited.
    *  We keep it in the registry until 'close' fires so callers can
    *  distinguish "still running" from "just exited". */
@@ -164,6 +169,41 @@ export class ProcessRegistryImpl {
 
   register(info: Omit<TrackedProcess, 'killed' | 'protected'> & { protected?: boolean | undefined }): void {
     this.processes.set(info.pid, { ...info, killed: false, protected: info.protected ?? false });
+  }
+
+  private _isSafeSignalPid(pid: number): boolean {
+    return Number.isInteger(pid) && pid > 1 && pid !== process.pid && pid !== process.ppid;
+  }
+
+  private _canSignalProcessGroup(p: TrackedProcess): boolean {
+    return (
+      os.platform() !== 'win32' &&
+      p.processGroupLeader === true &&
+      this._isSafeSignalPid(p.pid) &&
+      typeof p.child.pid === 'number' &&
+      p.child.pid === p.pid
+    );
+  }
+
+  private _killChildDirect(p: TrackedProcess, signal: NodeJS.Signals): void {
+    try {
+      p.child.kill(signal);
+    } catch {
+      // Process may have already exited, or this may be a persistent entry
+      // without a live ChildProcess handle in the current process.
+    }
+  }
+
+  private _killPosix(p: TrackedProcess, signal: NodeJS.Signals): void {
+    if (this._canSignalProcessGroup(p)) {
+      try {
+        process.kill(-p.pid, signal);
+        return;
+      } catch {
+        // Process group may already be gone; fall back to the direct child.
+      }
+    }
+    this._killChildDirect(p, signal);
   }
 
   /** Unregister a process by PID. Called on 'close' / 'exit' events. */
@@ -405,33 +445,19 @@ export class ProcessRegistryImpl {
       return true;
     }
 
-    // POSIX: kill the process group so grandchildren are cleaned up too.
+    // POSIX: kill the process group only when the tracked child is proven to
+    // be the group leader. Otherwise use child.kill(); negative PID signaling
+    // with untrusted/fake PIDs can target unrelated host processes.
     try {
       if (force) {
-        try {
-          process.kill(-pid, 'SIGKILL');
-        } catch {
-          p.child.kill('SIGKILL');
-        }
+        this._killPosix(p, 'SIGKILL');
       } else {
-        try {
-          process.kill(-pid, 'SIGTERM');
-        } catch {
-          p.child.kill('SIGTERM');
-        }
+        this._killPosix(p, 'SIGTERM');
         // Schedule SIGKILL as backup.
         const timer = setTimeout(() => {
           // Re-check: process may have exited on its own.
           if (this.processes.has(pid) && !p.child.killed) {
-            try {
-              process.kill(-pid, 'SIGKILL');
-            } catch {
-              try {
-                p.child.kill('SIGKILL');
-              } catch {
-                /* already gone */
-              }
-            }
+            this._killPosix(p, 'SIGKILL');
           }
         }, graceMs);
         timer.unref?.(); // Don't keep event loop alive.

--- a/packages/tools/tests/posix-signal-safety.test.ts
+++ b/packages/tools/tests/posix-signal-safety.test.ts
@@ -1,0 +1,56 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const self = rel(__filename);
+const allowedNegativeKillTests = new Set(['packages/tools/tests/spawn-background.test.ts']);
+const negativeProcessKillPattern = new RegExp('process\\.kill\\s*\\(\\s*-');
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.isFile() && entry.name.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+function rel(file: string): string {
+  return path.relative(repoRoot, file).replaceAll(path.sep, '/');
+}
+
+function withoutLineComments(text: string): string {
+  return text
+    .split(/\r?\n/)
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+}
+
+describe('POSIX signal safety in tests', () => {
+  it('does not add unguarded negative-PID process.kill calls to tests', () => {
+    const offenders: string[] = [];
+    for (const file of walk(path.join(repoRoot, 'packages'))) {
+      const relative = rel(file);
+      if (relative === self) continue;
+      const text = withoutLineComments(readFileSync(file, 'utf8'));
+      if (!negativeProcessKillPattern.test(text)) continue;
+      if (!allowedNegativeKillTests.has(relative)) offenders.push(relative);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the spawn-background negative-PID cleanup guarded', () => {
+    const file = path.join(repoRoot, 'packages/tools/tests/spawn-background.test.ts');
+    const text = readFileSync(file, 'utf8');
+
+    expect(text).toContain('function isSafePid(pid: number): boolean');
+    expect(text).toContain('pid > 1');
+    expect(text).toContain('pid !== process.pid');
+    expect(text).toContain('pid !== process.ppid');
+    expect(text).toContain('child.pid !== pid');
+    expect(text).toContain("process.kill(-pid, 'SIGKILL')");
+  });
+});

--- a/packages/tools/tests/process-registry-posix.test.ts
+++ b/packages/tools/tests/process-registry-posix.test.ts
@@ -13,84 +13,106 @@ const fakeChild = (): ChildProcess => {
   const c = { killed: false, kill: vi.fn(() => { c.killed = true; return true; }) };
   return c as never as ChildProcess;
 };
-const makeProc = (pid: number) => ({
-  pid,
-  name: 'bash',
-  command: 'sleep 1',
-  startedAt: Date.now(),
-  child: fakeChild(),
-});
+const makeProc = (pid: number, opts: { processGroupLeader?: boolean; childPid?: number } = {}) => {
+  const child = fakeChild();
+  Object.assign(child, { pid: opts.childPid ?? pid });
+  return {
+    pid,
+    name: 'bash',
+    command: 'sleep 1',
+    startedAt: Date.now(),
+    child,
+    processGroupLeader: opts.processGroupLeader,
+  };
+};
 
-beforeEach(() => _resetProcessRegistry());
+beforeEach(() => {
+  _resetProcessRegistry();
+  vi.spyOn(process, 'kill').mockImplementation(() => true);
+});
 afterEach(() => {
   _resetProcessRegistry();
   vi.restoreAllMocks();
 });
 
 describe('ProcessRegistry POSIX kill', () => {
-  it('force-kills via the process group (falls back to child.kill)', () => {
+  it('force-kills direct child when process-group leadership is not proven', () => {
     const r = getProcessRegistry();
-    const proc = makeProc(987654); // pid that process.kill(-pid) cannot signal
+    const proc = makeProc(987654);
     r.register(proc);
     expect(r.kill(proc.pid, { force: true })).toBe(true);
-    // process.kill(-pid) throws ESRCH for the bogus pid → child.kill('SIGKILL').
+    expect(process.kill).not.toHaveBeenCalled();
     expect((proc.child.kill as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith('SIGKILL');
     expect(r.get(proc.pid)?.killed).toBe(true);
   });
 
   it('non-force: falls back to child.kill when the group SIGTERM throws', () => {
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
       throw new Error('ESRCH');
     });
-    try {
-      const r = getProcessRegistry();
-      const proc = makeProc(987658);
-      r.register(proc);
-      expect(r.kill(proc.pid)).toBe(true);
-      // process.kill(-pid,'SIGTERM') threw → child.kill('SIGTERM') fallback.
-      expect(proc.child.kill).toHaveBeenCalledWith('SIGTERM');
-    } finally {
-      killSpy.mockRestore();
-    }
+    const r = getProcessRegistry();
+    const proc = makeProc(987658, { processGroupLeader: true });
+    r.register(proc);
+    expect(r.kill(proc.pid)).toBe(true);
+    expect(process.kill).toHaveBeenCalledWith(-proc.pid, 'SIGTERM');
+    expect(proc.child.kill).toHaveBeenCalledWith('SIGTERM');
   });
 
   it('non-force backup: falls back to child.kill when the group SIGKILL throws', () => {
     // SIGTERM succeeds (child stays "alive"), so the backup timer runs; the
     // group SIGKILL then throws → nested child.kill('SIGKILL') fallback.
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation((_pid, sig) => {
+    vi.spyOn(process, 'kill').mockImplementation((_pid, sig) => {
       if (sig === 'SIGKILL') throw new Error('ESRCH');
       return true;
     });
     vi.useFakeTimers();
     try {
       const r = getProcessRegistry();
-      const proc = makeProc(987659);
+      const proc = makeProc(987659, { processGroupLeader: true });
       r.register(proc);
       expect(r.kill(proc.pid, { graceMs: 50 })).toBe(true);
       vi.advanceTimersByTime(60); // backup timer fires → SIGKILL throws → child.kill
       expect(proc.child.kill).toHaveBeenCalledWith('SIGKILL');
     } finally {
       vi.useRealTimers();
-      killSpy.mockRestore();
     }
   });
 
   it('SIGTERM then schedules a SIGKILL backup (non-force)', () => {
     // Make the process-group signal "succeed" so child.killed stays false and
     // the backup SIGKILL timer actually escalates via process.kill(-pid).
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
     vi.useFakeTimers();
     try {
       const r = getProcessRegistry();
-      const proc = makeProc(987655);
+      const proc = makeProc(987655, { processGroupLeader: true });
       r.register(proc);
       expect(r.kill(proc.pid, { graceMs: 50 })).toBe(true);
-      expect(killSpy).toHaveBeenCalledWith(-proc.pid, 'SIGTERM');
+      expect(process.kill).toHaveBeenCalledWith(-proc.pid, 'SIGTERM');
       vi.advanceTimersByTime(60); // backup timer fires
-      expect(killSpy).toHaveBeenCalledWith(-proc.pid, 'SIGKILL');
+      expect(process.kill).toHaveBeenCalledWith(-proc.pid, 'SIGKILL');
     } finally {
       vi.useRealTimers();
-      killSpy.mockRestore();
     }
+  });
+
+  it('refuses process-group signaling for unsafe PIDs even when opted in', () => {
+    const r = getProcessRegistry();
+    for (const pid of [0, 1, -123, process.pid]) {
+      const proc = makeProc(pid, { processGroupLeader: true });
+      r.register(proc);
+      expect(r.kill(pid, { force: true })).toBe(true);
+      expect(proc.child.kill).toHaveBeenCalledWith('SIGKILL');
+      r.unregister(pid);
+    }
+    expect(process.kill).not.toHaveBeenCalled();
+  });
+
+  it('refuses process-group signaling when child.pid does not match the tracked PID', () => {
+    const r = getProcessRegistry();
+    const proc = makeProc(987660, { processGroupLeader: true, childPid: 987661 });
+    r.register(proc);
+    expect(r.kill(proc.pid, { force: true })).toBe(true);
+    expect(process.kill).not.toHaveBeenCalled();
+    expect(proc.child.kill).toHaveBeenCalledWith('SIGKILL');
   });
 });

--- a/packages/tools/tests/process-registry.test.ts
+++ b/packages/tools/tests/process-registry.test.ts
@@ -12,6 +12,7 @@ type Tracked = {
   startedAt: number;
   sessionId?: string;
   child: ChildProcess;
+  processGroupLeader?: boolean;
 };
 
 const fakeChild = (): ChildProcess => {
@@ -37,12 +38,14 @@ const makeProc = (overrides: Partial<Tracked> = {}): Tracked => ({
 describe('ProcessRegistry', () => {
   beforeEach(() => {
     _resetProcessRegistry();
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
     // The registry disables the breaker by default (users opt in via /settings).
     // These tests exercise breaker behavior, so enable it.
     getProcessRegistry().setBreakerConfig({ enabled: true });
   });
   afterEach(() => {
     _resetProcessRegistry();
+    vi.restoreAllMocks();
   });
 
   it('returns the same singleton on repeat access', () => {
@@ -70,18 +73,18 @@ describe('ProcessRegistry', () => {
 
   it('list returns all tracked processes', () => {
     const r = getProcessRegistry();
-    r.register(makeProc({ pid: 1 }));
-    r.register(makeProc({ pid: 2 }));
-    r.register(makeProc({ pid: 3 }));
+    r.register(makeProc({ pid: 10001 }));
+    r.register(makeProc({ pid: 10002 }));
+    r.register(makeProc({ pid: 10003 }));
     expect(r.list()).toHaveLength(3);
-    expect(r.list().map((p) => p.pid).sort()).toEqual([1, 2, 3]);
+    expect(r.list().map((p) => p.pid).sort()).toEqual([10001, 10002, 10003]);
   });
 
   it('byName filters by tool name', () => {
     const r = getProcessRegistry();
-    r.register(makeProc({ pid: 1, name: 'bash' }));
-    r.register(makeProc({ pid: 2, name: 'exec' }));
-    r.register(makeProc({ pid: 3, name: 'bash' }));
+    r.register(makeProc({ pid: 10011, name: 'bash' }));
+    r.register(makeProc({ pid: 10012, name: 'exec' }));
+    r.register(makeProc({ pid: 10013, name: 'bash' }));
     expect(r.byName('bash')).toHaveLength(2);
     expect(r.byName('exec')).toHaveLength(1);
     expect(r.byName('other')).toHaveLength(0);
@@ -89,9 +92,9 @@ describe('ProcessRegistry', () => {
 
   it('bySession filters by sessionId', () => {
     const r = getProcessRegistry();
-    r.register(makeProc({ pid: 1, sessionId: 's1' }));
-    r.register(makeProc({ pid: 2, sessionId: 's2' }));
-    r.register(makeProc({ pid: 3, sessionId: 's1' }));
+    r.register(makeProc({ pid: 10021, sessionId: 's1' }));
+    r.register(makeProc({ pid: 10022, sessionId: 's2' }));
+    r.register(makeProc({ pid: 10023, sessionId: 's1' }));
     expect(r.bySession('s1')).toHaveLength(2);
     expect(r.bySession('s2')).toHaveLength(1);
     expect(r.bySession('absent')).toHaveLength(0);
@@ -99,17 +102,17 @@ describe('ProcessRegistry', () => {
 
   it('activeCount excludes killed processes', () => {
     const r = getProcessRegistry();
-    r.register(makeProc({ pid: 1 }));
-    r.register(makeProc({ pid: 2 }));
+    r.register(makeProc({ pid: 10031 }));
+    r.register(makeProc({ pid: 10032 }));
     expect(r.activeCount).toBe(2);
-    r.kill(1, { force: true });
+    r.kill(10031, { force: true });
     expect(r.activeCount).toBe(1);
   });
 
   it('stats returns combined counts and breaker snapshot', () => {
     const r = getProcessRegistry();
-    r.register(makeProc({ pid: 1 }));
-    r.register(makeProc({ pid: 2 }));
+    r.register(makeProc({ pid: 10041 }));
+    r.register(makeProc({ pid: 10042 }));
     const s = r.stats();
     expect(s.activeCount).toBe(2);
     expect(s.totalCount).toBe(2);
@@ -174,40 +177,52 @@ describe('ProcessRegistry', () => {
 
   it('killAll kills every tracked process and returns their PIDs', () => {
     const r = getProcessRegistry();
-    r.register(makeProc({ pid: 1 }));
-    r.register(makeProc({ pid: 2 }));
-    r.register(makeProc({ pid: 3 }));
+    r.register(makeProc({ pid: 10051 }));
+    r.register(makeProc({ pid: 10052 }));
+    r.register(makeProc({ pid: 10053 }));
     const killed = r.killAll({ force: true }).sort((a, b) => a - b);
-    expect(killed).toEqual([1, 2, 3]);
+    expect(killed).toEqual([10051, 10052, 10053]);
     expect(r.activeCount).toBe(0);
   });
 
   it('killSession kills only matching session processes', () => {
     const r = getProcessRegistry();
-    r.register(makeProc({ pid: 1, sessionId: 's1' }));
-    r.register(makeProc({ pid: 2, sessionId: 's2' }));
-    r.register(makeProc({ pid: 3, sessionId: 's1' }));
+    r.register(makeProc({ pid: 10061, sessionId: 's1' }));
+    r.register(makeProc({ pid: 10062, sessionId: 's2' }));
+    r.register(makeProc({ pid: 10063, sessionId: 's1' }));
     const killed = r.killSession('s1', { force: true }).sort((a, b) => a - b);
-    expect(killed).toEqual([1, 3]);
-    expect(r.get(2)?.killed).toBe(false);
+    expect(killed).toEqual([10061, 10063]);
+    expect(r.get(10062)?.killed).toBe(false);
   });
 
   it('killSession returns an empty array when no processes match', () => {
     const r = getProcessRegistry();
-    r.register(makeProc({ pid: 1, sessionId: 's1' }));
+    r.register(makeProc({ pid: 10071, sessionId: 's1' }));
     expect(r.killSession('does-not-exist', { force: true })).toEqual([]);
+  });
+
+  it('never process-group kills untrusted fake PIDs', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const r = getProcessRegistry();
+    const child = fakeChild();
+    r.register(makeProc({ pid: 1, child }));
+    expect(r.kill(1, { force: true })).toBe(true);
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
   });
 });
 
 describe('ProcessRegistry circuit-breaker config', () => {
   beforeEach(() => {
     _resetProcessRegistry();
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
   });
   afterEach(() => {
     vi.useRealTimers();
     _resetProcessRegistry();
+    vi.restoreAllMocks();
   });
 
   it('defaults to disabled — calls proceed even after forceBreakerOpen', () => {
@@ -251,8 +266,8 @@ describe('ProcessRegistry circuit-breaker config', () => {
   it('fires killAll + reset when the countdown elapses', () => {
     const r = getProcessRegistry();
     r.setBreakerConfig({ enabled: true, autoKillResetMs: 10_000 });
-    r.register(makeProc({ pid: 11 }));
-    r.register(makeProc({ pid: 22 }));
+    r.register(makeProc({ pid: 10081 }));
+    r.register(makeProc({ pid: 10082 }));
     for (let i = 0; i < 5; i++) r.afterCall(10, true);
     expect(r.canProceed).toBe(false);
     expect(r.getBreakerCountdown()).not.toBeNull();
@@ -260,8 +275,8 @@ describe('ProcessRegistry circuit-breaker config', () => {
     vi.advanceTimersByTime(10_000);
 
     // Forced recovery: processes killed, breaker closed, countdown cleared.
-    expect(r.get(11)?.killed).toBe(true);
-    expect(r.get(22)?.killed).toBe(true);
+    expect(r.get(10081)?.killed).toBe(true);
+    expect(r.get(10082)?.killed).toBe(true);
     expect(r.canProceed).toBe(true);
     expect(r.stats().breaker.state).toBe('closed');
     expect(r.getBreakerCountdown()).toBeNull();
@@ -270,7 +285,7 @@ describe('ProcessRegistry circuit-breaker config', () => {
   it('manual reset cancels the armed countdown', () => {
     const r = getProcessRegistry();
     r.setBreakerConfig({ enabled: true, autoKillResetMs: 10_000 });
-    r.register(makeProc({ pid: 5 }));
+    r.register(makeProc({ pid: 10091 }));
     for (let i = 0; i < 5; i++) r.afterCall(10, true);
     expect(r.getBreakerCountdown()).not.toBeNull();
 
@@ -278,23 +293,23 @@ describe('ProcessRegistry circuit-breaker config', () => {
 
     expect(r.getBreakerCountdown()).toBeNull();
     // Process not killed — reset is a recovery, not a kill.
-    expect(r.get(5)?.killed).toBe(false);
+    expect(r.get(10091)?.killed).toBe(false);
     // Countdown never fires after cancel.
     vi.advanceTimersByTime(10_000);
-    expect(r.get(5)?.killed).toBe(false);
+    expect(r.get(10091)?.killed).toBe(false);
   });
 
   it('breakertimeout=0 means manual recovery (no countdown armed)', () => {
     const r = getProcessRegistry();
     r.setBreakerConfig({ enabled: true, autoKillResetMs: 0 });
-    r.register(makeProc({ pid: 9 }));
+    r.register(makeProc({ pid: 10101 }));
     for (let i = 0; i < 5; i++) r.afterCall(10, true);
     // Breaker is open → canProceed false, no countdown armed.
     expect(r.canProceed).toBe(false);
     expect(r.getBreakerCountdown()).toBeNull();
     vi.advanceTimersByTime(60_000);
     // No auto kill/reset fired — process untouched, breaker unchanged.
-    expect(r.get(9)?.killed).toBe(false);
+    expect(r.get(10101)?.killed).toBe(false);
   });
 
   it('notifies subscribers on arm and cancel', () => {
@@ -311,4 +326,3 @@ describe('ProcessRegistry circuit-breaker config', () => {
     expect(events.at(-1)).toBeNull();
   });
 });
-

--- a/packages/tools/tests/spawn-background.test.ts
+++ b/packages/tools/tests/spawn-background.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import * as os from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
 import { spawnBackground, spawnBackgroundExec } from '../src/spawn-background.js';
@@ -9,14 +10,28 @@ const isWin = os.platform() === 'win32';
 // test. These are *detached* processes — without explicit cleanup each run
 // left orphaned cmd.exe/node sleepers behind (multi-second `setTimeout`
 // children piled up across the suite and ate CPU/RAM on the host).
-const spawned: Array<{ pid: number | null }> = [];
+const spawned: Array<{ pid: number | null; child: ChildProcess }> = [];
 
-function track<T extends { pid: number | null }>(result: T): T {
+function track<T extends { pid: number | null; child: ChildProcess }>(result: T): T {
   spawned.push(result);
   return result;
 }
 
-function treeKill(pid: number): void {
+function isSafePid(pid: number): boolean {
+  return Number.isInteger(pid) && pid > 1 && pid !== process.pid && pid !== process.ppid;
+}
+
+function treeKill(entry: { pid: number; child: ChildProcess }): void {
+  const { pid, child } = entry;
+  if (!isSafePid(pid) || child.pid !== pid) {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      /* already gone */
+    }
+    return;
+  }
+
   try {
     if (isWin) {
       // The shell-wrapped variant spawns cmd.exe whose *grandchild* is the
@@ -37,8 +52,8 @@ function treeKill(pid: number): void {
 }
 
 afterEach(() => {
-  for (const { pid } of spawned.splice(0)) {
-    if (typeof pid === 'number') treeKill(pid);
+  for (const entry of spawned.splice(0)) {
+    if (typeof entry.pid === 'number') treeKill({ pid: entry.pid, child: entry.child });
   }
 });
 


### PR DESCRIPTION
## Summary
- require an explicit `processGroupLeader` registry flag before using POSIX negative-PID signaling
- reject unsafe signal PIDs (`<=1`, negative, current process, parent process) and mismatched `child.pid`
- route bash timeout killing through the guarded registry path
- mock `process.kill` in process-registry tests and stop using low fake PIDs except for the explicit regression case
- add the same PID/child guard to `spawn-background.test.ts` cleanup before it uses negative-PID teardown
- add `posix-signal-safety.test.ts` so new test files cannot introduce raw negative-PID `process.kill(-...)` calls unnoticed
- extend the static safety test across `packages/` and `apps/`, including production direct `process.kill(..., 'SIG*')` allow-listing
- keep production raw negative-PID `process.kill` isolated to `ProcessRegistry` and behind explicit guards
- guard `/sessions kill <id>` so a corrupt live-session registry cannot send SIGTERM to PID `0`, PID `1`, the current process, or the parent process
- make `bash-spawn.test.ts` use Vitest hoisted mock state so the guarded bash import path does not trip the `node:os` mock on import
- fix the Windows PowerShell stdin wrapper by removing the BOM and avoiding `finally { exit ... }`, which broke real PowerShell output and the backpressure test
- fix a `ToolExecutor` progress-stream edge case that emitted an empty `partial_output` event on final flush
- fix WebUI WS protocol guard drift: ignore non-WS mailbox bridge `case` labels and explicitly handle prompt/design ack messages on the client

## Why
A report showed that tests could register fake PID `1` and exercise the production POSIX kill path, producing `process.kill(-1, 'SIGKILL')`. On POSIX/macOS, that can signal every process the current user is allowed to signal. This patch makes process-group signaling opt-in and guarded at runtime, and makes the tests unable to leak real OS signals.

I also audited the macOS/POSIX-facing test signal paths. The only other test using direct negative-PID signaling was `spawn-background.test.ts`; it spawns a real detached child, but now also verifies the PID is safe and matches `child.pid` before process-group cleanup. The static safety test prevents future raw negative-PID process.kill calls in tests unless they are deliberately routed through the guarded helper, prevents production code from adding a second raw negative-PID signal path outside `ProcessRegistry`, and limits direct production `process.kill(..., 'SIG*')` calls to reviewed call sites.

Finally, the only non-self production `SIGTERM` path found was `/sessions kill <id>`. It now refuses host-sensitive PIDs before the liveness probe or termination signal. The WebUI `webui.shutdown` path remains explicitly scoped to `process.pid` and is pinned by the static test.

## Validation
- `pnpm test` — root Vitest: 744 files passed, 1 skipped; 10378 tests passed, 16 skipped. WebUI Vitest: 118 files passed; 1825 tests passed.
- `pnpm exec vitest run packages/tools/tests` — 90 files, 1306 tests passed
- `pnpm exec vitest run packages/tools/tests/posix-signal-safety.test.ts` — 7 tests passed
- `pnpm exec vitest run packages/tools/tests/posix-signal-safety.test.ts packages/tools/tests/spawn-background.test.ts packages/tools/tests/process-registry.test.ts packages/tools/tests/process-registry-posix.test.ts packages/cli/tests/slash-session.test.ts` — 5 files, 64 tests passed
- `pnpm exec vitest run packages/tools/tests/_shell-pick.test.ts packages/tools/tests/bash-backpressure.test.ts packages/tools/tests/bash-spawn.test.ts packages/tools/tests/bash.test.ts` — 4 files, 110 tests passed
- `pnpm exec vitest run packages/core/tests/coordination/tool-lifecycle.test.ts packages/cli/tests/webui-server/ws-handler-parity.test.ts packages/cli/tests/webui-server/ws-twoway-completeness.test.ts` — 3 files, 15 tests passed
- `pnpm --filter @wrongstack/tools typecheck`
- `pnpm --filter @wrongstack/core typecheck`
- `pnpm --filter @wrongstack/cli typecheck`
- `pnpm --filter @wrongstack/webui typecheck`
- `pnpm --filter @wrongstack/tools build`
- `pnpm -r build`
- pre-commit hook: corruption guard, changed-package build, workspace typecheck passed

## Broader test audit
- The full root test command is green on this Windows host.
- Static search found no additional macOS/POSIX host-destructive negative-PID signal path. The remaining real process cleanup tests are scoped to child processes or marker-based Windows cleanup.
- The earlier full `packages/tools/tests` failure was not macOS/POSIX signal-related: Windows PowerShell treated the stdin BOM as part of the first command name and `finally { exit $LASTEXITCODE }` swallowed output. The wrapper now starts with the encoding bootstrap directly and propagates native exit codes after the command body.
- `gh pr checks 137 --repo WrongStack/WrongStack`: no checks reported for this branch.