### PR TITLE
feat(acp): complete functional ACP v1 (client + agent, both directions)

### DIFF
--- a/docs/acp-editor-integration.md
+++ b/docs/acp-editor-integration.md
@@ -1,0 +1,171 @@
+# Connecting WrongStack to a real ACP editor
+
+This guide covers driving WrongStack **as an ACP agent** from a real editor
+(Zed, JetBrains, a VS Code ACP extension, or any ACP-v1 client), plus a
+manual verification checklist for each functional capability. For the reverse
+direction — WrongStack **as a client** driving other agents — see
+[`docs/subcommands/acp.md`](./subcommands/acp.md).
+
+> Scope: this is the field-verification companion to
+> [`packages/acp/COMPLIANCE.md`](../packages/acp/COMPLIANCE.md). The protocol
+> work is fully unit-tested, interop-tested (in-process loopback), and
+> runtime-tested (real WebSocket). What it has **not** had is a round-trip
+> against a shipping third-party editor — that's what this checklist is for.
+
+---
+
+## 1. Prerequisites
+
+```bash
+wstack auth            # configure a model provider (required for a real agent)
+wstack acp --echo      # optional: no-provider connectivity smoke (echo agent)
+```
+
+`wstack acp --echo` answers the protocol but runs a no-op turn — use it to
+confirm an editor can *connect and handshake* before involving a model.
+
+---
+
+## 2. Transports
+
+| Mode | Command | When to use |
+|------|---------|-------------|
+| **stdio** (default) | `wstack acp` | The normal path — the editor spawns it as a subprocess and talks JSON-RPC over stdin/stdout. |
+| **HTTP** | (programmatic: `new WrongStackACPServer({ transport: 7788 })`) | One JSON-RPC request/response per POST; notifications buffered into the response. No live mid-turn streaming. |
+| **WebSocket** | `wstack acp --ws[=port]` (default `127.0.0.1:8889`) | Remote / manual testing. Full-duplex: `session/update` and permission prompts stream live during a turn. Origin-guarded for loopback safety. |
+
+---
+
+## 3. Editor configuration
+
+### Zed
+
+Zed discovers ACP agents via `agent_servers` in `~/.config/zed/settings.json`:
+
+```jsonc
+{
+  "agent_servers": {
+    "WrongStack": {
+      "command": "wstack",
+      "args": ["acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+Then pick **WrongStack** as the agent in Zed's agent panel. Zed spawns the
+subprocess and speaks ACP v1 over stdio.
+
+### Generic ACP client
+
+Any ACP-v1 client that spawns a subprocess works with the same shape:
+
+- **command**: `wstack` (or the absolute path to your build's bin)
+- **args**: `["acp"]`
+- **transport**: stdio, newline-delimited JSON-RPC 2.0
+
+The agent advertises this in its `initialize` response:
+
+```jsonc
+{
+  "protocolVersion": 1,
+  "agentCapabilities": {
+    "loadSession": true,
+    "promptCapabilities": { "image": true, "audio": false, "embeddedContext": true },
+    "sessionCapabilities": { "close": {}, "list": {}, "delete": {}, "resume": {} },
+    "auth": { "logout": {} }
+  },
+  "agentInfo": { "name": "wrongstack", "title": "WrongStack", "version": "…" }
+}
+```
+
+A client that advertises `clientCapabilities.fs.{readTextFile,writeTextFile}`
+and/or `terminal: true` lets WrongStack operate on the **editor's** filesystem
+and terminal (see §5).
+
+---
+
+## 4. Manual smoke without an editor
+
+### stdio (no provider needed)
+
+Pipe JSON-RPC lines into the echo agent and watch the responses:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":true,"writeTextFile":true},"terminal":true}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"'"$PWD"'"}}' \
+  '{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"REPLACE_FROM_id2","prompt":[{"type":"text","text":"hi"}]}}' \
+  | wstack acp --echo
+```
+
+Expect: an `initialize` result, a `session/new` result with a `sessionId`,
+then a `session/prompt` result with `stopReason: "end_turn"`.
+
+### WebSocket
+
+```bash
+wstack acp --ws=8889            # terminal 1 (real agent; needs `wstack auth` first)
+wstack acp --ws=8889 --echo     # no-provider connectivity test over WS
+```
+
+Connect a WebSocket client to `ws://127.0.0.1:8889` and send the same
+JSON-RPC frames (one JSON object per WS message). Because WS is full-duplex,
+you'll see `session/update` notifications arrive *while* the turn runs.
+
+---
+
+## 5. Verification checklist
+
+Run each against a real editor (or the WS manual path) once a provider is
+configured. ✅ = expected behavior.
+
+### Handshake & sessions
+- [ ] **initialize** — editor connects; agent returns `protocolVersion: 1` and the capabilities above.
+- [ ] **session/new** — a fresh session id is returned; a `current_mode_update` arrives.
+- [ ] **session/prompt** — a simple "say hi" returns `agent_message_chunk`(s) then `stopReason: end_turn`.
+- [ ] **session/cancel** — interrupting a long turn yields `stopReason: cancelled` promptly.
+- [ ] **session/load after restart** — stop and restart `wstack acp`, then `session/load` a prior id: the conversation history is replayed back to the editor **and** the agent resumes the model context (a follow-up prompt remembers the earlier turns), restored from the durable session store.
+
+### Tool streaming (B1)
+- [ ] Ask for a change that uses tools (e.g. "read package.json and summarize"). The editor shows **tool-call cards** (`read`, `edit`, `bash`, …) with live `in_progress → completed` status — not just a final text blob.
+- [ ] An edit surfaces a **diff** in the tool card.
+
+### Permission (B2)
+- [ ] A side-effecting tool (file write / shell command) triggers a **permission prompt in the editor** (`session/request_permission`) before it runs.
+- [ ] Approving lets it proceed; rejecting stops it. Read-only tools (read/search/fetch) run without a prompt.
+
+### Client filesystem / terminal (B3)
+- [ ] With the editor advertising `fs` capabilities, file reads/writes go through the **editor's** buffers (unsaved edits are visible to the agent), not a stale on-disk copy.
+- [ ] With `terminal: true`, `bash`-style tools run in the **editor's** terminal.
+
+### Multimodal (B5)
+- [ ] If the editor + your model support vision, attaching an image to a prompt reaches the model (the agent advertises `promptCapabilities.image: true`).
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Editor can't connect | `wstack` not on PATH / wrong bin | Use the absolute path to your built CLI in the editor config. |
+| "No model provider configured" | no `wstack auth` | Run `wstack auth`, or test wiring with `wstack acp --echo`. |
+| No tool cards, only final text | client not rendering `tool_call` updates | Confirm the editor is an ACP-v1 client that renders tool calls; check it's not using a legacy/draft ACP build. |
+| File edits ignore unsaved buffers | client didn't advertise `fs` caps | Enable the editor's ACP filesystem capability; otherwise the agent uses local disk (correct on the same machine, just buffer-unaware). |
+| WS connection rejected (1008) | cross-origin | The WS server is loopback-only and rejects foreign `Origin` headers; connect from a non-browser client or same origin. |
+| `session/load` returns "not found" after restart | persistence dir mismatch | History persists under the project's wstack data dir (`paths.projectDir/acp-sessions`, i.e. `~/.wrongstack/projects/<hash>/acp-sessions`); restart from the **same project root** so the hash matches. |
+
+---
+
+## 7. What's validated vs. what this checklist adds
+
+Already covered by automated tests (see `COMPLIANCE.md`):
+- every method answered with a spec-shaped response (wire compliance);
+- our client ↔ our server interop over a JSON round-trip (in-process loopback);
+- the WebSocket transport over a real socket (runtime smoke);
+- no regressions across the full CLI suite.
+
+This checklist adds the one thing automation here can't: a **third-party
+editor's** interpretation of our wire. File any divergence you find against the
+relevant capability above.

--- a/docs/subcommands/acp.md
+++ b/docs/subcommands/acp.md
@@ -2,7 +2,9 @@
 
 WrongStack as an ACP-compatible agent (server) and as a driver of external
 ACP agents (client). See [ACP Ensemble Architecture](../acp-ensemble.md) for
-the top-level design; this page is the CLI surface reference.
+the top-level design; this page is the CLI surface reference. To connect a
+real editor (Zed, JetBrains, …) and verify each capability, see the
+[ACP editor integration guide](../acp-editor-integration.md).
 
 ## Usage
 

--- a/packages/acp/COMPLIANCE.md
+++ b/packages/acp/COMPLIANCE.md
@@ -3,8 +3,18 @@
 **Date:** 2026-06-27
 **Version:** 0.274.1
 **Specification:** Agent Client Protocol v1
-**Official SDK:** `@agentclientprotocol/sdk` ^1.0.0
-**Tested against:** Full source audit across 21 files, 143 checks — **0 failures, 0 warnings.**
+**Official SDK:** `@agentclientprotocol/sdk` ^1.0.0 (re-exported for its WS/SSE
+types; the live client/server paths are a self-contained hand-rolled
+JSON-RPC implementation, not the SDK runtime).
+
+> **Read this first — two kinds of "compliance".** The tables below measure
+> *wire compliance*: every ACP method name is answered with a spec-shaped
+> response. That is necessary but not sufficient. The
+> **[Functional fidelity](#functional-fidelity-beyond-wire-compliance)**
+> section tracks whether each surface actually *does the work* (streams tool
+> calls, routes permissions to a human, forwards diffs, etc.), and
+> **[Known limitations](#known-limitations)** lists what is deliberately not
+> done yet. Do not read "30/30 methods" as "feature-complete".
 
 ## Summary
 
@@ -14,10 +24,12 @@
 | ACP methods implemented (client) | 26/26 (100%) |
 | session/update discriminators | 13/13 (100%) |
 | ACP type definitions | 35/35 (100%) |
-| Transport support | 4/4 (stdio, HTTP, WebSocket, SSE) |
-| Official SDK integration | ✅ `@agentclientprotocol/sdk` re-exported |
+| Transport (live, wired) | stdio (client + server), HTTP (server POST), **WebSocket** (client via `connectWebSocket`; server via `wstack acp --ws[=port]`) |
+| Transport (types only, not wired) | SSE — available via the SDK re-export, no command instantiates it |
+| Official SDK integration | ⚠️ Re-exported types/helpers only; live paths are hand-rolled JSON-RPC (the WS server uses `ws` + our handler, not the SDK's `AcpServer`) |
 | Source files audited | 21/21 |
-| Test status | ✅ All passing |
+| Test status | ✅ All passing (acp 184 + cli acp suites; +21 new for the functional work) |
+| End-to-end interop | ✅ Capstone loopback test wires OUR client (`ACPSession`) to OUR agent (`ACPProtocolHandler`) in-process with a JSON round-trip per hop, exercising tool streaming + client-fs read + permission round-trip across both directions at once |
 
 ## Agent Methods (Server Handles — `ACPProtocolHandler`)
 
@@ -197,3 +209,54 @@ Pass: 143, Fail: 0
 ```
 
 Source files scanned: all 21 `.ts` files in `packages/acp/src/`.
+
+## Functional fidelity (beyond wire compliance)
+
+How much real work each surface does, not just whether the method answers.
+
+### DIR-1 — WrongStack as ACP client (driving external agents)
+
+| Capability | Status | Notes |
+|---|---|---|
+| Stream tool calls / diffs / thoughts | ✅ | `ACPSession.prompt(blocks, signal, onProgress)` captures `tool_call`/`tool_call_update`/diff/thought and returns them on `ACPSessionRunResult` (`toolCalls`, `diffs`, `thoughts`). |
+| Live progress to host | ✅ | `onProgress` callback fires per `session/update`; threaded through `makeACPSubagentRunner` (`onProgress` option), `runEnsemble` (`onProgress` per-agent), and rendered by `wstack acp spawn`/`parallel`. |
+| Real tool-call metrics | ✅ | `SubagentRunOutcome.toolCalls` reflects the captured count (was hard-coded `0`). |
+| Watchdog keepalive | ✅ | Runner calls `budget.markActivity()` on every update, so a long-but-working agent isn't idle-reaped. |
+| Permission policy injection | ✅ | `permissionPolicy` option on the runner / `ACPSession`; `readOnlyPermissionPolicy` + `makePermissionPolicy(decide)` provided. Default is documented auto-approve for non-interactive use. |
+| Director parity with CLI | ✅ | `buildACPRunner` falls back to the 12-entry catalog, so `claude-code`/`codex-cli`/`opencode`/`cursor`/… spawn from the Director, not just `wstack acp spawn`. |
+| Multi-turn session reuse | ✅ | `makeACPSubagentRunnerWithStop({ persistent: true })` keeps one session/process across turns; `stop()` tears it down. |
+| MCP passthrough | ✅ | `mcpServers` option forwarded to `session/new`/`load`, filtered by agent capabilities. |
+| Multimodal prompt | ✅ (types) | `ACPSession.prompt` accepts image/audio/resource blocks; the subagent runner currently sends text — richer callers can pass blocks directly. |
+| Lenient version negotiation | ✅ | Accepts any agent `protocolVersion ≤ 1`; only rejects a higher one. |
+| Remote agent over WebSocket | ✅ | `ACPSession.connectWebSocket({ url })` + `WebSocketClientTransport` (Node ≥ 22 built-in `WebSocket`, no dependency). `ACPSession.connect(transport)` accepts any custom transport. stdio path unchanged. |
+
+### DIR-2 — WrongStack as ACP agent (driven by editors)
+
+| Capability | Status | Notes |
+|---|---|---|
+| Stream tool calls to client | ✅ | `server-agent-turn` subscribes to the core agent's EventBus and emits `tool_call`/`tool_call_update` (with kind inference + output) per `tool.started`/`tool.executed`. |
+| Ask client for permission | ✅ | `ACPProtocolHandler` now makes outbound requests; side-effecting tools route through `session/request_permission` (`ACPClientPermissionPolicy`); safe/read tools auto-approve; fail-safe deny on no channel/timeout. |
+| Multimodal input | ✅ | Image blocks become a core `ContentBlock[]` (vision input); `promptCapabilities.image` advertised `true`. |
+| HTTP transport | ✅ | Fixed: responses are captured and returned in the HTTP body (previously read a non-existent `lastResponse`, returning `undefined`). |
+| WebSocket transport (server) | ✅ | `wstack acp --ws[=port]` serves over WebSocket (`WsBridgeTransport` + `ws`, one handler per connection) — full-duplex, so `session/update` and `session/request_permission` stream live during a turn (HTTP can't). Origin-guarded for loopback safety. |
+| session/load history replay + context resume | ✅ | `makeACPServerAgentTurn` records per-session user/agent turns (`.replay`); the handler streams them back on load. **Cross-process**: with `ACPSessionStore` wired (default under `<projectDir>/acp-sessions`), the handler persists sessions+history on create/prompt and restores them after a restart — replaying to the client UI **and** seeding the restored session's Agent context (`.seed` → `ctx.state.appendMessage`) so the model resumes the prior conversation, not just the editor view. |
+| Use client filesystem / terminal | ✅ | When the client advertises `fs`/`terminal`, the factory swaps `read`/`write`/`edit`/`bash` for ACP-backed tools that call `fs/read_text_file`, `fs/write_text_file`, and `terminal/*` — so the editor's buffers/terminal are the source of truth. Builtins reused for schema; gated on capabilities; falls back to local for un-advertised tools. |
+
+## Known limitations
+
+Deliberately not implemented yet — each is a separate, larger piece of work
+that needs a real ACP client to validate end-to-end:
+
+- **DIR-1 remote agent over HTTP POST.** WebSocket remote agents are supported
+  (`connectWebSocket`); a one-shot HTTP-POST client (no server-push
+  notifications) is not — use WebSocket for remote.
+- **Official SDK not wired into live paths (C1 — by design).** `@agentclientprotocol/sdk`
+  is re-exported for its types and SSE helpers, but the running client and
+  server use the hand-rolled JSON-RPC implementation. The functional goal the
+  SDK would have served — a WebSocket transport on both ends — is now met
+  natively (client `connectWebSocket`, server `--ws`), so adopting the SDK's
+  `AcpServer`/`AgentApp` runtime would be a no-gain rewrite of tested code.
+  Only SSE remains SDK-types-only (no command instantiates it).
+- **Legacy draft types (`acp-messages.ts` / `tool-translator.ts`).** Predate
+  the v1 rewrite (`tools/call`, `progress` content) and are unused by the live
+  v1 code path; kept for the transport's `ACPMessage` alias and backward compat.

--- a/packages/acp/src/agent/index.ts
+++ b/packages/acp/src/agent/index.ts
@@ -1,6 +1,18 @@
 export {StdioTransport} from './stdio-transport.js';
 export {ACPToolsRegistry} from './tools-registry.js';
 export {ACPProtocolHandler} from './protocol-handler.js';
+export type {
+  RunTurn,
+  RunTurnApi,
+  RunTurnInput,
+  RunTurnResult,
+  RunTurnPermissionRequest,
+  SessionPersistence,
+  ClientCapabilities,
+} from './protocol-handler.js';
+export {ACPSessionStore} from './session-store.js';
+export type {SessionStoreOptions, PersistedSession} from './session-store.js';
+export {WsBridgeTransport} from './ws-bridge-transport.js';
 export {WrongStackACPServer} from './wrongstack-acp-agent.js';
 export type {WrongStackACPServerOptions} from './wrongstack-acp-agent.js';
 export {makeACPServerAgentTurn} from './server-agent-turn.js';

--- a/packages/acp/src/agent/protocol-handler.ts
+++ b/packages/acp/src/agent/protocol-handler.ts
@@ -42,7 +42,16 @@
  *  notification can stop the running turn mid-stream without tearing
  *  down the session. Multiple sessions can be active concurrently.
  */
-import { ACP_PROTOCOL_VERSION, type StopReason, type ContentBlock, type PlanEntry, type UsageCost } from '../types/acp-v1.js';
+import {
+  ACP_PROTOCOL_VERSION,
+  type StopReason,
+  type ContentBlock,
+  type PermissionOption,
+  type PlanEntry,
+  type RequestPermissionOutcome,
+  type ToolKind,
+  type UsageCost,
+} from '../types/acp-v1.js';
 import type { AgentServerTransport } from './stdio-transport.js';
 import type { ACPMessage } from '../types/acp-messages.js';
 
@@ -95,13 +104,63 @@ export interface RunTurnResult {
 }
 
 /**
+ * A tool-call permission request the agent surfaces to the client.
+ */
+export interface RunTurnPermissionRequest {
+  toolCall: { toolCallId: string; title: string; kind?: ToolKind | undefined };
+  options: PermissionOption[];
+}
+
+/** Client filesystem/terminal capabilities advertised at initialize. */
+export interface ClientCapabilities {
+  fs?: { readTextFile?: boolean | undefined; writeTextFile?: boolean | undefined } | undefined;
+  terminal?: boolean | undefined;
+}
+
+/**
+ * Client-callback API handed to `runTurn`. Lets the agent's tools call back
+ * into the connected ACP client — ask for permission, and (when the client
+ * advertises the capability) use the client's filesystem and terminal so the
+ * editor's view (including unsaved buffers) is the source of truth.
+ */
+export interface RunTurnApi {
+  /**
+   * Ask the connected ACP client to approve/reject a tool call via the
+   * `session/request_permission` method. Resolves with the client's
+   * outcome. Rejects if no client channel is available or the request
+   * times out — the caller decides the fallback.
+   */
+  requestPermission(req: RunTurnPermissionRequest): Promise<RequestPermissionOutcome>;
+  /** Capabilities the client advertised at initialize — gate tool wiring on these. */
+  clientCapabilities: ClientCapabilities;
+  /** Read a text file from the client's filesystem (`fs/read_text_file`). */
+  readTextFile(params: { path: string; line?: number; limit?: number }): Promise<string>;
+  /** Write a text file in the client's filesystem (`fs/write_text_file`). */
+  writeTextFile(params: { path: string; content: string }): Promise<void>;
+  /**
+   * Run a command in the client's terminal (`terminal/create` →
+   * `wait_for_exit` → `output` → `release`) and resolve with the combined
+   * output and exit code.
+   */
+  runTerminal(params: {
+    command: string;
+    args?: string[] | undefined;
+    cwd?: string | undefined;
+  }): Promise<{ output: string; exitCode: number | null }>;
+}
+
+/**
  * The agent's per-turn work. Streams `SessionUpdate` notifications to
  * `emit` and resolves with the final stopReason. Errors thrown from
  * this iterable are converted to a `prompt_failed` JSON-RPC error.
+ *
+ * `api` is an optional client-callback surface (permission requests).
+ * Older runTurn implementations that ignore it keep working unchanged.
  */
 export type RunTurn = (
   input: RunTurnInput,
   emit: (update: unknown) => void,
+  api?: RunTurnApi,
 ) => Promise<RunTurnResult>;
 
 export interface SessionState {
@@ -151,6 +210,41 @@ export interface ProtocolHandlerOptions {
   configOptions?: readonly SessionConfigOption[] | undefined;
   /** Agent name advertised in initialize. */
   agentName?: string | undefined;
+  /**
+   * Optional source of replayable conversation history for `session/load`.
+   * Returns the `session/update` payloads (user/agent message chunks) to
+   * stream back to the client before the load response. Wired from
+   * `makeACPServerAgentTurn(...).replay`.
+   */
+  replayFor?: ((sessionId: string) => Array<{ sessionUpdate: string; content: unknown }>) | undefined;
+  /**
+   * Optional hook to prime the turn engine's session history on cold
+   * `session/load` (server restart). Wired from `makeACPServerAgentTurn(...).seed`
+   * — it re-feeds the persisted conversation into the next-created Agent so
+   * the model resumes, not just the client UI.
+   */
+  seedFor?: ((sessionId: string, history: Array<{ sessionUpdate: string; content: unknown }>) => void) | undefined;
+  /**
+   * Optional durable session store. When set, sessions + their recorded
+   * history are persisted on create/prompt and restored on `session/load`,
+   * so a reconnecting client can resume after a server restart.
+   * (Structural type — `ACPSessionStore` satisfies it without a value import.)
+   */
+  store?: SessionPersistence | undefined;
+}
+
+/** Minimal durable-store contract the handler uses (ACPSessionStore satisfies it). */
+export interface SessionPersistence {
+  save(
+    state: SessionState,
+    history?: Array<{ sessionUpdate: string; content: unknown }>,
+  ): Promise<unknown>;
+  load(
+    sessionId: string,
+  ): Promise<
+    | (Partial<SessionState> & { history?: Array<{ sessionUpdate: string; content: unknown }> | undefined })
+    | null
+  >;
 }
 
 /** Single global mode id, sufficient for v1. */
@@ -172,10 +266,26 @@ export class ACPProtocolHandler {
   private readonly modes: readonly SessionMode[];
   private readonly configOptions: readonly SessionConfigOption[];
   private readonly agentName: string;
+  private readonly replayFor:
+    | ((sessionId: string) => Array<{ sessionUpdate: string; content: unknown }>)
+    | undefined;
+  private readonly seedFor:
+    | ((sessionId: string, history: Array<{ sessionUpdate: string; content: unknown }>) => void)
+    | undefined;
+  private readonly store: SessionPersistence | undefined;
 
   private initialized = false;
+  private clientCapabilities: ClientCapabilities = {};
   private readonly sessions = new Map<string, SessionState>();
   private nextId = 1;
+
+  // Outbound request correlation (server → client requests, e.g.
+  // session/request_permission). Keyed by our own `srv_N` ids.
+  private readonly pendingOut = new Map<
+    string,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
+  >();
+  private nextOutId = 1;
 
   constructor(opts: ProtocolHandlerOptions) {
     this.transport = opts.transport;
@@ -185,6 +295,53 @@ export class ACPProtocolHandler {
     this.modes = opts.modes ?? DEFAULT_MODES;
     this.configOptions = opts.configOptions ?? [];
     this.agentName = opts.agentName ?? 'wrongstack';
+    this.replayFor = opts.replayFor;
+    this.seedFor = opts.seedFor;
+    this.store = opts.store;
+    // Route inbound JSON-RPC responses (to our outbound requests)
+    // independently of the server's read loop. StdioTransport fires
+    // onMessage on the stdin 'data' event, so a pending request resolves
+    // even while a session/prompt handler is parked awaiting it.
+    // Guarded: minimal transports (and some test fakes) may omit onMessage;
+    // without it, server→client requests simply aren't supported.
+    if (typeof this.transport.onMessage === 'function') {
+      this.transport.onMessage((m) => this.maybeResolvePending(m));
+    }
+  }
+
+  /**
+   * Send a request to the client and await its response. Used for
+   * server-initiated calls like `session/request_permission`. Rejects on
+   * timeout or transport error so the caller can pick a safe fallback.
+   */
+  private request(method: string, params: unknown, timeoutMs = 60_000): Promise<unknown> {
+    const id = `srv_${this.nextOutId++}`;
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingOut.delete(id);
+        reject(new Error(`${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pendingOut.set(id, { resolve, reject, timer });
+      this.transport
+        .send(toWire({ jsonrpc: '2.0', id, method, params }))
+        .catch((e: unknown) => {
+          clearTimeout(timer);
+          this.pendingOut.delete(id);
+          reject(e instanceof Error ? e : new Error(String(e)));
+        });
+    });
+  }
+
+  private maybeResolvePending(m: ACPMessage): void {
+    const id = (m as { id?: unknown }).id;
+    if (typeof id !== 'string') return;
+    const pending = this.pendingOut.get(id);
+    if (!pending) return;
+    this.pendingOut.delete(id);
+    clearTimeout(pending.timer);
+    const err = (m as { error?: { message?: string } }).error;
+    if (err) pending.reject(new Error(err.message ?? 'client request failed'));
+    else pending.resolve((m as { result?: unknown }).result);
   }
 
   /**
@@ -220,6 +377,11 @@ export class ACPProtocolHandler {
       session.abort.abort();
     }
     this.sessions.clear();
+    for (const [, p] of this.pendingOut) {
+      clearTimeout(p.timer);
+      p.reject(new Error('protocol handler closed'));
+    }
+    this.pendingOut.clear();
   }
 
   // ────────────────────────────────────────────────────────────────────
@@ -290,7 +452,10 @@ export class ACPProtocolHandler {
   }
 
   private async handleInitialize(id: string | number, params: unknown): Promise<boolean> {
-    const p = (params ?? {}) as { protocolVersion?: unknown };
+    const p = (params ?? {}) as { protocolVersion?: unknown; clientCapabilities?: ClientCapabilities };
+    if (p.clientCapabilities && typeof p.clientCapabilities === 'object') {
+      this.clientCapabilities = p.clientCapabilities;
+    }
     const requested = typeof p.protocolVersion === 'number' ? p.protocolVersion : 1;
     if (requested !== ACP_PROTOCOL_VERSION) {
       await this.sendError(
@@ -309,7 +474,10 @@ export class ACPProtocolHandler {
         agentCapabilities: {
           loadSession: true,
           promptCapabilities: {
-            image: false,
+            // We route ACP image blocks into the core agent's multimodal
+            // input (server-agent-turn.promptToAgentInput); whether the
+            // model can see them is the configured provider's concern.
+            image: true,
             audio: false,
             embeddedContext: true,
           },
@@ -375,6 +543,7 @@ export class ACPProtocolHandler {
     };
     this.sessions.set(sessionId, state);
     this.onSessionNew(state);
+    await this.persist(state);
 
     // Per spec, the server MAY emit current_mode_update /
     // config_option_update / available_commands_update notifications
@@ -411,14 +580,57 @@ export class ACPProtocolHandler {
   private async handleSessionLoad(id: string | number, params: unknown): Promise<boolean> {
     const p = (params ?? {}) as { sessionId?: unknown; cwd?: unknown; mcpServers?: unknown };
     const sessionId = typeof p.sessionId === 'string' ? p.sessionId : null;
-    const existing = sessionId ? this.sessions.get(sessionId) : undefined;
+    const loadCwd = typeof p.cwd === 'string' ? p.cwd : undefined;
+    let existing = sessionId ? this.sessions.get(sessionId) : undefined;
+
+    // Cold path: not in memory but persisted (server restarted). Restore the
+    // session state + replay its stored history. The agent's own model
+    // context starts fresh — the client UI is made whole via replay.
+    if (!existing && sessionId && this.store) {
+      const persisted = await this.store.load(sessionId);
+      if (persisted) {
+        const restored: SessionState = {
+          id: sessionId,
+          cwd: persisted.cwd ?? loadCwd ?? this.defaultCwd,
+          abort: new AbortController(),
+          modeId: persisted.modeId ?? DEFAULT_MODE_ID,
+          createdAt: persisted.createdAt ?? new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          ...(persisted.title !== undefined ? { title: persisted.title } : {}),
+        };
+        this.sessions.set(sessionId, restored);
+        // Prime the turn engine so the next prompt's Agent resumes the
+        // model's context, not just the client UI.
+        this.seedFor?.(sessionId, persisted.history ?? []);
+        for (const update of persisted.history ?? []) {
+          await this.sendNotification({ sessionId, update });
+        }
+        await this.sendNotification({
+          sessionId,
+          update: { sessionUpdate: 'current_mode_update', modeId: restored.modeId },
+        });
+        await this.transport.send(toWire({
+          jsonrpc: '2.0',
+          id,
+          result: {
+            initialMode: { currentModeId: restored.modeId, availableModes: this.modes },
+          },
+        }));
+        return false;
+      }
+    }
 
     if (existing) {
       // Session exists in memory — restore it.
       existing.updatedAt = new Date().toISOString();
-      // Replay the conversation: for now we emit a single info update
-      // since we don't persist full history. The client gets the mode
-      // and config state back.
+      // Replay the recorded conversation history (user/agent message
+      // chunks) so the reconnecting client sees the prior turns.
+      const replay = sessionId ? this.replayFor?.(sessionId) : undefined;
+      if (replay) {
+        for (const update of replay) {
+          await this.sendNotification({ sessionId, update });
+        }
+      }
       await this.sendNotification({
         sessionId,
         update: {
@@ -591,11 +803,63 @@ export class ACPProtocolHandler {
     const onCancel = (): void => turnSignal.abort();
     session.abort.signal.addEventListener('abort', onCancel, { once: true });
 
+    // Client-callback surface for this turn: lets the agent's tools ask
+    // the connected client for permission, and use the client's filesystem
+    // and terminal (when advertised) instead of the local ones.
+    const api: RunTurnApi = {
+      clientCapabilities: this.clientCapabilities,
+      requestPermission: async (req) => {
+        const res = await this.request('session/request_permission', {
+          sessionId,
+          toolCall: req.toolCall,
+          options: req.options,
+        });
+        const outcome = (res as { outcome?: RequestPermissionOutcome } | undefined)?.outcome;
+        return outcome ?? { outcome: 'cancelled' };
+      },
+      readTextFile: async (params) => {
+        const res = await this.request('fs/read_text_file', { sessionId, ...params });
+        return String((res as { content?: unknown })?.content ?? '');
+      },
+      writeTextFile: async (params) => {
+        await this.request('fs/write_text_file', { sessionId, ...params });
+      },
+      runTerminal: async ({ command, args, cwd }) => {
+        const created = (await this.request('terminal/create', {
+          sessionId,
+          command,
+          ...(args ? { args } : {}),
+          ...(cwd ? { cwd } : {}),
+        })) as { terminalId?: string };
+        const terminalId = created?.terminalId;
+        if (!terminalId) return { output: '', exitCode: null };
+        try {
+          const exit = (await this.request('terminal/wait_for_exit', { sessionId, terminalId })) as {
+            exitCode?: number | null;
+          };
+          const out = (await this.request('terminal/output', { sessionId, terminalId })) as {
+            output?: unknown;
+          };
+          return {
+            output: String(out?.output ?? ''),
+            exitCode: typeof exit?.exitCode === 'number' ? exit.exitCode : null,
+          };
+        } finally {
+          try {
+            await this.request('terminal/release', { sessionId, terminalId });
+          } catch {
+            // best-effort release
+          }
+        }
+      },
+    };
+
     let result: RunTurnResult;
     try {
       result = await this.runTurn(
         { sessionId, prompt: p.prompt as ContentBlock[], signal: turnSignal.signal },
         (update) => this.sendNotification({ sessionId, update }),
+        api,
       );
     } catch (err) {
       session.abort.signal.removeEventListener('abort', onCancel);
@@ -605,6 +869,7 @@ export class ACPProtocolHandler {
     }
     session.abort.signal.removeEventListener('abort', onCancel);
     session.updatedAt = new Date().toISOString();
+    await this.persist(session);
 
     await this.transport.send(toWire({
       jsonrpc: '2.0',
@@ -710,6 +975,16 @@ export class ACPProtocolHandler {
 
   private async sendNotification(params: unknown): Promise<void> {
     await this.transport.send(toWire({ jsonrpc: '2.0', method: 'session/update', params }));
+  }
+
+  /** Best-effort durable persistence of a session + its recorded history. */
+  private async persist(state: SessionState): Promise<void> {
+    if (!this.store) return;
+    try {
+      await this.store.save(state, this.replayFor?.(state.id));
+    } catch {
+      // persistence is best-effort — never fail a request because the disk hiccuped
+    }
   }
 
   private async sendError(

--- a/packages/acp/src/agent/server-agent-turn.ts
+++ b/packages/acp/src/agent/server-agent-turn.ts
@@ -38,15 +38,17 @@
  * it. On abort, the adapter maps the resulting `AbortError` to
  * `{stopReason: 'cancelled'}`.
  */
-import type { Agent } from '@wrongstack/core';
+import type { Agent, AgentInput } from '@wrongstack/core';
 import type {
   ContentBlock,
   PlanEntry,
   StopReason,
+  ToolKind,
   UsageCost,
 } from '../types/acp-v1.js';
 import type {
   RunTurn,
+  RunTurnApi,
   RunTurnResult,
 } from './protocol-handler.js';
 
@@ -56,8 +58,18 @@ export interface ACPServerAgentTurnOptions {
    * Called once per session on the first `session/prompt` turn.
    * The factory must isolate each agent — sharing one agent
    * across sessions would defeat v1's session-isolation model.
+   *
+   * `api` (when provided) is the client-callback surface: ask the client
+   * for permission, and use the client's filesystem/terminal when it
+   * advertises those capabilities. A factory that wires it builds a
+   * client-backed permission policy and ACP-backed fs/terminal tools
+   * instead of silently auto-approving against the local disk.
    */
-  agentFor: (sessionId: string, cwd: string) => Promise<Agent> | Agent;
+  agentFor: (
+    sessionId: string,
+    cwd: string,
+    api?: RunTurnApi,
+  ) => Promise<Agent> | Agent;
   /**
    * Hard wall-clock cap for one turn. The agent's own provider
    * timeout is layered under this; this cap is a safety belt.
@@ -66,25 +78,64 @@ export interface ACPServerAgentTurnOptions {
   timeoutMs?: number | undefined;
 }
 
+/** A recorded conversation turn, replayable on `session/load`. */
+export interface SessionReplayUpdate {
+  sessionUpdate: 'user_message_chunk' | 'agent_message_chunk';
+  content: { type: 'text'; text: string };
+}
+
+/**
+ * A `RunTurn` that also exposes the recorded per-session history so the
+ * server can replay it on `session/load`.
+ */
+export interface ACPServerAgentTurn {
+  (input: Parameters<RunTurn>[0], emit: Parameters<RunTurn>[1], api?: Parameters<RunTurn>[2]): Promise<RunTurnResult>;
+  /** Recorded user/agent text turns for a session, in order. */
+  replay(sessionId: string): SessionReplayUpdate[];
+  /**
+   * Seed a session's history (from a durable store on cold `session/load`)
+   * so `replay()` returns it AND the next-created `Agent` for the session is
+   * primed with the prior conversation as model context — not just the
+   * client UI. Call before the first post-load `session/prompt`.
+   */
+  seed(sessionId: string, history: ReadonlyArray<{ sessionUpdate: string; content: unknown }>): void;
+}
+
 /**
  * Build a `RunTurn` that owns per-session `Agent` instances and
  * delegates each turn to the appropriate agent. The returned
  * function is reusable across sessions — the agents are kept in a
- * Map keyed by `sessionId`.
+ * Map keyed by `sessionId`. It also records each turn's user/agent
+ * text so the server can replay history on `session/load` (see
+ * `.replay(sessionId)`).
  */
 export function makeACPServerAgentTurn(
   opts: ACPServerAgentTurnOptions,
-): RunTurn {
+): ACPServerAgentTurn {
   const agents = new Map<string, Agent>();
   const timeouts = new Map<string, ReturnType<typeof setTimeout>>();
+  const history = new Map<string, SessionReplayUpdate[]>();
+  // Sessions restored from a durable store whose freshly-created Agent must
+  // be primed with the prior conversation before its first turn runs.
+  const pendingSeed = new Set<string>();
   const timeoutMs = opts.timeoutMs ?? 5 * 60_000;
 
-  return async (input, emit): Promise<RunTurnResult> => {
+  const turn = async (
+    input: Parameters<RunTurn>[0],
+    emit: Parameters<RunTurn>[1],
+    api?: Parameters<RunTurn>[2],
+  ): Promise<RunTurnResult> => {
     // Lazily create an agent for this session on the first turn.
     let agent = agents.get(input.sessionId);
     if (!agent) {
-      agent = await opts.agentFor(input.sessionId, process.cwd());
+      agent = await opts.agentFor(input.sessionId, process.cwd(), api);
       agents.set(input.sessionId, agent);
+      // Cold-load priming: re-feed the restored conversation into the new
+      // agent's context so the MODEL resumes (not just the client UI).
+      if (pendingSeed.has(input.sessionId)) {
+        pendingSeed.delete(input.sessionId);
+        seedAgentContext(agent, history.get(input.sessionId) ?? []);
+      }
     }
 
     // Per-turn safety belt: even if the agent ignores the parent
@@ -96,9 +147,46 @@ export function makeACPServerAgentTurn(
     }, timeoutMs);
     timeouts.set(input.sessionId, timer);
 
+    // Stream the core agent's tool activity to the ACP client as
+    // tool_call / tool_call_update notifications so editors (Zed,
+    // JetBrains, …) render live tool cards + statuses instead of seeing
+    // a silent gap until the final text. We subscribe for the duration
+    // of this turn and detach in the finally block.
+    const unsub: Array<() => void> = [];
+    // Real `Agent` always exposes `.events`; guard for Agent-like fakes.
+    const bus = (agent as { events?: { on?: typeof agent.events.on } }).events;
+    if (bus?.on) {
+      unsub.push(
+        bus.on('tool.started', (e) => {
+          emit({
+            sessionUpdate: 'tool_call',
+            toolCallId: e.id,
+            title: toolTitle(e.name, e.input),
+            kind: toolNameToKind(e.name),
+            status: 'in_progress',
+            ...(isRecord(e.input) ? { rawInput: e.input } : {}),
+          });
+        }),
+        bus.on('tool.executed', (e) => {
+          emit({
+            sessionUpdate: 'tool_call_update',
+            toolCallId: e.id ?? e.name,
+            status: e.ok ? 'completed' : 'failed',
+            ...(e.output !== undefined
+              ? {
+                  content: [
+                    { type: 'content', content: { type: 'text', text: e.output } },
+                  ],
+                }
+              : {}),
+          });
+        }),
+      );
+    }
+
     try {
-      const userMessage = promptToText(input.prompt);
-      const result = await agent.run(userMessage, { signal: input.signal });
+      const userInput = promptToAgentInput(input.prompt);
+      const result = await agent.run(userInput, { signal: input.signal });
 
       // Stream the agent's final text back
       const text = extractText(result);
@@ -108,6 +196,17 @@ export function makeACPServerAgentTurn(
           content: { type: 'text', text },
         });
       }
+
+      // Record the turn so `session/load` can replay the conversation.
+      const userText = promptToText(input.prompt);
+      const hist = history.get(input.sessionId) ?? [];
+      if (userText) {
+        hist.push({ sessionUpdate: 'user_message_chunk', content: { type: 'text', text: userText } });
+      }
+      if (text) {
+        hist.push({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } });
+      }
+      if (hist.length > 0) history.set(input.sessionId, hist);
 
       // Emit plan if the agent provided one
       const plan = extractPlan(result);
@@ -140,8 +239,109 @@ export function makeACPServerAgentTurn(
     } finally {
       clearTimeout(timer);
       timeouts.delete(input.sessionId);
+      for (const u of unsub) u();
     }
   };
+
+  const replay = (sessionId: string): SessionReplayUpdate[] =>
+    history.get(sessionId) ?? [];
+
+  const seed = (
+    sessionId: string,
+    incoming: ReadonlyArray<{ sessionUpdate: string; content: unknown }>,
+  ): void => {
+    if (incoming.length === 0) return;
+    history.set(sessionId, [...incoming] as SessionReplayUpdate[]);
+    pendingSeed.add(sessionId);
+  };
+
+  return Object.assign(turn, { replay, seed });
+}
+
+/**
+ * Prime a freshly-created agent's conversation state with restored history.
+ * Each recorded user/agent chunk becomes a `user`/`assistant` message so the
+ * model continues the prior conversation instead of starting blank.
+ */
+function seedAgentContext(
+  agent: Agent,
+  history: ReadonlyArray<{ sessionUpdate: string; content: unknown }>,
+): void {
+  const state = (agent as { ctx?: { state?: { appendMessage?: (m: unknown) => void } } }).ctx?.state;
+  if (!state?.appendMessage) return;
+  for (const u of history) {
+    const text = (u.content as { text?: unknown } | undefined)?.text;
+    if (typeof text !== 'string' || text.length === 0) continue;
+    const role = u.sessionUpdate === 'user_message_chunk' ? 'user' : 'assistant';
+    state.appendMessage({ role, content: text });
+  }
+}
+
+/** Map a WrongStack tool name to the closest ACP ToolKind for UI grouping. */
+function toolNameToKind(name: string): ToolKind {
+  const n = name.toLowerCase();
+  if (n.includes('read') || n.includes('cat')) return 'read';
+  if (n.includes('write') || n.includes('edit') || n.includes('apply') || n.includes('patch')) return 'edit';
+  if (n.includes('delete') || n.includes('rm')) return 'delete';
+  if (n.includes('move') || n.includes('rename') || n.includes('mv')) return 'move';
+  if (n.includes('grep') || n.includes('glob') || n.includes('search') || n.includes('find')) return 'search';
+  if (n.includes('bash') || n.includes('shell') || n.includes('exec') || n.includes('run') || n.includes('terminal')) return 'execute';
+  if (n.includes('fetch') || n.includes('http') || n.includes('web') || n.includes('url')) return 'fetch';
+  if (n.includes('think') || n.includes('plan')) return 'think';
+  return 'other';
+}
+
+/** A short, human-readable title for a tool call card. */
+function toolTitle(name: string, input: unknown): string {
+  if (isRecord(input)) {
+    const path = input.path ?? input.file ?? input.filePath ?? input.pattern ?? input.command;
+    if (typeof path === 'string' && path.length > 0) {
+      return `${name}: ${path.length > 80 ? `${path.slice(0, 77)}…` : path}`;
+    }
+  }
+  return name;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Convert an ACP `ContentBlock[]` prompt into a core `AgentInput`.
+ *
+ * When the prompt is all text we return a plain string (the common,
+ * cheapest path). When it carries images we build a multimodal
+ * `ContentBlock[]` the provider can pass to a vision-capable model.
+ * Audio and resource blocks have no core representation yet, so they're
+ * recorded as bracketed text placeholders alongside the other content.
+ */
+function promptToAgentInput(blocks: readonly ContentBlock[]): AgentInput {
+  const hasImage = blocks.some((b) => b.type === 'image');
+  if (!hasImage) {
+    return promptToText(blocks);
+  }
+  const out: AgentInput = [];
+  for (const b of blocks) {
+    if (b.type === 'text') {
+      out.push({ type: 'text', text: b.text });
+    } else if (b.type === 'image') {
+      out.push({
+        type: 'image',
+        source: { type: 'base64', media_type: b.mimeType, data: b.data },
+      });
+    } else if (b.type === 'audio') {
+      out.push({ type: 'text', text: `[audio: ${b.mimeType}]` });
+    } else if (b.type === 'resource') {
+      const text =
+        'text' in b.resource && typeof b.resource.text === 'string'
+          ? b.resource.text
+          : `[embedded resource: ${b.resource.uri}]`;
+      out.push({ type: 'text', text });
+    } else if (b.type === 'resource_link') {
+      out.push({ type: 'text', text: `[resource link: ${b.uri}]` });
+    }
+  }
+  return out;
 }
 
 /**

--- a/packages/acp/src/agent/stdio-transport.ts
+++ b/packages/acp/src/agent/stdio-transport.ts
@@ -18,6 +18,18 @@ export interface AgentServerTransport {
   onMessage(handler: (msg: ACPMessage) => void): () => void;
 }
 
+/**
+ * Minimal client-side transport contract `ACPSession` drives. `ClientTransport`
+ * (stdio subprocess) and `WebSocketClientTransport` (remote) both implement it,
+ * so the session is agnostic to how bytes reach the agent.
+ */
+export interface ACPClientTransport {
+  start(): Promise<void>;
+  send(msg: ACPMessage): Promise<void>;
+  onMessage(handler: (msg: ACPMessage) => void): () => void;
+  stop(): void;
+}
+
 export class StdioTransport implements AgentServerTransport {
   private readonly stdin = process.stdin;
   private readonly stdout = process.stdout;
@@ -147,7 +159,7 @@ export interface ACPChildProcess extends EventEmitter {
   kill(): void;
 }
 
-export class ClientTransport {
+export class ClientTransport implements ACPClientTransport {
   private child: ACPChildProcess | null = null;
   private buffer = '';
   private readonly handlers = new Set<(msg: ACPMessage) => void>();

--- a/packages/acp/src/agent/wrongstack-acp-agent.ts
+++ b/packages/acp/src/agent/wrongstack-acp-agent.ts
@@ -32,6 +32,7 @@ import {
   ACPProtocolHandler,
   type RunTurn,
   type RunTurnResult,
+  type SessionPersistence,
 } from './protocol-handler.js';
 import { StdioTransport } from './stdio-transport.js';
 
@@ -49,6 +50,22 @@ export interface WrongStackACPServerOptions {
   host?: string | undefined;
   /** Emit the pre-v1 startup marker on stdio. Defaults to false. */
   legacyStartupMarker?: boolean | undefined;
+  /**
+   * Conversation-history source for `session/load` replay. Pass
+   * `makeACPServerAgentTurn(...).replay` here so a reconnecting client
+   * gets prior turns streamed back.
+   */
+  replayFor?: ((sessionId: string) => Array<{ sessionUpdate: string; content: unknown }>) | undefined;
+  /**
+   * Cold-load seed hook. Pass `makeACPServerAgentTurn(...).seed` so a
+   * restored session's Agent resumes the model context, not just the UI.
+   */
+  seedFor?: ((sessionId: string, history: Array<{ sessionUpdate: string; content: unknown }>) => void) | undefined;
+  /**
+   * Durable session store. When set, sessions + history are persisted and
+   * restored across restarts for `session/load`. Pass an `ACPSessionStore`.
+   */
+  store?: SessionPersistence | undefined;
 }
 
 export class WrongStackACPServer {
@@ -68,6 +85,9 @@ export class WrongStackACPServer {
       defaultCwd: opts.defaultCwd ?? process.cwd(),
       runTurn,
       agentName: opts.agentName,
+      ...(opts.replayFor ? { replayFor: opts.replayFor } : {}),
+      ...(opts.seedFor ? { seedFor: opts.seedFor } : {}),
+      ...(opts.store ? { store: opts.store } : {}),
     });
   }
 
@@ -154,18 +174,23 @@ export class WrongStackACPServer {
         return;
       }
 
-      // Process the message and return the response
-      // For HTTP transport, we buffer notifications and return them
-      // inline with the response (Streamable HTTP pattern).
+      // Process the message and return the response. For HTTP transport we
+      // must NOT let the handler write to stdout — instead we intercept
+      // `transport.send` and capture the JSON-RPC response + any buffered
+      // notifications, then return them inline (Streamable HTTP pattern).
       const notifications: unknown[] = [];
+      let response: ACPMessage | null = null;
       const originalSend = this.transport.send.bind(this.transport);
       this.transport.send = async (m: ACPMessage) => {
-        // If it's a notification (session/update), buffer it
-        if (m.method === 'session/update' && m.id === undefined) {
+        if (m.id !== undefined && (m.result !== undefined || m.error !== undefined)) {
+          // The JSON-RPC response to this request — capture, don't write
+          // to stdout (which is meaningless over HTTP).
+          response = m;
+        } else if (m.method === 'session/update') {
           notifications.push(m.params);
         } else {
-          // Responses go to the original send
-          await originalSend(m);
+          // Any other server-initiated notification — buffer it too.
+          notifications.push(m);
         }
       };
 
@@ -175,15 +200,11 @@ export class WrongStackACPServer {
         this.transport.send = originalSend;
       }
 
-      // Get the response that was sent
-      const sent = this.transport as { lastSent?: unknown };
-      const lastResponse = (sent as { lastResponse?: unknown }).lastResponse;
-
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      const responseBody = {
-        result: lastResponse,
-        notifications,
-      };
+      const responseBody =
+        response !== null
+          ? { ...(response as ACPMessage), notifications }
+          : { notifications };
       res.end(JSON.stringify(responseBody));
     });
 

--- a/packages/acp/src/agent/ws-bridge-transport.ts
+++ b/packages/acp/src/agent/ws-bridge-transport.ts
@@ -1,0 +1,72 @@
+/**
+ * WsBridgeTransport — an `AgentServerTransport` backed by a single
+ * bidirectional message channel (one WebSocket connection).
+ *
+ * Unlike stdio (a process-wide pipe driven by a read loop) or HTTP (one
+ * request/response per POST, notifications buffered), a WebSocket is a live
+ * full-duplex channel: the agent can stream `session/update` notifications
+ * and make `session/request_permission` callbacks WHILE a turn runs. This
+ * transport is the seam that lets `ACPProtocolHandler` drive one such
+ * connection.
+ *
+ * It is dependency-free and structural: the caller (the CLI, which already
+ * depends on `ws`) constructs it with a `send` sink and feeds inbound
+ * messages via `receive(msg)`. One handler + one transport per connection.
+ */
+import type { ACPMessage } from '../types/acp-messages.js';
+import type { AgentServerTransport } from './stdio-transport.js';
+
+export class WsBridgeTransport implements AgentServerTransport {
+  private readonly handlers = new Set<(msg: ACPMessage) => void>();
+  private closed = false;
+
+  /** @param sink Called with each outbound message to write to the socket. */
+  constructor(private readonly sink: (msg: ACPMessage) => void) {}
+
+  send(msg: ACPMessage): Promise<void> {
+    if (this.closed) return Promise.resolve();
+    try {
+      this.sink(msg);
+    } catch {
+      // socket write failures tear the connection down elsewhere
+    }
+    return Promise.resolve();
+  }
+
+  sendRaw(): void {
+    // Raw byte writes have no meaning over a JSON-message WebSocket.
+  }
+
+  read(): Promise<ACPMessage | null> {
+    // The WS server drives the handler via handleMessage(receive); the
+    // read-loop model isn't used for this transport.
+    return Promise.resolve(null);
+  }
+
+  onMessage(handler: (msg: ACPMessage) => void): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.handlers.clear();
+  }
+
+  /**
+   * Feed one inbound message from the socket. Fires the registered
+   * `onMessage` handlers (which route JSON-RPC responses to pending
+   * outbound requests inside the handler). Inbound *requests* are processed
+   * by the caller via `handler.handleMessage(msg)` — call both per message.
+   */
+  receive(msg: ACPMessage): void {
+    if (this.closed) return;
+    for (const handler of [...this.handlers]) {
+      try {
+        handler(msg);
+      } catch {
+        // a faulty consumer must not break the socket pump
+      }
+    }
+  }
+}

--- a/packages/acp/src/client/acp-session.ts
+++ b/packages/acp/src/client/acp-session.ts
@@ -8,11 +8,16 @@
  * Spec: https://agentclientprotocol.com/protocol/v1/overview
  * Design: see ./acp-session.design.md in this directory.
  */
-import { ClientTransport } from '../agent/stdio-transport.js';
+import { ClientTransport, type ACPClientTransport } from '../agent/stdio-transport.js';
 import type { ACPMessage } from '../types/acp-messages.js';
+import {
+  WebSocketClientTransport,
+  type WebSocketClientTransportOptions,
+} from './websocket-transport.js';
 import {
   ACP_PROTOCOL_VERSION,
   type AgentCapabilities,
+  type AnySessionUpdate,
   type AuthMethod,
   type ContentBlock,
   type McpServer,
@@ -20,7 +25,10 @@ import {
   type SessionId,
   type SessionInfo,
   type StopReason,
+  type ToolCallContent,
+  type ToolCallStatus,
   type ToolCallUpdateNotification,
+  type ToolKind,
   type UsageCost,
 } from '../types/acp-v1.js';
 import { FileServer, FsError } from './file-server.js';
@@ -59,13 +67,65 @@ export interface ACPSessionOptions {
   mcpServers?: McpServer[] | undefined;
 }
 
+/**
+ * A captured file diff emitted by the agent during a turn (via a tool
+ * call's `diff` content). `oldText: null` means the file was created.
+ */
+export interface ACPCapturedDiff {
+  path: string;
+  oldText: string | null;
+  newText: string;
+}
+
+/**
+ * A captured tool call the agent ran during a turn. We collapse the
+ * `tool_call` + subsequent `tool_call_update` notifications for the same
+ * `toolCallId` into one record carrying its latest status.
+ */
+export interface ACPCapturedToolCall {
+  toolCallId: string;
+  title: string;
+  kind?: ToolKind | undefined;
+  status: ToolCallStatus;
+  /** Terminal/command output or text content surfaced by the tool, if any. */
+  rawOutput?: Record<string, unknown> | undefined;
+  rawInput?: Record<string, unknown> | undefined;
+}
+
 export interface ACPSessionRunResult {
   text: string;
   stopReason: StopReason;
   hasText: boolean;
   usage?: { used: number; size: number; cost?: UsageCost | undefined } | undefined;
   plan?: PlanEntry[] | undefined;
+  /** Tool calls the agent ran this turn (deduped by toolCallId). */
+  toolCalls: ACPCapturedToolCall[];
+  /** File diffs the agent produced this turn. */
+  diffs: ACPCapturedDiff[];
+  /** Agent "thinking" text emitted via thought_chunk, concatenated. */
+  thoughts: string;
 }
+
+/**
+ * Live progress callback. Invoked for every `session/update` notification
+ * the agent streams during a `prompt()` turn, in arrival order, BEFORE the
+ * turn resolves. Lets the host render tool activity / text deltas / diffs
+ * as they happen instead of waiting for the buffered final result.
+ *
+ * The raw `update` (the discriminated `session/update` payload) is passed
+ * through verbatim so callers can switch on `update.sessionUpdate`.
+ */
+export type ACPProgressHandler = (event: ACPProgressEvent) => void;
+
+export type ACPProgressEvent =
+  | { type: 'message'; text: string }
+  | { type: 'thought'; text: string }
+  | { type: 'tool_call'; toolCall: ACPCapturedToolCall }
+  | { type: 'tool_call_update'; toolCall: ACPCapturedToolCall }
+  | { type: 'diff'; diff: ACPCapturedDiff }
+  | { type: 'plan'; entries: PlanEntry[] }
+  | { type: 'usage'; usage: { used: number; size: number; cost?: UsageCost | undefined } }
+  | { type: 'raw'; update: AnySessionUpdate };
 
 export type ACPSessionErrorKind =
   | 'spawn_failed'
@@ -117,7 +177,7 @@ function isJsonRpcError(v: unknown): v is JsonRpcError {
 }
 
 export class ACPSession {
-  private readonly transport: ClientTransport;
+  private readonly transport: ACPClientTransport;
   private readonly fileServer: FileServer;
   private readonly terminalServer: TerminalServer;
   private readonly permissionPolicy: PermissionPolicy;
@@ -136,8 +196,10 @@ export class ACPSession {
   private agentCapabilities: AgentCapabilities = {};
   private agentInfo: { name: string; title?: string | undefined; version: string } | null = null;
   private authMethods: AuthMethod[] = [];
+  /** Protocol version negotiated with the agent during initialize. */
+  private negotiatedVersion: number = ACP_PROTOCOL_VERSION;
 
-  private constructor(opts: ACPSessionOptions, transport: ClientTransport) {
+  private constructor(opts: ACPSessionOptions, transport: ACPClientTransport) {
     this.opts = opts;
     this.transport = transport;
     this.timeoutMs = opts.timeoutMs ?? 5 * 60_000;
@@ -188,6 +250,11 @@ export class ACPSession {
     return this.sessionId;
   }
 
+  /** Protocol version negotiated during initialize. */
+  getNegotiatedVersion(): number {
+    return this.negotiatedVersion;
+  }
+
   // ──────────────────────────────────────────────────────────────────────
   // Lifecycle — start
   // ──────────────────────────────────────────────────────────────────────
@@ -206,11 +273,45 @@ export class ACPSession {
     if (opts.env !== undefined) transportOpts.env = opts.env;
     if (opts.cwd !== undefined) transportOpts.cwd = opts.cwd;
     const transport = new ClientTransport(transportOpts);
+    return ACPSession.attach(opts, transport, `failed to spawn ${opts.command}`);
+  }
+
+  /**
+   * Connect to a REMOTE ACP agent over a WebSocket instead of spawning a
+   * local subprocess. `opts.command` is ignored for the wire (a label is
+   * still useful for `role`); everything else (projectRoot sandbox for
+   * fs/terminal, timeouts, permission policy, MCP servers) applies the same.
+   */
+  static async connectWebSocket(
+    wsOpts: WebSocketClientTransportOptions,
+    opts: ACPSessionOptions,
+  ): Promise<ACPSession> {
+    const transport = new WebSocketClientTransport(wsOpts);
+    return ACPSession.attach(opts, transport, `failed to connect to ${wsOpts.url}`);
+  }
+
+  /**
+   * Connect using a caller-supplied transport. Lets advanced callers plug
+   * in their own wire (SDK streams, in-process pipes, test doubles).
+   */
+  static async connect(
+    transport: ACPClientTransport,
+    opts: ACPSessionOptions,
+  ): Promise<ACPSession> {
+    return ACPSession.attach(opts, transport, 'failed to connect transport');
+  }
+
+  /** Shared connect path: start the transport, install dispatch, handshake. */
+  private static async attach(
+    opts: ACPSessionOptions,
+    transport: ACPClientTransport,
+    spawnErrLabel: string,
+  ): Promise<ACPSession> {
     try {
       await transport.start();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      throw new ACPSessionError('spawn_failed', `failed to spawn ${opts.command}: ${msg}`, err);
+      throw new ACPSessionError('spawn_failed', `${spawnErrLabel}: ${msg}`, err);
     }
 
     const session = new ACPSession(opts, transport);
@@ -259,12 +360,19 @@ export class ACPSession {
       agentInfo?: { name: string; title?: string | undefined; version: string };
       authMethods?: AuthMethod[];
     };
-    if (r.protocolVersion !== ACP_PROTOCOL_VERSION) {
+    // Negotiation per spec: the client advertises its latest supported
+    // version; the agent replies with the version both will use — the
+    // client's if the agent supports it, otherwise the agent's own latest.
+    // We therefore accept any version <= ours (we can speak it) and only
+    // reject a version HIGHER than we support (the agent demands a protocol
+    // we don't implement). Equal is the common path.
+    if (r.protocolVersion > ACP_PROTOCOL_VERSION) {
       throw new ACPSessionError(
         'unsupported_capability',
-        `agent speaks protocolVersion=${r.protocolVersion}, client speaks ${ACP_PROTOCOL_VERSION}`,
+        `agent requires protocolVersion=${r.protocolVersion}, client supports up to ${ACP_PROTOCOL_VERSION}`,
       );
     }
+    this.negotiatedVersion = r.protocolVersion;
     // Store agent metadata
     this.agentCapabilities = r.agentCapabilities ?? {};
     this.agentInfo = r.agentInfo ?? null;
@@ -600,7 +708,11 @@ export class ACPSession {
    * The result is the same shape as a normal turn, with
    * `stopReason === 'cancelled'`.
    */
-  async prompt(blocks: ContentBlock[], signal: AbortSignal): Promise<ACPSessionRunResult> {
+  async prompt(
+    blocks: ContentBlock[],
+    signal: AbortSignal,
+    onProgress?: ACPProgressHandler,
+  ): Promise<ACPSessionRunResult> {
     if (this.closed) {
       throw new ACPSessionError('closed', 'session is closed');
     }
@@ -611,7 +723,7 @@ export class ACPSession {
     // Pre-aborted signals short-circuit BEFORE we create a session
     // and before any wire activity.
     if (signal.aborted) {
-      return { text: '', stopReason: 'cancelled', hasText: false };
+      return emptyRunResult('cancelled');
     }
 
     if (!this.sessionId) {
@@ -619,6 +731,7 @@ export class ACPSession {
     }
 
     this.resetScratch();
+    this.progressHandler = onProgress ?? null;
 
     const promptId = this.allocId();
     const turnPromise = this.sendRequest(
@@ -656,6 +769,7 @@ export class ACPSession {
       throw new ACPSessionError('prompt_failed', `session/prompt failed: ${msg}`, err);
     } finally {
       signal.removeEventListener('abort', onAbort);
+      this.progressHandler = null;
     }
 
     this.state = 'done';
@@ -670,6 +784,9 @@ export class ACPSession {
       hasText: finalText.length > 0,
       usage: this.scratch.usage,
       plan: this.scratch.plan,
+      toolCalls: [...this.scratch.toolCalls.values()],
+      diffs: this.scratch.diffs,
+      thoughts: this.scratch.thoughts,
     };
   }
 
@@ -889,31 +1006,48 @@ export class ACPSession {
     const update = (msg as { params?: { update?: unknown } }).params?.update;
     if (typeof update !== 'object' || update === null) return;
     const u = update as { sessionUpdate?: string; [k: string]: unknown };
+    // Always surface the raw update so callers that want full fidelity
+    // (forwarding to an event bus, etc.) never lose a notification.
+    this.emitProgress({ type: 'raw', update: u as AnySessionUpdate });
     switch (u.sessionUpdate) {
       case 'agent_message_chunk': {
         const text = extractText(u.content);
-        if (text) this.accumulatedText(text);
+        if (text) {
+          this.scratch.text += text;
+          this.emitProgress({ type: 'message', text });
+        }
         return;
       }
-      case 'thought_chunk':
+      case 'thought_chunk': {
+        const text = extractText(u.content);
+        if (text) {
+          this.scratch.thoughts += text;
+          this.emitProgress({ type: 'thought', text });
+        }
         return;
+      }
       case 'tool_call':
-      case 'tool_call_update':
+      case 'tool_call_update': {
+        this.captureToolCall(u, u.sessionUpdate === 'tool_call');
         return;
+      }
       case 'plan':
         if (Array.isArray(u.entries)) {
-          this.accumulatedPlan(u.entries as PlanEntry[]);
+          this.scratch.plan = u.entries as PlanEntry[];
+          this.emitProgress({ type: 'plan', entries: u.entries as PlanEntry[] });
         }
         return;
       case 'usage_update':
         if (typeof u.used === 'number' && typeof u.size === 'number') {
-          this.accumulatedUsage({
+          const usage = {
             used: u.used,
             size: u.size,
             ...(typeof u.cost === 'object' && u.cost !== null
               ? { cost: u.cost as UsageCost }
               : {}),
-          });
+          };
+          this.scratch.usage = usage;
+          this.emitProgress({ type: 'usage', usage });
         }
         return;
       case 'available_commands_update':
@@ -929,25 +1063,82 @@ export class ACPSession {
     }
   }
 
+  /**
+   * Fold a `tool_call` / `tool_call_update` notification into the scratch
+   * tool-call map (deduped by toolCallId), extract any `diff` content into
+   * the diffs list, and emit live progress.
+   */
+  private captureToolCall(
+    u: { [k: string]: unknown },
+    isNew: boolean,
+  ): void {
+    const toolCallId = typeof u.toolCallId === 'string' ? u.toolCallId : '';
+    if (!toolCallId) return;
+    const prev = this.scratch.toolCalls.get(toolCallId);
+    const record: ACPCapturedToolCall = {
+      toolCallId,
+      title:
+        typeof u.title === 'string'
+          ? u.title
+          : (prev?.title ?? toolCallId),
+      kind: (typeof u.kind === 'string' ? (u.kind as ToolKind) : prev?.kind),
+      status:
+        typeof u.status === 'string'
+          ? (u.status as ToolCallStatus)
+          : (prev?.status ?? (isNew ? 'pending' : 'in_progress')),
+      rawInput:
+        isRecord(u.rawInput) ? u.rawInput : prev?.rawInput,
+      rawOutput:
+        isRecord(u.rawOutput) ? u.rawOutput : prev?.rawOutput,
+    };
+    this.scratch.toolCalls.set(toolCallId, record);
+
+    // Pull any diff content out of the tool call so the host can show
+    // what changed. The agent sends diffs as ToolCallContent of type 'diff'.
+    if (Array.isArray(u.content)) {
+      for (const c of u.content as ToolCallContent[]) {
+        if (c && typeof c === 'object' && c.type === 'diff') {
+          const diff: ACPCapturedDiff = {
+            path: c.path,
+            oldText: c.oldText,
+            newText: c.newText,
+          };
+          this.scratch.diffs.push(diff);
+          this.emitProgress({ type: 'diff', diff });
+        }
+      }
+    }
+
+    this.emitProgress({
+      type: isNew ? 'tool_call' : 'tool_call_update',
+      toolCall: record,
+    });
+  }
+
+  private emitProgress(event: ACPProgressEvent): void {
+    if (!this.progressHandler) return;
+    try {
+      this.progressHandler(event);
+    } catch {
+      // A faulty host handler must never break the wire pump.
+    }
+  }
+
+  /** Live progress handler installed for the duration of a `prompt()` turn. */
+  private progressHandler: ACPProgressHandler | null = null;
+
   // Per-prompt scratch state
   private scratch: {
     text: string;
+    thoughts: string;
     plan?: PlanEntry[];
     usage?: { used: number; size: number; cost?: UsageCost | undefined };
-  } = { text: '' };
-
-  private accumulatedText(chunk: string): void {
-    this.scratch.text += chunk;
-  }
-  private accumulatedPlan(entries: PlanEntry[]): void {
-    this.scratch.plan = entries;
-  }
-  private accumulatedUsage(u: { used: number; size: number; cost?: UsageCost | undefined }): void {
-    this.scratch.usage = u;
-  }
+    toolCalls: Map<string, ACPCapturedToolCall>;
+    diffs: ACPCapturedDiff[];
+  } = { text: '', thoughts: '', toolCalls: new Map(), diffs: [] };
 
   private resetScratch(): void {
-    this.scratch = { text: '' };
+    this.scratch = { text: '', thoughts: '', toolCalls: new Map(), diffs: [] };
   }
 
   private async handlePermissionRequest(msg: ACPMessage): Promise<void> {
@@ -1108,7 +1299,36 @@ export function audioContent(mimeType: string, data: string): ContentBlock {
 
 function extractText(block: unknown): string {
   if (typeof block !== 'object' || block === null) return '';
-  const b = block as { type?: string; text?: unknown };
+  const b = block as {
+    type?: string;
+    text?: unknown;
+    resource?: { text?: unknown };
+  };
   if (b.type === 'text' && typeof b.text === 'string') return b.text;
+  // Embedded text resources carry their content under `resource.text`.
+  if (
+    b.type === 'resource' &&
+    b.resource &&
+    typeof b.resource === 'object' &&
+    typeof b.resource.text === 'string'
+  ) {
+    return b.resource.text;
+  }
   return '';
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** A fully-populated empty run result (used for pre-aborted short-circuits). */
+function emptyRunResult(stopReason: StopReason): ACPSessionRunResult {
+  return {
+    text: '',
+    stopReason,
+    hasText: false,
+    toolCalls: [],
+    diffs: [],
+    thoughts: '',
+  };
 }

--- a/packages/acp/src/client/index.ts
+++ b/packages/acp/src/client/index.ts
@@ -1,5 +1,7 @@
 export { ClientTransport } from '../agent/stdio-transport.js';
-export type { ClientTransportOptions, ACPChildProcess } from '../agent/stdio-transport.js';
+export type { ClientTransportOptions, ACPChildProcess, ACPClientTransport } from '../agent/stdio-transport.js';
+export { WebSocketClientTransport } from './websocket-transport.js';
+export type { WebSocketClientTransportOptions } from './websocket-transport.js';
 export { ToolTranslator } from './tool-translator.js';
 export {
   ACPSession,
@@ -12,6 +14,16 @@ export type {
   ACPSessionOptions,
   ACPSessionRunResult,
   ACPSessionErrorKind,
+  ACPProgressEvent,
+  ACPProgressHandler,
+  ACPCapturedToolCall,
+  ACPCapturedDiff,
 } from './acp-session.js';
+export {
+  defaultPermissionPolicy,
+  readOnlyPermissionPolicy,
+  makePermissionPolicy,
+} from './permission.js';
+export type { PermissionPolicy, PermissionRequest } from './permission.js';
 export { makeACPSubagentRunner } from '../integration/acp-subagent-runner.js';
 export type { ACPSubagentRunnerOptions } from '../integration/acp-subagent-runner.js';

--- a/packages/acp/src/client/permission.ts
+++ b/packages/acp/src/client/permission.ts
@@ -37,13 +37,13 @@ export type PermissionPolicy = (
  * Real WrongStack permission UIs replace this; the contract is the
  * `PermissionPolicy` function type, not the implementation.
  */
-export const defaultPermissionPolicy: PermissionPolicy = async (req) => {
-  if (req.signal.aborted) return { outcome: 'cancelled' };
-
-  const ranked = [...req.options].sort((a, b) => {
+function pickAllow(
+  options: readonly PermissionOption[],
+): RequestPermissionOutcome {
+  const ranked = [...options].sort((a, b) => {
     const score = (k: PermissionOption['kind']): number => {
-      if (k === 'allow_always') return 0;
-      if (k === 'allow_once') return 1;
+      if (k === 'allow_once') return 0; // prefer once over always — least standing grant
+      if (k === 'allow_always') return 1;
       if (k === 'reject_once') return 2;
       return 3;
     };
@@ -54,4 +54,66 @@ export const defaultPermissionPolicy: PermissionPolicy = async (req) => {
     return { outcome: 'cancelled' };
   }
   return { outcome: 'selected', optionId: chosen.optionId };
+}
+
+function pickReject(
+  options: readonly PermissionOption[],
+): RequestPermissionOutcome {
+  const reject = options.find(
+    (o) => o.kind === 'reject_once' || o.kind === 'reject_always',
+  );
+  return reject ? { outcome: 'selected', optionId: reject.optionId } : { outcome: 'cancelled' };
+}
+
+/**
+ * Tool kinds considered side-effect-free (safe to auto-approve even in a
+ * non-interactive run). Everything else (edit/delete/move/execute) mutates
+ * the workspace or runs commands and should be gated by a real policy.
+ */
+const READ_ONLY_KINDS = new Set(['read', 'search', 'fetch', 'think']);
+
+/**
+ * Default policy: auto-approve the least-standing allow option.
+ *
+ * ⚠️ This auto-approves EVERY tool call, including file writes and shell
+ * commands. It exists so non-interactive contexts (CLI `acp spawn`,
+ * the Director fan-out) work without a human in the loop. Interactive
+ * surfaces (TUI/WebUI) MUST inject a policy that surfaces the request to
+ * the user — pass `permissionPolicy` to `ACPSession` / the subagent runner.
+ * For untrusted agents prefer {@link readOnlyPermissionPolicy}.
+ */
+export const defaultPermissionPolicy: PermissionPolicy = async (req) => {
+  if (req.signal.aborted) return { outcome: 'cancelled' };
+  return pickAllow(req.options);
 };
+
+/**
+ * Safe-by-default policy: auto-approve only side-effect-free tool calls
+ * (read/search/fetch/think); reject anything that would write files or
+ * run commands. Use this when driving an untrusted external agent and no
+ * interactive surface is available to ask the user.
+ */
+export const readOnlyPermissionPolicy: PermissionPolicy = async (req) => {
+  if (req.signal.aborted) return { outcome: 'cancelled' };
+  const kind = req.toolCall.kind;
+  if (kind && READ_ONLY_KINDS.has(kind)) {
+    return pickAllow(req.options);
+  }
+  return pickReject(req.options);
+};
+
+/**
+ * Build a policy from a yes/no decision function. The decider receives the
+ * tool call (title + kind + rawInput) and returns whether to allow it.
+ * This is the seam an interactive host (TUI/WebUI confirm prompt, trust
+ * store, exec-allowlist) plugs into.
+ */
+export function makePermissionPolicy(
+  decide: (req: PermissionRequest) => boolean | Promise<boolean>,
+): PermissionPolicy {
+  return async (req) => {
+    if (req.signal.aborted) return { outcome: 'cancelled' };
+    const allow = await decide(req);
+    return allow ? pickAllow(req.options) : pickReject(req.options);
+  };
+}

--- a/packages/acp/src/client/websocket-transport.ts
+++ b/packages/acp/src/client/websocket-transport.ts
@@ -1,0 +1,173 @@
+/**
+ * WebSocketClientTransport — remote ACP transport for `ACPSession`.
+ *
+ * Connects to a remote ACP agent over a WebSocket (cloud-hosted agents,
+ * separate-process agents reachable over the network). Each WebSocket
+ * message carries exactly one JSON-RPC 2.0 object — message boundaries
+ * are preserved by the WS framing, so (unlike stdio) no newline delimiter
+ * is needed.
+ *
+ * Uses the Node ≥ 22 built-in global `WebSocket` (undici), so there is no
+ * runtime dependency. Per-connection auth headers are not supported by the
+ * WHATWG WebSocket client; authenticate over the protocol instead
+ * (`ACPSession.authenticate`) or embed a token in the URL query string.
+ *
+ * Spec: https://agentclientprotocol.com/protocol/v1/overview (remote transport)
+ */
+
+import type { ACPClientTransport } from '../agent/stdio-transport.js';
+import type { ACPMessage } from '../types/acp-messages.js';
+
+export interface WebSocketClientTransportOptions {
+  /** ws:// or wss:// URL of the remote ACP agent. */
+  url: string;
+  /** Optional WebSocket subprotocols. */
+  protocols?: string | string[] | undefined;
+  /** How long to wait for the socket to open. Default 30s. */
+  handshakeTimeoutMs?: number | undefined;
+}
+
+/** Narrow view of the global WebSocket we rely on (avoids lib.dom typings). */
+interface WSLike {
+  send(data: string): void;
+  close(): void;
+  addEventListener(type: 'open', cb: () => void): void;
+  addEventListener(type: 'error', cb: (ev: unknown) => void): void;
+  addEventListener(type: 'close', cb: () => void): void;
+  addEventListener(type: 'message', cb: (ev: { data: unknown }) => void): void;
+}
+
+type WSConstructor = new (url: string, protocols?: string | string[]) => WSLike;
+
+export class WebSocketClientTransport implements ACPClientTransport {
+  private ws: WSLike | null = null;
+  private readonly handlers = new Set<(msg: ACPMessage) => void>();
+  private closed = false;
+  private readonly opts: WebSocketClientTransportOptions;
+
+  constructor(opts: WebSocketClientTransportOptions) {
+    this.opts = opts;
+  }
+
+  start(): Promise<void> {
+    const WS = (globalThis as { WebSocket?: WSConstructor }).WebSocket;
+    if (!WS) {
+      return Promise.reject(
+        new Error(
+          'global WebSocket is not available — Node ≥ 22 is required for the remote ACP transport',
+        ),
+      );
+    }
+    const timeoutMs = this.opts.handshakeTimeoutMs ?? 30_000;
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const ws = new WS(this.opts.url, this.opts.protocols);
+      this.ws = ws;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        try {
+          ws.close();
+        } catch {
+          // ignore
+        }
+        reject(new Error(`WebSocket failed to open within ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      ws.addEventListener('open', () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      });
+      ws.addEventListener('error', (ev: unknown) => {
+        if (settled) {
+          // Post-open errors just tear the connection down.
+          this.closed = true;
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        const message =
+          ev && typeof ev === 'object' && 'message' in ev
+            ? String((ev as { message: unknown }).message)
+            : 'WebSocket error';
+        reject(new Error(message));
+      });
+      ws.addEventListener('close', () => {
+        this.closed = true;
+      });
+      ws.addEventListener('message', (ev: { data: unknown }) => {
+        this.onData(ev.data);
+      });
+    });
+  }
+
+  send(msg: ACPMessage): Promise<void> {
+    if (this.closed || !this.ws) {
+      return Promise.reject(new Error('WebSocket transport is not open'));
+    }
+    try {
+      this.ws.send(JSON.stringify(msg));
+      return Promise.resolve();
+    } catch (err) {
+      return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  onMessage(handler: (msg: ACPMessage) => void): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+
+  stop(): void {
+    this.closed = true;
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {
+        // already closed
+      }
+      this.ws = null;
+    }
+  }
+
+  private onData(data: unknown): void {
+    const text =
+      typeof data === 'string'
+        ? data
+        : data instanceof ArrayBuffer
+          ? Buffer.from(data).toString('utf8')
+          : Buffer.isBuffer(data)
+            ? data.toString('utf8')
+            : String(data);
+    if (!text.trim()) return;
+    let msg: ACPMessage;
+    try {
+      msg = JSON.parse(text) as ACPMessage;
+    } catch {
+      // A remote agent that frames multiple JSON objects per message is
+      // non-conformant; try newline-splitting as a fallback before dropping.
+      for (const line of text.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          this.dispatch(JSON.parse(line) as ACPMessage);
+        } catch {
+          // skip malformed fragment
+        }
+      }
+      return;
+    }
+    this.dispatch(msg);
+  }
+
+  private dispatch(msg: ACPMessage): void {
+    for (const handler of [...this.handlers]) {
+      try {
+        handler(msg);
+      } catch {
+        // a faulty consumer must not break the socket pump
+      }
+    }
+  }
+}

--- a/packages/acp/src/index.ts
+++ b/packages/acp/src/index.ts
@@ -18,7 +18,9 @@ export type {WrongStackACPServerOptions} from './agent/wrongstack-acp-agent.js';
 
 // Client side (DIR-1: WrongStack spawns external ACP agents)
 export {ClientTransport} from './agent/stdio-transport.js';
-export type {ClientTransportOptions, ACPChildProcess} from './agent/stdio-transport.js';
+export type {ClientTransportOptions, ACPChildProcess, ACPClientTransport} from './agent/stdio-transport.js';
+export {WebSocketClientTransport} from './client/websocket-transport.js';
+export type {WebSocketClientTransportOptions} from './client/websocket-transport.js';
 export {ToolTranslator} from './client/tool-translator.js';
 export type {ToolTranslatorOptions} from './client/tool-translator.js';
 export {makeACPSubagentRunner, makeACPSubagentRunnerWithStop} from './integration/acp-subagent-runner.js';
@@ -37,17 +39,25 @@ export type {
 } from './registry/ensemble-registry.js';
 
 // Client session — the v1-correct ACP client (added in feat/acp-ensemble).
-export {ACPSession, ACPSessionError} from './client/acp-session.js';
+export {ACPSession, ACPSessionError, textContent, imageContent, audioContent} from './client/acp-session.js';
 export type {
   ACPSessionOptions,
   ACPSessionRunResult,
   ACPSessionErrorKind,
+  ACPProgressEvent,
+  ACPProgressHandler,
+  ACPCapturedToolCall,
+  ACPCapturedDiff,
 } from './client/acp-session.js';
 export {FileServer, FsError} from './client/file-server.js';
 export type {FileServerOptions, ReadFileParams, WriteFileParams, FsErrorCode} from './client/file-server.js';
 export {TerminalServer} from './client/terminal-server.js';
 export type {TerminalServerOptions} from './client/terminal-server.js';
-export {defaultPermissionPolicy} from './client/permission.js';
+export {
+  defaultPermissionPolicy,
+  readOnlyPermissionPolicy,
+  makePermissionPolicy,
+} from './client/permission.js';
 export type {PermissionPolicy, PermissionRequest} from './client/permission.js';
 
 // Ensemble runner — fan a single task out to multiple ACP agents.
@@ -57,6 +67,7 @@ export {
   runEnsemble,
   type EnsembleAgentResult,
   type EnsembleCmdResolver,
+  type EnsembleProgressHandler,
   type EnsembleResult,
   type EnsembleRunnerOptions,
 } from './integration/ensemble-runner.js';

--- a/packages/acp/src/integration/acp-subagent-runner.ts
+++ b/packages/acp/src/integration/acp-subagent-runner.ts
@@ -19,8 +19,16 @@ import type {
   SubagentRunner,
   TaskSpec,
 } from '@wrongstack/core';
-import { ACPSession, ACPSessionError, textContent } from '../client/acp-session.js';
+import {
+  ACPSession,
+  ACPSessionError,
+  textContent,
+  type ACPProgressEvent,
+  type ACPProgressHandler,
+} from '../client/acp-session.js';
 import type { ACPSessionErrorKind } from '../client/acp-session.js';
+import type { PermissionPolicy } from '../client/permission.js';
+import type { McpServer } from '../types/acp-v1.js';
 
 export interface ACPSubagentRunnerOptions {
   /** How to spawn the external agent. */
@@ -41,6 +49,32 @@ export interface ACPSubagentRunnerOptions {
    * `fs/write_text_file` calls are bounded to this root.
    */
   projectRoot?: string | undefined;
+  /**
+   * Live progress callback. Forwarded to `ACPSession.prompt` so the host
+   * can render the external agent's tool calls / diffs / text as they
+   * stream, instead of waiting for the buffered final result.
+   */
+  onProgress?: ACPProgressHandler | undefined;
+  /**
+   * Permission policy for the external agent's `session/request_permission`
+   * calls. Defaults to the session's own default. Inject the host's
+   * confirm/trust UI here so an external agent's file writes / commands
+   * are surfaced to a human instead of silently auto-approved.
+   */
+  permissionPolicy?: PermissionPolicy | undefined;
+  /**
+   * MCP servers to expose to the external agent (passed through
+   * `session/new` / `session/load`). Stdio servers are always sent;
+   * HTTP/SSE are filtered by the agent's advertised capabilities.
+   */
+  mcpServers?: McpServer[] | undefined;
+  /**
+   * When true, the underlying `ACPSession` is kept open across multiple
+   * runner invocations (multi-turn conversation — the external agent
+   * keeps its context). The caller MUST call `stop()` to tear it down.
+   * Defaults to false (one process per task).
+   */
+  persistent?: boolean | undefined;
 }
 
 /**
@@ -111,66 +145,99 @@ export async function makeACPSubagentRunner(
  */
 export async function makeACPSubagentRunnerWithStop(
   options: ACPSubagentRunnerOptions,
-): Promise<{ runner: SubagentRunner; stop: () => void }> {
+): Promise<{ runner: SubagentRunner; stop: () => void | Promise<void> }> {
   const projectRoot = options.projectRoot ?? options.cwd ?? process.cwd();
   const timeoutMs = options.timeoutMs ?? 5 * 60_000;
+  const persistent = options.persistent === true;
+
+  // In persistent mode we keep a single session alive across runner calls
+  // so the external agent retains its conversation context (multi-turn).
+  let shared: ACPSession | null = null;
+
+  const startSession = async (): Promise<ACPSession> => {
+    return ACPSession.start({
+      command: options.command,
+      ...(options.args !== undefined ? { args: options.args } : {}),
+      ...(options.env !== undefined ? { env: options.env } : {}),
+      ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+      projectRoot,
+      timeoutMs,
+      role: options.role,
+      ...(options.permissionPolicy !== undefined
+        ? { permissionPolicy: options.permissionPolicy }
+        : {}),
+      ...(options.mcpServers !== undefined ? { mcpServers: options.mcpServers } : {}),
+    });
+  };
 
   const runner: SubagentRunner = async (
     task: TaskSpec,
     ctx: SubagentRunContext,
   ): Promise<SubagentRunOutcome> => {
-    let session: ACPSession | null = null;
+    let session: ACPSession;
+    const reuse = persistent && shared !== null;
     try {
-      session = await ACPSession.start({
-        command: options.command,
-        ...(options.args !== undefined ? { args: options.args } : {}),
-        ...(options.env !== undefined ? { env: options.env } : {}),
-        ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
-        projectRoot,
-        timeoutMs,
-        role: options.role,
-      });
+      session = reuse ? (shared as ACPSession) : await startSession();
+      if (persistent) shared = session;
     } catch (err) {
       // init / spawn failure. Throw a structured error so the host can
       // classify it (SubagentErrorKind).
       throw acpErrorToSubagentError(err, options.role ?? 'acp-subagent');
     }
 
+    // Count real tool calls from the captured stream, and keep the
+    // budget's idle clock fresh on every update so a long-but-working
+    // external agent is never reaped by the watchdog as "stalled".
+    const onProgress: ACPProgressHandler = (event: ACPProgressEvent) => {
+      try {
+        ctx.budget.markActivity();
+      } catch {
+        // markActivity never throws today; guard defensively anyway.
+      }
+      options.onProgress?.(event);
+    };
+
     try {
-      const result = await session.prompt([textContent(task.description)], ctx.signal);
-      // We don't surface plan/usage in the simple SubagentRunOutcome;
-      // a future PR can add them if the TUI/renderer wants to display
-      // them. Treat "no text emitted" as a soft signal (an ACP agent
-      // may legitimately end with no message), not an error.
+      const result = await session.prompt(
+        [textContent(task.description)],
+        ctx.signal,
+        onProgress,
+      );
+      // Surface the real tool-call count captured from the stream. A
+      // text-less turn is a soft signal (an ACP agent may legitimately
+      // end with no message), not an error.
       return {
         result: result.text,
         iterations: 1,
-        toolCalls: 0,
+        toolCalls: result.toolCalls.length,
       };
     } catch (err) {
-      if (err instanceof ACPSessionError && err.kind === 'aborted') {
-        // The host's AbortController fired. Surface a structured
-        // 'aborted_by_parent' so the coordinator's classifier can
-        // branch correctly.
-        throw acpErrorToSubagentError(err, options.role ?? 'acp-subagent');
-      }
       throw acpErrorToSubagentError(err, options.role ?? 'acp-subagent');
     } finally {
-      // Per design: stop() is idempotent. We always close after a turn
-      // — multi-turn conversations are a future feature, not v1.
-      try {
-        await session.close();
-      } catch {
-        // best-effort cleanup
+      // One-shot mode closes after each turn. Persistent mode keeps the
+      // session open; the caller tears it down via stop().
+      if (!persistent) {
+        try {
+          await session.close();
+        } catch {
+          // best-effort cleanup
+        }
       }
     }
   };
 
-  // No long-lived resources outside of `session`, which is created
-  // and destroyed per call. `stop()` is a no-op kept for API parity
-  // with the previous version.
-  const stop = (): void => {
-    // no-op; session is closed in the runner's finally block.
+  // In persistent mode stop() closes the long-lived session; in one-shot
+  // mode it's a no-op (each session is closed in the runner's finally).
+  const stop = async (): Promise<void> => {
+    if (shared) {
+      const s = shared;
+      shared = null;
+      try {
+        await s.close();
+      } catch {
+        // best-effort
+      }
+    }
   };
 
   return { runner, stop };

--- a/packages/acp/src/sdk.ts
+++ b/packages/acp/src/sdk.ts
@@ -68,7 +68,15 @@ export type {
   ACPSessionOptions,
   ACPSessionRunResult,
   ACPSessionErrorKind,
+  ACPProgressEvent,
+  ACPProgressHandler,
+  ACPCapturedToolCall,
+  ACPCapturedDiff,
 } from './client/acp-session.js';
+
+export { WebSocketClientTransport } from './client/websocket-transport.js';
+export type { WebSocketClientTransportOptions } from './client/websocket-transport.js';
+export type { ACPClientTransport } from './agent/stdio-transport.js';
 
 export {
   ACPProtocolHandler,
@@ -126,6 +134,8 @@ export type {
 
 export {
   defaultPermissionPolicy,
+  readOnlyPermissionPolicy,
+  makePermissionPolicy,
 } from './client/permission.js';
 export type {
   PermissionPolicy,

--- a/packages/acp/tests/acp-loopback.test.ts
+++ b/packages/acp/tests/acp-loopback.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Capstone end-to-end loopback test: OUR client (`ACPSession`) talking to
+ * OUR agent (`ACPProtocolHandler`) in-process, with a JSON round-trip on
+ * every hop so serialization mismatches surface. Exercises the functional
+ * features added across both directions at once:
+ *
+ *   - DIR-2 agent streams `tool_call` / `tool_call_update` + a diff (B1)
+ *   - DIR-1 client captures them into the run result (A1) and fires onProgress (A2)
+ *   - DIR-2 agent reads a file via the client's filesystem (B3) — served by
+ *     the client's real `FileServer` over `fs/read_text_file`
+ *   - DIR-2 agent asks the client for permission (B2); the client's default
+ *     policy auto-approves (A3)
+ *
+ * If the two sides disagree on the wire, this test fails where the unit
+ * tests (which use fakes on one side) cannot.
+ */
+
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ACPProtocolHandler, type RunTurn } from '../src/agent/protocol-handler.js';
+import type { ACPClientTransport } from '../src/agent/stdio-transport.js';
+import { WsBridgeTransport } from '../src/agent/ws-bridge-transport.js';
+import { ACPSession } from '../src/client/acp-session.js';
+import type { ACPMessage } from '../src/types/acp-messages.js';
+
+/** JSON round-trip so branded types / undefined fields behave like the wire. */
+function wire<T>(m: T): T {
+  return JSON.parse(JSON.stringify(m)) as T;
+}
+
+let projectRoot: string;
+
+beforeEach(async () => {
+  projectRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'acp-loopback-'));
+});
+afterEach(async () => {
+  await fsp.rm(projectRoot, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('ACP client ↔ server loopback', () => {
+  it('runs a turn end-to-end: tool stream + client fs read + permission', async () => {
+    const notePath = path.join(projectRoot, 'note.txt');
+    await fsp.writeFile(notePath, 'hello from client fs', 'utf8');
+
+    // The agent's per-turn work: stream a tool call + diff, read a file via
+    // the client's fs, ask permission, then echo the file content.
+    let fileContent: string | undefined;
+    let permissionOutcome: unknown;
+    const runTurn: RunTurn = async (_input, emit, api) => {
+      emit({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'tc1',
+        title: 'read note.txt',
+        kind: 'read',
+        status: 'in_progress',
+      });
+      fileContent = await api!.readTextFile({ path: notePath });
+      emit({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'tc1',
+        status: 'completed',
+        content: [{ type: 'diff', path: notePath, oldText: null, newText: fileContent }],
+      });
+      permissionOutcome = await api!.requestPermission({
+        toolCall: { toolCallId: 'tc1', title: 'apply edit', kind: 'edit' },
+        options: [{ optionId: 'allow_once', name: 'Allow', kind: 'allow_once' }],
+      });
+      emit({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: `file says: ${fileContent}` },
+      });
+      return { stopReason: 'end_turn' };
+    };
+
+    // Wire the two sides together with a JSON round-trip on every hop.
+    const clientHandlers = new Set<(m: ACPMessage) => void>();
+    let handler: ACPProtocolHandler;
+
+    const serverTransport = new WsBridgeTransport((m) => {
+      // server → client
+      const msg = wire(m);
+      for (const h of [...clientHandlers]) h(msg);
+    });
+
+    const clientTransport: ACPClientTransport = {
+      start: async () => {},
+      send: async (m) => {
+        // client → server: route responses + process requests
+        const msg = wire(m);
+        serverTransport.receive(msg);
+        void handler.handleMessage(msg);
+      },
+      onMessage: (h) => {
+        clientHandlers.add(h);
+        return () => clientHandlers.delete(h);
+      },
+      stop: () => {},
+    };
+
+    handler = new ACPProtocolHandler({
+      transport: serverTransport,
+      defaultCwd: projectRoot,
+      runTurn,
+    });
+
+    const session = await ACPSession.connect(clientTransport, {
+      command: 'loopback',
+      projectRoot,
+      timeoutMs: 10_000,
+    });
+
+    // Sanity: the real handshake completed over the loopback.
+    expect(session.getAgentInfo()?.name).toBe('wrongstack');
+    expect(session.getCapabilities().promptCapabilities?.image).toBe(true);
+
+    const progress: string[] = [];
+    const result = await session.prompt(
+      [{ type: 'text', text: 'read the note' }],
+      new AbortController().signal,
+      (e) => progress.push(e.type),
+    );
+
+    // Agent side: it actually read the client's file and got permission.
+    expect(fileContent).toBe('hello from client fs');
+    expect(permissionOutcome).toMatchObject({ outcome: 'selected', optionId: 'allow_once' });
+
+    // Client side: captured the stream + final text.
+    expect(result.text).toBe('file says: hello from client fs');
+    expect(result.stopReason).toBe('end_turn');
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]).toMatchObject({ toolCallId: 'tc1', status: 'completed' });
+    expect(result.diffs).toEqual([
+      { path: notePath, oldText: null, newText: 'hello from client fs' },
+    ]);
+    expect(progress).toEqual(
+      expect.arrayContaining(['tool_call', 'tool_call_update', 'diff', 'message']),
+    );
+
+    await session.close();
+  }, 20_000);
+});

--- a/packages/acp/tests/acp-session.test.ts
+++ b/packages/acp/tests/acp-session.test.ts
@@ -157,6 +157,57 @@ describe('ACPSession', () => {
     await session.close();
   });
 
+  it('captures tool calls, diffs and thoughts, and streams them via onProgress', async () => {
+    const session = await startSession();
+    const t = lastTransport();
+
+    const events: string[] = [];
+    const promptP = session.prompt(
+      [textContent('do it')],
+      new AbortController().signal,
+      (e) => events.push(e.type),
+    );
+
+    await new Promise((r) => setImmediate(r));
+    const newMsg = t.sent.find((m) => m.method === 'session/new');
+    t.respond(newMsg!.id!, 'session/new', { sessionId: 'sess_abc' });
+    await new Promise((r) => setImmediate(r));
+    const promptMsg = t.sent.find((m) => m.method === 'session/prompt');
+
+    const update = (u: unknown) =>
+      t.emit({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: { sessionId: 'sess_abc', update: u },
+      } as never as ACPMessage);
+
+    update({ sessionUpdate: 'thought_chunk', content: { type: 'text', text: 'hmm' } });
+    update({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'tc1',
+      title: 'edit a.ts',
+      kind: 'edit',
+      status: 'in_progress',
+      content: [{ type: 'diff', path: 'a.ts', oldText: null, newText: 'new' }],
+    });
+    update({ sessionUpdate: 'tool_call_update', toolCallId: 'tc1', status: 'completed' });
+    update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'done' } });
+    t.respond(promptMsg!.id!, 'session/prompt', { stopReason: 'end_turn' });
+
+    const result = await promptP;
+    expect(result.text).toBe('done');
+    expect(result.thoughts).toBe('hmm');
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]).toMatchObject({ toolCallId: 'tc1', status: 'completed' });
+    expect(result.diffs).toEqual([{ path: 'a.ts', oldText: null, newText: 'new' }]);
+    // Live progress fired for thought, tool_call, diff, tool_call_update, message.
+    expect(events).toEqual(
+      expect.arrayContaining(['thought', 'tool_call', 'diff', 'tool_call_update', 'message']),
+    );
+
+    await session.close();
+  });
+
   it('returns stopReason=cancelled and a session/cancel notification when aborted', async () => {
     const session = await startSession();
     const t = lastTransport();

--- a/packages/acp/tests/acp-subagent-runner.test.ts
+++ b/packages/acp/tests/acp-subagent-runner.test.ts
@@ -18,7 +18,7 @@ const hoisted = vi.hoisted(() => ({
   session: undefined as MockSession | undefined,
   errorKind: undefined as undefined | string,
   errorMessage: undefined as undefined | string,
-  promptResult: undefined as { text: string; stopReason: string; hasText: boolean; plan?: unknown[]; usage?: { used: number; size: number } } | undefined,
+  promptResult: undefined as { text: string; stopReason: string; hasText: boolean; toolCalls: unknown[]; diffs: unknown[]; thoughts: string; plan?: unknown[]; usage?: { used: number; size: number } } | undefined,
   promptError: undefined as unknown,
 }));
 
@@ -100,7 +100,7 @@ beforeEach(() => {
   hoisted.errorKind = undefined;
   hoisted.errorMessage = undefined;
   hoisted.promptError = undefined;
-  hoisted.promptResult = { text: 'ok', stopReason: 'end_turn', hasText: true };
+  hoisted.promptResult = { text: 'ok', stopReason: 'end_turn', hasText: true, toolCalls: [], diffs: [], thoughts: '' };
 });
 
 describe('ACP_AGENT_COMMANDS', () => {
@@ -149,6 +149,9 @@ describe('makeACPSubagentRunner', () => {
       text: 'hello world',
       stopReason: 'end_turn',
       hasText: true,
+      toolCalls: [],
+      diffs: [],
+      thoughts: '',
     };
     const runner = await makeACPSubagentRunner({ command: 'gemini' });
     const result = await runner(TASK, makeCtx(5000).ctx);
@@ -157,6 +160,23 @@ describe('makeACPSubagentRunner', () => {
     expect(result.toolCalls).toBe(0);
     // session was closed in the finally block
     expect(hoisted.session?.close).toHaveBeenCalled();
+  });
+
+  it('reports the real tool-call count captured from the stream', async () => {
+    hoisted.promptResult = {
+      text: 'done',
+      stopReason: 'end_turn',
+      hasText: true,
+      toolCalls: [
+        { toolCallId: 'a', title: 'read x', status: 'completed' },
+        { toolCallId: 'b', title: 'edit y', status: 'completed' },
+      ],
+      diffs: [],
+      thoughts: '',
+    };
+    const runner = await makeACPSubagentRunner({ command: 'gemini' });
+    const result = await runner(TASK, makeCtx(5000).ctx);
+    expect(result.toolCalls).toBe(2);
   });
 
   it('throws SubagentError when ACPSession.start fails with spawn_failed', async () => {

--- a/packages/acp/tests/protocol-handler.test.ts
+++ b/packages/acp/tests/protocol-handler.test.ts
@@ -74,7 +74,7 @@ describe('ACPProtocolHandler', () => {
         agentInfo: { name: 'wrongstack', title: 'WrongStack', version: WRONGSTACK_VERSION },
         agentCapabilities: {
           loadSession: true,
-          promptCapabilities: { image: false, audio: false, embeddedContext: true },
+          promptCapabilities: { image: true, audio: false, embeddedContext: true },
           mcpCapabilities: { http: false, sse: false },
           sessionCapabilities: { close: {}, list: {}, delete: {}, resume: {} },
           auth: { logout: {} },
@@ -421,6 +421,111 @@ describe('ACPProtocolHandler', () => {
       handler.close();
       // The pending turn should resolve because the runTurn's signal fires.
       await turnDone;
+    });
+  });
+
+  describe('client permission requests', () => {
+    it('round-trips session/request_permission to the client and returns the outcome', async () => {
+      // Transport that also captures the onMessage handler so we can push
+      // a simulated client response back into the handler.
+      let onMsg: ((m: unknown) => void) | undefined;
+      const sent: unknown[] = [];
+      const transport = {
+        sent,
+        send: vi.fn(async (m: unknown) => { sent.push(m); }),
+        onMessage: (h: (m: unknown) => void) => { onMsg = h; return () => {}; },
+      };
+
+      let observedOutcome: unknown;
+      const runTurn: RunTurn = async (_input, _emit, api) => {
+        const outcome = await api!.requestPermission({
+          toolCall: { toolCallId: 'tc1', title: 'write a.ts', kind: 'edit' },
+          options: [
+            { optionId: 'allow_once', name: 'Allow', kind: 'allow_once' },
+            { optionId: 'reject_once', name: 'Reject', kind: 'reject_once' },
+          ],
+        });
+        observedOutcome = outcome;
+        return { stopReason: 'end_turn' };
+      };
+
+      const handler = new ACPProtocolHandler({
+        transport: transport as never as AgentServerTransport,
+        defaultCwd: '/test',
+        runTurn,
+      });
+      await handler.handleMessage({ id: 1, method: 'initialize', params: { protocolVersion: 1 } });
+      await handler.handleMessage({ id: 2, method: 'session/new', params: { cwd: '/test' } });
+      const sessionId = (sent[sent.length - 1] as { result?: { sessionId?: string } }).result?.sessionId!;
+      sent.length = 0;
+
+      // Kick off the turn without awaiting — it parks on requestPermission.
+      const turnDone = handler.handleMessage({
+        id: 3, method: 'session/prompt',
+        params: { sessionId, prompt: [{ type: 'text', text: 'edit' }] },
+      });
+      await new Promise((r) => setImmediate(r));
+
+      // The handler should have sent a session/request_permission REQUEST.
+      const req = sent.find(
+        (m) => (m as { method?: string }).method === 'session/request_permission',
+      ) as { id: string; params?: { toolCall?: unknown; options?: unknown } } | undefined;
+      expect(req).toBeDefined();
+      expect(req?.params?.toolCall).toMatchObject({ toolCallId: 'tc1' });
+
+      // Simulate the client's response, routed via onMessage.
+      onMsg?.({ id: req!.id, result: { outcome: { outcome: 'selected', optionId: 'allow_once' } } });
+      await turnDone;
+
+      expect(observedOutcome).toEqual({ outcome: 'selected', optionId: 'allow_once' });
+    });
+
+    it('exposes client fs/terminal via api and round-trips fs/read_text_file', async () => {
+      let onMsg: ((m: unknown) => void) | undefined;
+      const sent: unknown[] = [];
+      const transport = {
+        sent,
+        send: vi.fn(async (m: unknown) => { sent.push(m); }),
+        onMessage: (h: (m: unknown) => void) => { onMsg = h; return () => {}; },
+      };
+
+      let content: string | undefined;
+      let caps: unknown;
+      const runTurn: RunTurn = async (_input, _emit, api) => {
+        caps = api!.clientCapabilities;
+        content = await api!.readTextFile({ path: '/abs/a.ts' });
+        return { stopReason: 'end_turn' };
+      };
+
+      const handler = new ACPProtocolHandler({
+        transport: transport as never as AgentServerTransport,
+        defaultCwd: '/test',
+        runTurn,
+      });
+      await handler.handleMessage({
+        id: 1, method: 'initialize',
+        params: { protocolVersion: 1, clientCapabilities: { fs: { readTextFile: true }, terminal: true } },
+      });
+      await handler.handleMessage({ id: 2, method: 'session/new', params: { cwd: '/test' } });
+      const sessionId = (sent[sent.length - 1] as { result?: { sessionId?: string } }).result?.sessionId!;
+      sent.length = 0;
+
+      const turnDone = handler.handleMessage({
+        id: 3, method: 'session/prompt',
+        params: { sessionId, prompt: [{ type: 'text', text: 'read it' }] },
+      });
+      await new Promise((r) => setImmediate(r));
+
+      const req = sent.find(
+        (m) => (m as { method?: string }).method === 'fs/read_text_file',
+      ) as { id: string; params?: { path?: string } } | undefined;
+      expect(req).toBeDefined();
+      expect(req?.params?.path).toBe('/abs/a.ts');
+      onMsg?.({ id: req!.id, result: { content: 'file body' } });
+      await turnDone;
+
+      expect(content).toBe('file body');
+      expect(caps).toMatchObject({ fs: { readTextFile: true }, terminal: true });
     });
   });
 });

--- a/packages/acp/tests/server-agent-turn.test.ts
+++ b/packages/acp/tests/server-agent-turn.test.ts
@@ -10,11 +10,15 @@
  *  - non-text content blocks are converted to bracketed placeholders
  */
 import { describe, expect, it, vi } from 'vitest';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { Agent } from '@wrongstack/core';
 
 import type { AgentServerTransport } from '../src/agent/stdio-transport.js';
 import { ACPProtocolHandler } from '../src/agent/protocol-handler.js';
 import { makeACPServerAgentTurn } from '../src/agent/server-agent-turn.js';
+import { ACPSessionStore } from '../src/agent/session-store.js';
 
 interface FakeAgent {
   run: ReturnType<typeof vi.fn>;
@@ -89,10 +93,10 @@ describe('makeACPServerAgentTurn', () => {
     expect(resp.result?.stopReason).toBe('end_turn');
   });
 
-  it('converts non-text content blocks to bracketed placeholders', async () => {
-    let captured = '';
+  it('routes an image prompt into a multimodal ContentBlock[] input', async () => {
+    let captured: unknown;
     const { handler, transport } = makeHandlerWithFactory(() => ({
-      run: vi.fn(async (userMessage: string) => {
+      run: vi.fn(async (userMessage: unknown) => {
         captured = userMessage;
         return { text: 'ok', stopReason: 'end_turn' };
       }),
@@ -110,14 +114,41 @@ describe('makeACPServerAgentTurn', () => {
         sessionId,
         prompt: [
           { type: 'text', text: 'look at this:' },
-          { type: 'image', mimeType: 'image/png' },
+          { type: 'image', mimeType: 'image/png', data: 'AAAA' },
           { type: 'text', text: 'and tell me' },
         ],
       },
     });
-    expect(captured).toContain('look at this:');
-    expect(captured).toContain('[image: image/png]');
-    expect(captured).toContain('and tell me');
+    // With an image present the adapter builds a core ContentBlock[] so a
+    // vision model can actually see it (not a bracketed text placeholder).
+    expect(Array.isArray(captured)).toBe(true);
+    const blocks = captured as Array<{ type: string; text?: string; source?: { media_type?: string; data?: string } }>;
+    expect(blocks.map((b) => b.type)).toEqual(['text', 'image', 'text']);
+    expect(blocks[0]?.text).toBe('look at this:');
+    expect(blocks[1]?.source).toMatchObject({ media_type: 'image/png', data: 'AAAA' });
+    expect(blocks[2]?.text).toBe('and tell me');
+  });
+
+  it('keeps an all-text prompt as a plain string input', async () => {
+    let captured: unknown;
+    const { handler, transport } = makeHandlerWithFactory(() => ({
+      run: vi.fn(async (userMessage: unknown) => {
+        captured = userMessage;
+        return { text: 'ok', stopReason: 'end_turn' };
+      }),
+      teardown: vi.fn(async () => {}),
+    }));
+    await handler.handleMessage({ id: 1, method: 'initialize', params: { protocolVersion: 1 } });
+    await handler.handleMessage({ id: 2, method: 'session/new', params: { cwd: '/test' } });
+    const sessionId = (transport.sent[transport.sent.length - 1] as { result?: { sessionId?: string } }).result?.sessionId!;
+    transport.sent.length = 0;
+
+    await handler.handleMessage({
+      id: 3,
+      method: 'session/prompt',
+      params: { sessionId, prompt: [{ type: 'text', text: 'just text' }] },
+    });
+    expect(captured).toBe('just text');
   });
 
   it('returns cancelled stopReason when the parent signal aborts', async () => {
@@ -140,6 +171,183 @@ describe('makeACPServerAgentTurn', () => {
         params: { sessionId, prompt: [{ type: 'text', text: 'go' }] },
       }),
     ).resolves.toBeDefined();
+  });
+
+  it('streams tool_call / tool_call_update from the core agent event bus', async () => {
+    // Minimal event-bus stand-in: captures handlers and lets run() fire them.
+    const handlers: Record<string, (e: unknown) => void> = {};
+    const bus = {
+      on: (name: string, cb: (e: unknown) => void) => {
+        handlers[name] = cb;
+        return () => delete handlers[name];
+      },
+    };
+    const fakeAgent = {
+      events: bus,
+      run: vi.fn(async () => {
+        handlers['tool.started']?.({ id: 'tc1', name: 'write_file', input: { path: 'a.ts' } });
+        handlers['tool.executed']?.({ id: 'tc1', name: 'write_file', ok: true, output: 'wrote' });
+        return { text: 'done', stopReason: 'end_turn' };
+      }),
+      teardown: vi.fn(async () => {}),
+    };
+
+    const transport = fakeTransport();
+    const turn = makeACPServerAgentTurn({ agentFor: async () => fakeAgent as never as Agent });
+    const handler = new ACPProtocolHandler({
+      transport: transport as never as AgentServerTransport,
+      defaultCwd: '/test',
+      runTurn: turn,
+    });
+    await handler.handleMessage({ id: 1, method: 'initialize', params: { protocolVersion: 1 } });
+    await handler.handleMessage({ id: 2, method: 'session/new', params: { cwd: '/test' } });
+    const sessionId = (transport.sent[transport.sent.length - 1] as { result?: { sessionId?: string } }).result?.sessionId!;
+    transport.sent.length = 0;
+
+    await handler.handleMessage({
+      id: 3, method: 'session/prompt',
+      params: { sessionId, prompt: [{ type: 'text', text: 'go' }] },
+    });
+
+    const updates = transport.sent
+      .map((m) => (m as { params?: { update?: { sessionUpdate?: string; status?: string; kind?: string } } }).params?.update)
+      .filter((u): u is { sessionUpdate: string; status?: string; kind?: string } => !!u);
+    const toolCall = updates.find((u) => u.sessionUpdate === 'tool_call');
+    const toolUpdate = updates.find((u) => u.sessionUpdate === 'tool_call_update');
+    expect(toolCall).toBeDefined();
+    expect(toolCall?.kind).toBe('edit');
+    expect(toolUpdate?.status).toBe('completed');
+  });
+
+  it('replays recorded user/agent history on session/load', async () => {
+    const transport = fakeTransport();
+    const turn = makeACPServerAgentTurn({
+      agentFor: async () => makeFakeAgent('the answer') as never as Agent,
+    });
+    const handler = new ACPProtocolHandler({
+      transport: transport as never as AgentServerTransport,
+      defaultCwd: '/test',
+      runTurn: turn,
+      replayFor: turn.replay,
+    });
+    await handler.handleMessage({ id: 1, method: 'initialize', params: { protocolVersion: 1 } });
+    await handler.handleMessage({ id: 2, method: 'session/new', params: { cwd: '/test' } });
+    const sessionId = (transport.sent[transport.sent.length - 1] as { result?: { sessionId?: string } }).result?.sessionId!;
+
+    await handler.handleMessage({
+      id: 3, method: 'session/prompt',
+      params: { sessionId, prompt: [{ type: 'text', text: 'the question' }] },
+    });
+    transport.sent.length = 0;
+
+    await handler.handleMessage({ id: 4, method: 'session/load', params: { sessionId, cwd: '/test' } });
+
+    const replayed = transport.sent
+      .map((m) => (m as { method?: string; params?: { update?: { sessionUpdate?: string; content?: { text?: string } } } }))
+      .filter((m) => m.method === 'session/update')
+      .map((m) => m.params?.update)
+      .filter((u): u is { sessionUpdate: string; content?: { text?: string } } => !!u);
+    const user = replayed.find((u) => u.sessionUpdate === 'user_message_chunk');
+    const agent = replayed.find((u) => u.sessionUpdate === 'agent_message_chunk');
+    expect(user?.content?.text).toBe('the question');
+    expect(agent?.content?.text).toBe('the answer');
+  });
+
+  it('seeds a restored session\'s agent context with prior conversation', async () => {
+    const appended: Array<{ role: string; content: unknown }> = [];
+    const agent = {
+      run: vi.fn(async () => ({ text: 'continued', stopReason: 'end_turn' as const })),
+      teardown: vi.fn(async () => {}),
+      ctx: { state: { appendMessage: (m: { role: string; content: unknown }) => appended.push(m) } },
+    };
+    const turn = makeACPServerAgentTurn({ agentFor: async () => agent as never as Agent });
+
+    // Simulate a cold load: seed the prior conversation, then prompt.
+    turn.seed('s1', [
+      { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'first question' } },
+      { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'first answer' } },
+    ]);
+    expect(turn.replay('s1')).toHaveLength(2); // seed also feeds replay
+
+    await turn(
+      { sessionId: 's1', prompt: [{ type: 'text', text: 'follow up' }], signal: new AbortController().signal },
+      () => {},
+    );
+
+    // The new agent's context was primed with the prior turns as messages.
+    expect(appended).toEqual([
+      { role: 'user', content: 'first question' },
+      { role: 'assistant', content: 'first answer' },
+    ]);
+
+    // Seeding is one-shot: a second prompt on the same session doesn't re-seed.
+    appended.length = 0;
+    await turn(
+      { sessionId: 's1', prompt: [{ type: 'text', text: 'again' }], signal: new AbortController().signal },
+      () => {},
+    );
+    expect(appended).toEqual([]);
+  });
+
+  it('persists history and restores it on session/load after a "restart"', async () => {
+    const dir = path.join(os.tmpdir(), `wstack-acp-store-${process.pid}-${Math.round(performance.now())}`);
+    const store = new ACPSessionStore({ dir });
+    try {
+      // First server instance: create a session and run a turn.
+      const t1 = fakeTransport();
+      const turn1 = makeACPServerAgentTurn({
+        agentFor: async () => makeFakeAgent('persisted answer') as never as Agent,
+      });
+      const h1 = new ACPProtocolHandler({
+        transport: t1 as never as AgentServerTransport,
+        defaultCwd: '/test',
+        runTurn: turn1,
+        replayFor: turn1.replay,
+        store,
+      });
+      await h1.handleMessage({ id: 1, method: 'initialize', params: { protocolVersion: 1 } });
+      await h1.handleMessage({ id: 2, method: 'session/new', params: { cwd: '/test' } });
+      const sessionId = (t1.sent[t1.sent.length - 1] as { result?: { sessionId?: string } }).result?.sessionId!;
+      await h1.handleMessage({
+        id: 3, method: 'session/prompt',
+        params: { sessionId, prompt: [{ type: 'text', text: 'persisted question' }] },
+      });
+
+      // Second server instance (fresh in-memory state — simulates a restart),
+      // sharing the same durable store.
+      const t2 = fakeTransport();
+      const turn2 = makeACPServerAgentTurn({
+        agentFor: async () => makeFakeAgent('x') as never as Agent,
+      });
+      const h2 = new ACPProtocolHandler({
+        transport: t2 as never as AgentServerTransport,
+        defaultCwd: '/test',
+        runTurn: turn2,
+        replayFor: turn2.replay,
+        seedFor: turn2.seed,
+        store,
+      });
+      await h2.handleMessage({ id: 1, method: 'initialize', params: { protocolVersion: 1 } });
+      // Before load, the fresh turn engine knows nothing about the session.
+      expect(turn2.replay(sessionId)).toHaveLength(0);
+      await h2.handleMessage({ id: 2, method: 'session/load', params: { sessionId, cwd: '/test' } });
+      // After load, the handler seeded the turn engine from the durable store.
+      expect(turn2.replay(sessionId)).toHaveLength(2);
+
+      const replayed = t2.sent
+        .map((m) => (m as { method?: string; params?: { update?: { sessionUpdate?: string; content?: { text?: string } } } }))
+        .filter((m) => m.method === 'session/update')
+        .map((m) => m.params?.update)
+        .filter((u): u is { sessionUpdate: string; content?: { text?: string } } => !!u);
+      expect(replayed.find((u) => u.sessionUpdate === 'user_message_chunk')?.content?.text).toBe('persisted question');
+      expect(replayed.find((u) => u.sessionUpdate === 'agent_message_chunk')?.content?.text).toBe('persisted answer');
+      // The load response succeeded (no error).
+      const loadResp = t2.sent[t2.sent.length - 1] as { result?: unknown; error?: unknown };
+      expect(loadResp.error).toBeUndefined();
+      expect(loadResp.result).toBeDefined();
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
   });
 
   it('creates one agent per session and reuses it across turns', async () => {

--- a/packages/acp/tests/websocket-transport.test.ts
+++ b/packages/acp/tests/websocket-transport.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for the remote WebSocket client transport and
+ * `ACPSession.connectWebSocket`. A fake global `WebSocket` lets us drive
+ * open/message/close without a real socket.
+ */
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ACPSession } from '../src/client/acp-session.js';
+import { WebSocketClientTransport } from '../src/client/websocket-transport.js';
+import type { ACPMessage } from '../src/types/acp-messages.js';
+
+type Listener = (ev?: unknown) => void;
+
+class FakeWS {
+  static instances: FakeWS[] = [];
+  readonly url: string;
+  readonly listeners: Record<string, Listener[]> = {};
+  readonly sent: string[] = [];
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    FakeWS.instances.push(this);
+  }
+  addEventListener(type: string, cb: Listener): void {
+    const list = this.listeners[type] ?? [];
+    list.push(cb);
+    this.listeners[type] = list;
+  }
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.closed = true;
+    this.fire('close');
+  }
+  fire(type: string, ev?: unknown): void {
+    for (const cb of this.listeners[type] ?? []) cb(ev);
+  }
+}
+
+const realWS = (globalThis as { WebSocket?: unknown }).WebSocket;
+
+function last(): FakeWS {
+  const t = FakeWS.instances[FakeWS.instances.length - 1];
+  if (!t) throw new Error('no WebSocket constructed');
+  return t;
+}
+
+beforeEach(() => {
+  FakeWS.instances.length = 0;
+  (globalThis as { WebSocket?: unknown }).WebSocket = FakeWS as never;
+});
+
+afterEach(() => {
+  (globalThis as { WebSocket?: unknown }).WebSocket = realWS;
+});
+
+describe('WebSocketClientTransport', () => {
+  it('resolves start() on open, dispatches parsed messages, serializes sends', async () => {
+    const t = new WebSocketClientTransport({ url: 'ws://agent.test' });
+    const startP = t.start();
+    last().fire('open');
+    await startP;
+
+    const received: ACPMessage[] = [];
+    t.onMessage((m) => received.push(m));
+    last().fire('message', {
+      data: JSON.stringify({ jsonrpc: '2.0', id: 1, result: { ok: true } }),
+    });
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ id: 1, result: { ok: true } });
+
+    await t.send({ jsonrpc: '2.0', id: 2, method: 'ping' } as never as ACPMessage);
+    expect(JSON.parse(last().sent[0]!)).toMatchObject({ id: 2, method: 'ping' });
+
+    t.stop();
+    expect(last().closed).toBe(true);
+  });
+
+  it('rejects start() on a timeout', async () => {
+    const t = new WebSocketClientTransport({ url: 'ws://agent.test', handshakeTimeoutMs: 10 });
+    await expect(t.start()).rejects.toThrow(/within 10ms/);
+  });
+
+  it('rejects send() after the socket is closed', async () => {
+    const t = new WebSocketClientTransport({ url: 'ws://agent.test' });
+    const startP = t.start();
+    last().fire('open');
+    await startP;
+    t.stop();
+    await expect(t.send({ jsonrpc: '2.0', id: 1 } as never as ACPMessage)).rejects.toThrow(
+      /not open/,
+    );
+  });
+});
+
+describe('ACPSession.connectWebSocket', () => {
+  const PROJECT_ROOT = path.resolve(os.tmpdir(), 'wstack-acp-ws-test');
+
+  it('connects, handshakes, and runs a prompt turn over the socket', async () => {
+    const sessionP = ACPSession.connectWebSocket(
+      { url: 'ws://agent.test' },
+      { command: 'remote', projectRoot: PROJECT_ROOT },
+    );
+    // Open the socket so initialize can be sent.
+    last().fire('open');
+    await new Promise((r) => setImmediate(r));
+
+    const ws = last();
+    const initMsg = ws.sent.map((s) => JSON.parse(s)).find((m) => m.method === 'initialize');
+    expect(initMsg).toBeDefined();
+    ws.fire('message', {
+      data: JSON.stringify({
+        jsonrpc: '2.0',
+        id: initMsg.id,
+        result: { protocolVersion: 1, agentInfo: { name: 'remote', version: '1' } },
+      }),
+    });
+    const session = await sessionP;
+    expect(session.getAgentInfo()?.name).toBe('remote');
+
+    // Run a prompt: new → stream a chunk → stopReason.
+    const promptP = session.prompt([{ type: 'text', text: 'hi' }], new AbortController().signal);
+    await new Promise((r) => setImmediate(r));
+    const newMsg = ws.sent.map((s) => JSON.parse(s)).find((m) => m.method === 'session/new');
+    ws.fire('message', {
+      data: JSON.stringify({ jsonrpc: '2.0', id: newMsg.id, result: { sessionId: 'sess_ws' } }),
+    });
+    await new Promise((r) => setImmediate(r));
+    const promptMsg = ws.sent.map((s) => JSON.parse(s)).find((m) => m.method === 'session/prompt');
+    ws.fire('message', {
+      data: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_ws',
+          update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'pong' } },
+        },
+      }),
+    });
+    ws.fire('message', {
+      data: JSON.stringify({
+        jsonrpc: '2.0',
+        id: promptMsg.id,
+        result: { stopReason: 'end_turn' },
+      }),
+    });
+
+    const result = await promptP;
+    expect(result.text).toBe('pong');
+    expect(result.stopReason).toBe('end_turn');
+    await session.close();
+  });
+});

--- a/packages/acp/tests/wrongstack-acp-agent.test.ts
+++ b/packages/acp/tests/wrongstack-acp-agent.test.ts
@@ -71,7 +71,9 @@ describe('WrongStackACPServer', () => {
 
     await server.start();
 
-    expect(t.sendStartupMarker).toHaveBeenCalledTimes(1);
+    // v1: stdout is JSON-RPC only by default — no startup marker unless
+    // `legacyStartupMarker` is explicitly set (see the dedicated test below).
+    expect(t.sendStartupMarker).toHaveBeenCalledTimes(0);
     expect(handler.handleMessage).toHaveBeenCalledTimes(2);
     expect(t.close).toHaveBeenCalledTimes(1);
   });

--- a/packages/acp/tests/ws-bridge-transport.test.ts
+++ b/packages/acp/tests/ws-bridge-transport.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the WebSocket server bridge transport and its integration with
+ * `ACPProtocolHandler` — including a live permission round-trip (the thing a
+ * full-duplex WS connection enables that HTTP cannot).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { ACPMessage } from '../src/types/acp-messages.js';
+import type { AgentServerTransport } from '../src/agent/stdio-transport.js';
+import { WsBridgeTransport } from '../src/agent/ws-bridge-transport.js';
+import { ACPProtocolHandler, type RunTurn } from '../src/agent/protocol-handler.js';
+
+describe('WsBridgeTransport', () => {
+  it('writes outbound to the sink and routes inbound to onMessage handlers', async () => {
+    const sink: ACPMessage[] = [];
+    const t = new WsBridgeTransport((m) => sink.push(m));
+    const seen: ACPMessage[] = [];
+    t.onMessage((m) => seen.push(m));
+
+    await t.send({ jsonrpc: '2.0', id: 1, result: {} } as never as ACPMessage);
+    expect(sink).toHaveLength(1);
+
+    t.receive({ jsonrpc: '2.0', id: 2, method: 'ping' } as never as ACPMessage);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ id: 2, method: 'ping' });
+
+    t.close();
+    t.receive({ jsonrpc: '2.0', id: 3 } as never as ACPMessage);
+    expect(seen).toHaveLength(1); // no dispatch after close
+  });
+
+  it('drives a full prompt turn with a live permission round-trip over the bridge', async () => {
+    const sink: ACPMessage[] = [];
+    const t = new WsBridgeTransport((m) => sink.push(m));
+
+    let outcome: unknown;
+    const runTurn: RunTurn = async (_input, _emit, api) => {
+      outcome = await api!.requestPermission({
+        toolCall: { toolCallId: 'tc1', title: 'write x', kind: 'edit' },
+        options: [{ optionId: 'allow_once', name: 'Allow', kind: 'allow_once' }],
+      });
+      return { stopReason: 'end_turn' };
+    };
+    const handler = new ACPProtocolHandler({
+      transport: t as never as AgentServerTransport,
+      defaultCwd: '/test',
+      runTurn,
+    });
+
+    // Mirror the WS glue: each inbound message is fed to receive() + handleMessage().
+    const feed = async (msg: unknown): Promise<void> => {
+      t.receive(msg as never as ACPMessage);
+      await handler.handleMessage(msg);
+    };
+
+    await feed({ id: 1, method: 'initialize', params: { protocolVersion: 1 } });
+    await feed({ id: 2, method: 'session/new', params: { cwd: '/test' } });
+    const sessionId = (sink[sink.length - 1] as { result?: { sessionId?: string } }).result?.sessionId!;
+    sink.length = 0;
+
+    // Start the turn without awaiting — it parks on requestPermission.
+    const turnDone = feed({
+      id: 3, method: 'session/prompt',
+      params: { sessionId, prompt: [{ type: 'text', text: 'edit' }] },
+    });
+    await new Promise((r) => setImmediate(r));
+
+    const req = sink.find(
+      (m) => (m as { method?: string }).method === 'session/request_permission',
+    ) as { id: string } | undefined;
+    expect(req).toBeDefined();
+
+    // Client answers over the same socket (full-duplex).
+    await feed({ id: req!.id, result: { outcome: { outcome: 'selected', optionId: 'allow_once' } } });
+    await turnDone;
+
+    expect(outcome).toEqual({ outcome: 'selected', optionId: 'allow_once' });
+  });
+});

--- a/packages/cli/src/acp-server-agent.ts
+++ b/packages/cli/src/acp-server-agent.ts
@@ -22,12 +22,16 @@ import {
   DefaultTokenCounter,
   EventBus,
   type Logger,
+  type PermissionDecision,
+  type PermissionPolicy,
   TOKENS,
   type Tool,
+  ToolCapabilities,
   ToolRegistry,
   type WstackPaths,
 } from '@wrongstack/core';
 import { ToolExecutor } from '@wrongstack/core/execution';
+import type { RunTurnApi } from '@wrongstack/acp/agent';
 import { createDefaultContainer } from '@wrongstack/runtime';
 import type { SubcommandDeps } from './subcommands/index.js';
 import { setupProvider } from './wiring/provider.js';
@@ -49,6 +53,184 @@ export interface AcpAgentFactoryOptions {
   logger?: Logger | undefined;
 }
 
+/** Capabilities considered safe to auto-approve without asking the client. */
+const SAFE_CAPS = new Set<string>([
+  ToolCapabilities.FS_READ,
+  ToolCapabilities.NET_OUTBOUND,
+  ToolCapabilities.COORDINATION_FLEET_READ,
+]);
+
+/**
+ * Permission policy that routes side-effecting tool calls to the connected
+ * ACP client via `session/request_permission` (the v1-correct behavior),
+ * while auto-approving read-only/safe tools. This replaces the blanket
+ * auto-approve so an editor driving WrongStack-as-agent gets a real
+ * permission prompt before file writes / shell commands run.
+ */
+class ACPClientPermissionPolicy implements PermissionPolicy {
+  constructor(private readonly requestPermission: RunTurnApi['requestPermission']) {}
+
+  async evaluate(tool: Tool, input: unknown): Promise<PermissionDecision> {
+    const caps = tool.capabilities ?? [];
+    // Safe iff every declared capability is in the safe set (and at least
+    // one exists). A tool with no declared caps is treated as unsafe.
+    const isSafe = caps.length > 0 && caps.every((c) => SAFE_CAPS.has(c));
+    if (isSafe) {
+      return { permission: 'auto', source: 'default' };
+    }
+
+    const title = describeToolCall(tool.name, input);
+    try {
+      const outcome = await this.requestPermission({
+        toolCall: { toolCallId: `tc_${tool.name}_${Date.now()}`, title },
+        options: [
+          { optionId: 'allow_once', name: 'Allow', kind: 'allow_once' },
+          { optionId: 'allow_always', name: 'Always allow', kind: 'allow_always' },
+          { optionId: 'reject_once', name: 'Reject', kind: 'reject_once' },
+        ],
+      });
+      const allowed =
+        outcome.outcome === 'selected' && outcome.optionId.startsWith('allow');
+      return allowed
+        ? { permission: 'auto', source: 'user' }
+        : { permission: 'deny', source: 'user', reason: 'rejected by ACP client' };
+    } catch {
+      // No client channel or the request timed out. Fail safe: deny the
+      // side-effecting tool rather than silently running it.
+      return { permission: 'deny', source: 'deny', reason: 'no permission channel' };
+    }
+  }
+
+  async trust(): Promise<void> {}
+  async deny(): Promise<void> {}
+  denyOnce(): void {}
+  allowOnce(): void {}
+  async reload(): Promise<void> {}
+}
+
+function describeToolCall(name: string, input: unknown): string {
+  if (input && typeof input === 'object') {
+    const r = input as Record<string, unknown>;
+    const arg = r.path ?? r.file ?? r.command ?? r.pattern;
+    if (typeof arg === 'string') return `${name}: ${arg}`;
+  }
+  return name;
+}
+
+/**
+ * Swap filesystem/terminal tools for ACP-backed versions that operate on the
+ * connected client's `fs/*` + `terminal/*`, gated on the client's advertised
+ * capabilities. Each ACP tool reuses the builtin's name/description/inputSchema
+ * so the model calls it identically — only execution is redirected.
+ *
+ * Note: for a local (stdio) client the agent and editor share a filesystem, so
+ * tools that aren't redirected still operate on the same real files; this swap
+ * adds editor-buffer awareness and makes remote (WebSocket) agents correct.
+ */
+function wireClientBackedTools(tools: ToolRegistry, api: RunTurnApi): void {
+  const caps = api.clientCapabilities ?? {};
+  const swap = (name: string, make: (base: Tool) => Tool): void => {
+    const base = tools.get(name);
+    if (!base) return;
+    tools.unregister(name);
+    tools.register(make(base));
+  };
+  if (caps.fs?.readTextFile) {
+    swap('read', (base) => makeAcpRead(base, api));
+  }
+  if (caps.fs?.writeTextFile) {
+    swap('write', (base) => makeAcpWrite(base, api));
+    swap('edit', (base) => makeAcpEdit(base, api));
+  }
+  if (caps.terminal) {
+    swap('bash', (base) => makeAcpBash(base, api));
+  }
+}
+
+function makeAcpRead(base: Tool, api: RunTurnApi): Tool {
+  return {
+    ...base,
+    mutating: false,
+    execute: async (input: unknown) => {
+      const i = (input ?? {}) as { path?: string; offset?: number; limit?: number };
+      if (!i.path) throw new Error('read: path is required');
+      const content = await api.readTextFile({
+        path: i.path,
+        ...(typeof i.offset === 'number' ? { line: i.offset } : {}),
+        ...(typeof i.limit === 'number' ? { limit: i.limit } : {}),
+      });
+      const lines = content.split(/\r\n|\r|\n/);
+      const start = Math.max(1, i.offset ?? 1);
+      const width = String(start + lines.length - 1).length;
+      const text = lines
+        .map((l, idx) => `${String(start + idx).padStart(width, ' ')}→${l}`)
+        .join('\n');
+      return { text, total_lines: lines.length, encoding: 'utf8', truncated: false };
+    },
+  } as Tool;
+}
+
+function makeAcpWrite(base: Tool, api: RunTurnApi): Tool {
+  return {
+    ...base,
+    execute: async (input: unknown) => {
+      const i = (input ?? {}) as { path?: string; content?: string };
+      if (!i.path) throw new Error('write: path is required');
+      await api.writeTextFile({ path: i.path, content: i.content ?? '' });
+      return { path: i.path, ok: true };
+    },
+  } as Tool;
+}
+
+function makeAcpEdit(base: Tool, api: RunTurnApi): Tool {
+  return {
+    ...base,
+    execute: async (input: unknown) => {
+      const i = (input ?? {}) as {
+        path?: string;
+        old_string?: string;
+        new_string?: string;
+        replace_all?: boolean;
+      };
+      if (!i.path) throw new Error('edit: path is required');
+      if (!i.old_string) throw new Error('edit: old_string is required');
+      const before = await api.readTextFile({ path: i.path });
+      const occurrences = before.split(i.old_string).length - 1;
+      if (occurrences === 0) {
+        throw new Error(`edit: old_string not found in "${i.path}"`);
+      }
+      if (occurrences > 1 && !i.replace_all) {
+        throw new Error(
+          `edit: old_string appears ${occurrences} times in "${i.path}"; pass replace_all or use a more specific string`,
+        );
+      }
+      const after = i.replace_all
+        ? before.split(i.old_string).join(i.new_string ?? '')
+        : before.replace(i.old_string, i.new_string ?? '');
+      await api.writeTextFile({ path: i.path, content: after });
+      return { path: i.path, replacements: i.replace_all ? occurrences : 1 };
+    },
+  } as Tool;
+}
+
+function makeAcpBash(base: Tool, api: RunTurnApi): Tool {
+  return {
+    ...base,
+    execute: async (input: unknown) => {
+      const i = (input ?? {}) as { command?: string; cwd?: string };
+      if (!i.command) throw new Error('bash: command is required');
+      // ACP terminals run the command through the client's shell; we pass it
+      // as `sh -c "<command>"` so pipelines/operators work as the model expects.
+      const { output, exitCode } = await api.runTerminal({
+        command: 'sh',
+        args: ['-c', i.command],
+        ...(i.cwd ? { cwd: i.cwd } : {}),
+      });
+      return { stdout: output, exit_code: exitCode, command: i.command };
+    },
+  } as Tool;
+}
+
 /**
  * Build a per-session `Agent` factory suitable for `makeACPServerAgentTurn`.
  *
@@ -61,7 +243,7 @@ export interface AcpAgentFactoryOptions {
 export function buildAcpServerAgentFactory(
   deps: SubcommandDeps,
   options: AcpAgentFactoryOptions = {},
-): (sessionId: string, cwd: string) => Promise<Agent> {
+): (sessionId: string, cwd: string, api?: RunTurnApi) => Promise<Agent> {
   const config = deps.config;
   if (!config.provider || !config.model) {
     throw new AcpServerConfigError(
@@ -95,20 +277,37 @@ export function buildAcpServerAgentFactory(
     modelsRegistry: deps.modelsRegistry,
   });
 
-  return async function agentFor(_sessionId: string, cwd: string): Promise<Agent> {
+  return async function agentFor(
+    _sessionId: string,
+    cwd: string,
+    api?: RunTurnApi,
+  ): Promise<Agent> {
     const { provider, providerRegistry } = await bootProvider();
 
     // Per-session event bus — keeps each ACP session's tool/iteration events
     // isolated from the others.
     const events = new EventBus();
 
-    // Tools: prefer the caller-supplied registry (already populated by the
-    // subcommand dispatcher with builtin tools); fall back to an empty one.
-    const tools: ToolRegistry = deps.toolRegistry ?? new ToolRegistry();
+    // Per-session tool registry: start from the builtins, then (when the
+    // client advertises fs/terminal) swap read/write/edit/bash for
+    // ACP-backed versions that operate on the CLIENT's filesystem and
+    // terminal — so the editor's view (incl. unsaved buffers) is the source
+    // of truth. A fresh registry avoids mutating the shared builtin one.
+    const source = deps.toolRegistry ?? new ToolRegistry();
+    const tools = new ToolRegistry();
+    for (const t of source.list()) tools.register(t);
+    if (api) {
+      wireClientBackedTools(tools, api);
+    }
 
-    // Headless policy: auto-approve. The ACP server has no interactive prompt
-    // channel, mirroring the subagent posture in fleet/host.ts.
-    const permissionPolicy = new AutoApprovePermissionPolicy();
+    // Permission posture: when the ACP client exposes a permission channel
+    // (the live `wstack acp` path always does), route side-effecting tools
+    // to the client for approval. Without a channel (tests, --echo) fall
+    // back to the headless auto-approve, matching the subagent posture in
+    // fleet/host.ts.
+    const permissionPolicy: PermissionPolicy = api?.requestPermission
+      ? new ACPClientPermissionPolicy(api.requestPermission)
+      : new AutoApprovePermissionPolicy();
 
     const tokenCounter = new DefaultTokenCounter({
       registry: deps.modelsRegistry,

--- a/packages/cli/src/fleet/host.ts
+++ b/packages/cli/src/fleet/host.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
  * factory is created lazily on the first `/spawn` so users who never use
  * subagents don't pay the construction cost.
  */
-import { ACP_AGENT_COMMANDS, makeACPSubagentRunner } from '@wrongstack/acp';
+import { ACP_AGENT_COMMANDS, findAgentDescriptor, makeACPSubagentRunner } from '@wrongstack/acp';
 import type { BrainArbiter, SubagentRunner, TextBlock } from '@wrongstack/core';
 import {
   Agent,
@@ -975,7 +975,21 @@ export class MultiAgentHost {
       this.acpRunnerAccessOrder.push(subagentId);
       return cached;
     }
-    const cmd = ACP_AGENT_COMMANDS[subagentId];
+    // Prefer the legacy command map, then fall back to the 12-entry
+    // catalog so Director-spawned agents (claude-code, codex-cli,
+    // opencode, cursor, …) work the same as `wstack acp spawn`.
+    let cmd = ACP_AGENT_COMMANDS[subagentId];
+    if (!cmd) {
+      const desc = findAgentDescriptor(subagentId);
+      if (desc) {
+        cmd = {
+          command: desc.acp.command,
+          args: [...(desc.acp.args ?? [])],
+          role: subagentId,
+          ...(desc.acp.env ? { env: desc.acp.env } : {}),
+        };
+      }
+    }
     if (!cmd) throw new Error(`Unknown ACP agent: ${subagentId}`);
     // LRU eviction: remove oldest entries if at capacity
     while (this.acpRunnerAccessOrder.length >= MultiAgentHost.ACP_CACHE_MAX) {

--- a/packages/cli/src/subcommands/handlers/acp.ts
+++ b/packages/cli/src/subcommands/handlers/acp.ts
@@ -13,12 +13,22 @@
 
 import {
   ACP_AGENT_COMMANDS,
+  type ACPProgressEvent,
   EnsembleRegistry,
   findAgentDescriptor,
   makeACPSubagentRunnerWithStop,
   runEnsemble,
 } from '@wrongstack/acp';
-import { makeACPServerAgentTurn, WrongStackACPServer } from '@wrongstack/acp/agent';
+import {
+  ACPProtocolHandler,
+  ACPSessionStore,
+  makeACPServerAgentTurn,
+  type RunTurn,
+  WrongStackACPServer,
+  WsBridgeTransport,
+} from '@wrongstack/acp/agent';
+import * as path from 'node:path';
+import { WebSocketServer } from 'ws';
 import type { SubagentRunContext } from '@wrongstack/core';
 import { SubagentBudget } from '@wrongstack/core/coordination';
 import { AcpServerConfigError, buildAcpServerAgentFactory } from '../../acp-server-agent.js';
@@ -73,6 +83,11 @@ ACP Mode:
   \`wstack auth\` first to configure a provider, or pass \`--echo\` for a no-op
   connectivity test that needs no provider. Press Ctrl+C to stop.
 
+  Transports:
+    (default)        stdio JSON-RPC (the usual editor-spawned-subprocess mode)
+    --ws[=port]      serve over WebSocket on 127.0.0.1:<port> (default 8889) —
+                     full-duplex, so updates/permission prompts stream live.
+
 spawn:
   Spawns a named ACP agent (claude-code, gemini-cli, codex-cli, copilot,
   cline, goose, openhands, qwen-code, kiro-cli, opencode, mistral-vibe,
@@ -106,7 +121,105 @@ parallel:
   return 1;
 };
 
+/** Parse the `--ws[=port]` flag into a port number, or null if not set. */
+function parseWsPort(flag: unknown): number | null {
+  if (flag === undefined || flag === false) return null;
+  if (flag === true || flag === 'true') return 8889;
+  const n = Number(flag);
+  return Number.isInteger(n) && n > 0 && n < 65_536 ? n : 8889;
+}
+
+/**
+ * Serve WrongStack as an ACP agent over WebSocket. Unlike the HTTP transport
+ * (one POST per message, notifications buffered), a WebSocket is full-duplex:
+ * the agent streams `session/update` and makes `session/request_permission`
+ * callbacks live during a turn. One handler + transport per connection.
+ */
+async function runACPWebSocketServer(deps: SubcommandDeps, port: number): Promise<number> {
+  const host = '127.0.0.1';
+  // `--echo` over WS: a no-provider connectivity test, mirroring stdio `--echo`.
+  const echo = deps.flags?.echo === true || deps.flags?.echo === 'true';
+
+  let turn: ReturnType<typeof makeACPServerAgentTurn> | undefined;
+  let echoTurn: RunTurn | undefined;
+  let store: ACPSessionStore | undefined;
+  if (echo) {
+    echoTurn = async () => ({ stopReason: 'end_turn' });
+  } else {
+    let agentFor;
+    try {
+      agentFor = buildAcpServerAgentFactory(deps);
+    } catch (err) {
+      if (err instanceof AcpServerConfigError) {
+        deps.renderer.writeError(`${err.message}\n`);
+        return 1;
+      }
+      throw err;
+    }
+    turn = makeACPServerAgentTurn({ agentFor });
+    store = deps.paths?.projectDir
+      ? new ACPSessionStore({ dir: path.join(deps.paths.projectDir, 'acp-sessions') })
+      : undefined;
+  }
+
+  const wss = new WebSocketServer({ host, port });
+  wss.on('connection', (socket, req) => {
+    // Origin guard: real ACP clients send no Origin; reject cross-origin
+    // browser connections so a web page can't drive this loopback agent.
+    const origin = req.headers.origin;
+    if (origin && origin !== `http://${host}:${port}` && origin !== `ws://${host}:${port}`) {
+      socket.close(1008, 'cross-origin forbidden');
+      return;
+    }
+    const transport = new WsBridgeTransport((m) => socket.send(JSON.stringify(m)));
+    const handler = new ACPProtocolHandler({
+      transport,
+      defaultCwd: deps.cwd ?? process.cwd(),
+      runTurn: turn ?? echoTurn!,
+      ...(turn ? { replayFor: turn.replay, seedFor: turn.seed } : {}),
+      ...(store ? { store } : {}),
+    });
+    socket.on('message', (data: { toString(): string }) => {
+      let msg: unknown;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
+      transport.receive(msg as never);
+      void handler.handleMessage(msg);
+    });
+    const teardown = (): void => {
+      handler.close();
+      transport.close();
+    };
+    socket.on('close', teardown);
+    socket.on('error', teardown);
+  });
+
+  deps.renderer.writeInfo(
+    echo
+      ? `ACP server (echo, no provider) listening on ws://${host}:${port}. Press Ctrl+C to stop.\n`
+      : `WrongStack ACP server listening on ws://${host}:${port} (${deps.config.provider}/${deps.config.model}). Press Ctrl+C to stop.\n`,
+  );
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      deps.renderer.writeWarning('\nShutting down ACP WebSocket server...');
+      wss.close();
+      resolve();
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+  });
+  return 0;
+}
+
 async function runACPServer(deps: SubcommandDeps): Promise<number> {
+  const wsPort = parseWsPort(deps.flags?.ws);
+  if (wsPort !== null) {
+    return runACPWebSocketServer(deps, wsPort);
+  }
   // `--echo` keeps the no-op connectivity-smoke-test path that the default
   // runTurn provided before this server was wired to a real Agent. Useful for
   // `wstack acp --echo` when you just want to verify the wire format against a
@@ -127,7 +240,18 @@ async function runACPServer(deps: SubcommandDeps): Promise<number> {
             }
             throw err;
           }
-          return { runTurn: makeACPServerAgentTurn({ agentFor }) };
+          const turn = makeACPServerAgentTurn({ agentFor });
+          // Persist sessions under the project's wstack dir so `session/load`
+          // survives a server restart (project-scoped, not in the repo).
+          const store = deps.paths?.projectDir
+            ? new ACPSessionStore({ dir: path.join(deps.paths.projectDir, 'acp-sessions') })
+            : undefined;
+          return {
+            runTurn: turn,
+            replayFor: turn.replay,
+            seedFor: turn.seed,
+            ...(store ? { store } : {}),
+          };
         })(),
   );
 
@@ -219,7 +343,13 @@ async function spawnACPAgent(args: string[], deps: SubcommandDeps): Promise<numb
   let stop: (() => void) | null = null;
 
   try {
-    const { runner, stop: runStop } = await makeACPSubagentRunnerWithStop(cmd);
+    const { runner, stop: runStop } = await makeACPSubagentRunnerWithStop({
+      ...cmd,
+      onProgress: (event) => {
+        const line = formatProgress(event);
+        if (line) deps.renderer.writeInfo(`  ${line}\n`);
+      },
+    });
     stop = runStop;
 
     const taskId = `acp-${crypto.randomUUID()}`;
@@ -271,6 +401,29 @@ async function spawnACPAgent(args: string[], deps: SubcommandDeps): Promise<numb
   }
 }
 
+/**
+ * Render one streamed ACP progress event as a compact one-line summary
+ * for the CLI. Returns '' for events that shouldn't print a line (the
+ * final assistant text is already shown in the result block, so we skip
+ * `message`/`raw` to avoid double-printing).
+ */
+function formatProgress(event: ACPProgressEvent): string {
+  switch (event.type) {
+    case 'tool_call':
+      return `▸ ${event.toolCall.title} (${event.toolCall.status})`;
+    case 'tool_call_update':
+      return event.toolCall.status === 'completed' || event.toolCall.status === 'failed'
+        ? `  ↳ ${event.toolCall.title}: ${event.toolCall.status}`
+        : '';
+    case 'diff':
+      return `✎ ${event.diff.path}${event.diff.oldText === null ? ' (new)' : ''}`;
+    case 'plan':
+      return `☰ plan: ${event.entries.length} step(s)`;
+    default:
+      return '';
+  }
+}
+
 async function parallelACPAgents(
   args: string[],
   deps: SubcommandDeps,
@@ -301,6 +454,10 @@ async function parallelACPAgents(
       task,
       resolveCmd: resolveCmdFromCatalog,
       signal: ac.signal,
+      onProgress: (agentId, event) => {
+        const line = formatProgress(event);
+        if (line) deps.renderer.writeInfo(`  [${agentId}] ${line}\n`);
+      },
     });
 
     // Surface skipped agents up-front, before the per-agent output.

--- a/packages/cli/tests/acp-server-agent.test.ts
+++ b/packages/cli/tests/acp-server-agent.test.ts
@@ -42,6 +42,7 @@ vi.mock('@wrongstack/runtime', () => ({
 }));
 
 import { AcpServerConfigError, buildAcpServerAgentFactory } from '../src/acp-server-agent.js';
+import type { RunTurnApi } from '@wrongstack/acp/agent';
 import type { SubcommandDeps } from '../src/subcommands/index.js';
 
 function makeStubProvider(): Provider {
@@ -133,6 +134,75 @@ describe('buildAcpServerAgentFactory', () => {
     expect(a1.ctx).not.toBe(a2.ctx);
     // The configured model flows through to the context.
     expect(a1.ctx.model).toBe('test-model');
+  });
+
+  it('wires ACP-backed fs/terminal tools when the client advertises capabilities', async () => {
+    const provider = makeStubProvider();
+    const providerRegistry = { has: () => true } as never as ProviderRegistry;
+    mockSetupProvider.mockResolvedValue({
+      provider,
+      providerRegistry,
+      resolvedProvider: {} as ResolvedProvider,
+    });
+
+    const reads: Array<{ path: string }> = [];
+    const writes: Array<{ path: string; content: string }> = [];
+    const terminals: Array<{ command: string; args?: string[] }> = [];
+    const api: RunTurnApi = {
+      clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: true },
+      requestPermission: async () => ({ outcome: 'selected', optionId: 'allow_once' }),
+      readTextFile: async (p) => {
+        reads.push({ path: p.path });
+        return 'line one\nline two';
+      },
+      writeTextFile: async (p) => {
+        writes.push(p);
+      },
+      runTerminal: async (p) => {
+        terminals.push({ command: p.command, ...(p.args ? { args: p.args } : {}) });
+        return { output: 'terminal output', exitCode: 0 };
+      },
+    };
+
+    const agentFor = buildAcpServerAgentFactory(makeDeps());
+    const agent = await agentFor('sess-acp', '/tmp', api);
+
+    const readTool = agent.tools.get('read');
+    const readOut = (await readTool!.execute({ path: 'a.ts' }, agent.ctx)) as { text: string };
+    expect(reads[0]).toMatchObject({ path: 'a.ts' });
+    expect(readOut.text).toContain('line one');
+
+    const writeTool = agent.tools.get('write');
+    await writeTool!.execute({ path: 'b.ts', content: 'hello' }, agent.ctx);
+    expect(writes[0]).toMatchObject({ path: 'b.ts', content: 'hello' });
+
+    const bashTool = agent.tools.get('bash');
+    const bashOut = (await bashTool!.execute({ command: 'echo hi' }, agent.ctx)) as {
+      stdout: string;
+      exit_code: number | null;
+    };
+    expect(terminals[0]?.command).toBe('sh');
+    expect(bashOut.stdout).toBe('terminal output');
+    expect(bashOut.exit_code).toBe(0);
+  });
+
+  it('keeps local builtin tools when the client advertises no fs/terminal', async () => {
+    const provider = makeStubProvider();
+    mockSetupProvider.mockResolvedValue({
+      provider,
+      providerRegistry: { has: () => true } as never as ProviderRegistry,
+      resolvedProvider: {} as ResolvedProvider,
+    });
+    const api: RunTurnApi = {
+      clientCapabilities: {},
+      requestPermission: async () => ({ outcome: 'cancelled' }),
+      readTextFile: async () => '',
+      writeTextFile: async () => {},
+      runTerminal: async () => ({ output: '', exitCode: 0 }),
+    };
+    const agent = await buildAcpServerAgentFactory(makeDeps())('s', '/tmp', api);
+    // The builtin read tool is still the local one (its capabilities include fs.read).
+    expect(agent.tools.get('read')?.capabilities).toContain('fs.read');
   });
 
   it('memoizes the provider boot so repeated sessions reuse one setup call', async () => {

--- a/packages/cli/tests/acp-ws-runtime.test.ts
+++ b/packages/cli/tests/acp-ws-runtime.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Runtime WebSocket smoke test for the ACP server transport.
+ *
+ * Earlier WS tests stub the socket (fake sink / fake global WebSocket). This
+ * one uses a REAL `ws` server and the REAL Node global `WebSocket` client via
+ * `ACPSession.connectWebSocket`, so actual bytes cross a real socket through
+ * `WsBridgeTransport` → `ACPProtocolHandler` and back. Proves the live
+ * `wstack acp --ws` wiring works, not just its parts.
+ */
+
+import { ACPSession } from '@wrongstack/acp';
+import { ACPProtocolHandler, type RunTurn, WsBridgeTransport } from '@wrongstack/acp/agent';
+import { afterEach, describe, expect, it } from 'vitest';
+import { type WebSocket, WebSocketServer } from 'ws';
+
+const cleanups: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  // LIFO: close the client (session) before the server, otherwise
+  // wss.close() blocks waiting for the still-connected client.
+  for (const c of cleanups.splice(0).reverse()) await c();
+});
+
+describe('wstack acp --ws runtime', () => {
+  it('serves a real WebSocket connection and runs a prompt turn end-to-end', async () => {
+    const echoTurn: RunTurn = async (input, emit) => {
+      const text = (input.prompt[0] as { text?: string })?.text ?? '';
+      emit({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: `echo: ${text}` },
+      });
+      return { stopReason: 'end_turn' };
+    };
+
+    // Real ws server on an ephemeral port — wire one handler per connection
+    // exactly like runACPWebSocketServer does. Use the constructor's listening
+    // callback to avoid racing the 'listening' event.
+    const wss = await new Promise<WebSocketServer>((resolve) => {
+      const s = new WebSocketServer({ host: '127.0.0.1', port: 0 }, () => resolve(s));
+    });
+    cleanups.push(() => new Promise<void>((r) => wss.close(() => r())));
+    wss.on('connection', (socket: WebSocket) => {
+      const transport = new WsBridgeTransport((m) => socket.send(JSON.stringify(m)));
+      const handler = new ACPProtocolHandler({
+        transport,
+        defaultCwd: process.cwd(),
+        runTurn: echoTurn,
+      });
+      socket.on('message', (data: Buffer) => {
+        let msg: unknown;
+        try {
+          msg = JSON.parse(data.toString());
+        } catch {
+          return;
+        }
+        transport.receive(msg as never);
+        void handler.handleMessage(msg);
+      });
+      socket.on('close', () => {
+        handler.close();
+        transport.close();
+      });
+    });
+
+    const addr = wss.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    expect(port).toBeGreaterThan(0);
+
+    // Real client over a real WebSocket.
+    const session = await ACPSession.connectWebSocket(
+      { url: `ws://127.0.0.1:${port}` },
+      { command: 'ws', projectRoot: process.cwd(), timeoutMs: 10_000 },
+    );
+    cleanups.push(() => session.close());
+
+    expect(session.getAgentInfo()?.name).toBe('wrongstack');
+
+    const result = await session.prompt(
+      [{ type: 'text', text: 'ping' }],
+      new AbortController().signal,
+    );
+    expect(result.text).toBe('echo: ping');
+    expect(result.stopReason).toBe('end_turn');
+  }, 20_000);
+});


### PR DESCRIPTION
## Summary

Takes the ACP integration from **wire-compliant** (every method answered with a spec-shaped response) to **functionally complete** in both directions, with end-to-end interop and real-socket validation. Builds on the existing `@wrongstack/acp` package.

### Client (DIR-1 — WrongStack driving external agents)
- **A1/A2** capture `tool_call`/`tool_call_update`/diff/thought into the run result + live `onProgress` streaming (was: text-only, everything else dropped).
- **A3** inject a real permission policy; added `readOnlyPermissionPolicy` + `makePermissionPolicy` (was: silent auto-approve only).
- **A4** Director catalog parity — `buildACPRunner` falls back to the 12-entry catalog (claude-code/codex-cli/opencode/cursor now spawn from the Director, not just `acp spawn`).
- **A5/A6/A7/A9** persistent multi-turn sessions, MCP passthrough, multimodal blocks, lenient protocol-version negotiation. Real tool-call metrics + watchdog keepalive.
- **A8** remote agents over WebSocket — `ACPSession.connectWebSocket` + `WebSocketClientTransport` (Node built-in `WebSocket`, no dep); transport abstracted behind `ACPClientTransport` (stdio path unchanged).

### Agent (DIR-2 — editors driving WrongStack)
- **B1** stream `tool_call`/`tool_call_update` from the core agent's event bus (kind inference + output) → editors render live tool cards.
- **B2** `session/request_permission` round-trip to the client via a new outbound-request channel; side-effecting tools gated, read-only auto-approved, fail-safe deny.
- **B3** use the client's `fs`/`terminal` via ACP-backed `read`/`write`/`edit`/`bash` tools (reusing builtin schemas) when the client advertises the capability.
- **B4** `session/load` history replay + cross-process persist/restore (`ACPSessionStore`) + **agent model-context reseed** so the model resumes, not just the editor UI.
- **B5** multimodal input + `promptCapabilities.image: true`.
- **B6** fix HTTP transport response capture (previously read a non-existent field → `undefined`).
- WebSocket **server** transport: `wstack acp --ws[=port]` (+ `--echo`), full-duplex live streaming (`WsBridgeTransport`).

## Tests
~21 new acp/cli tests, including an **in-process client↔server loopback** (JSON round-trip per hop) and a **real-socket WebSocket runtime** smoke. Full repo green: typecheck + build + 12,371 tests, zero errors.

## Docs
- `packages/acp/COMPLIANCE.md` rewritten to separate **wire-compliance** from **functional fidelity**, with an honest known-limitations section.
- New `docs/acp-editor-integration.md` — connect Zed/JetBrains, transports, and a per-capability verification checklist.

## Not yet done (deliberate, documented)
- SSE transport (SDK-types-only); HTTP-POST client (WebSocket covers remote); wiring the official SDK runtime into the live paths (the hand-rolled impl is tested; WS goal met natively).
- **Real third-party editor field round-trip** — not runnable from CI; the new guide is the checklist for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)