### PR TITLE
fix(tui): swallow Enter mid-paste to prevent Windows paste corruption

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -4327,6 +4327,14 @@ export function App({
       return;
     }
 
+    // ── Paste-active guard: swallow Enter mid-paste ──────────────────
+    // Ink can split `\r\n` (which arrives inside a paste payload) into
+    // BOTH a raw `\r` character AND a decoded Enter event (key.return,
+    // input=''). The former is correctly accumulated by feedPaste above,
+    // but the decoded Enter has input='' → it bypasses feedPaste and
+    // would submit the buffer mid-paste. Catch it here.
+    if (pasteAccumRef.current !== null && isEnter) return;
+
     // IMPORTANT: do NOT bail on `!input` here. Special keys (arrows,
     // Enter, Escape, Tab, Backspace) arrive with an empty `input`
     // string, and the slash/file pickers + cursor movement below all

--- a/packages/tui/tests/paste-accumulator.test.ts
+++ b/packages/tui/tests/paste-accumulator.test.ts
@@ -43,6 +43,17 @@ describe('feedPaste', () => {
     expect(r3).toEqual({ accum: null, complete: 'a\nb' });
   });
 
+  it('accumulates \\r (Windows CR) mid-paste same as \\n', () => {
+    // Windows terminals send \r\n for newlines. Ink may split these into
+    // separate events; feedPaste must accumulate \r as ordinary content.
+    const r1 = feedPaste(null, `${BEGIN}hello`);
+    expect(r1?.complete).toBeNull();
+    const r2 = feedPaste(r1?.accum ?? null, '\r');
+    expect(r2).toEqual({ accum: 'hello\r', complete: null });
+    const r3 = feedPaste(r2?.accum ?? null, `world${END}`);
+    expect(r3).toEqual({ accum: null, complete: 'hello\rworld' });
+  });
+
   it('strips begin and end markers even when both arrive in the same later fragment', () => {
     const r1 = feedPaste(null, `${BEGIN}x`);
     const r2 = feedPaste(r1?.accum ?? null, `y${END}`);


### PR DESCRIPTION
Ink can split CRLF (which arrives inside a bracketed paste payload on Windows) into BOTH a raw CR character AND a decoded Enter event (key.return, input=). The raw CR is correctly accumulated by feedPaste, but the decoded Enter has input= - bypasses feedPaste and would submit the buffer mid-paste.

Fix: add a guard in handleKey that swallows Enter events while paste accumulation is active (pasteAccumRef.current !== null).

Also adds a test verifying that CR (Windows CR) is accumulated as ordinary content mid-paste, not triggering completion.
