### PR TITLE
feat(webui): subscription OAuth login (ChatGPT/Claude/Copilot) + key-entry UX refresh

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -185,6 +185,9 @@ import {
   handleModelSwitch,
   handleModeSwitch,
   handleModesList,
+  handleOAuthCancel,
+  handleOAuthCode,
+  handleOAuthStart,
   handlePing,
   handlePlanGet,
   handlePlanItemUpdate,
@@ -600,16 +603,21 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       const projectName = opts.projectRoot ? path.basename(opts.projectRoot) : 'unknown';
       await mailbox.registerClient({
         clientId: webuiClientId,
-        sessionId: projectRoot,
+        sessionId: opts.agent.ctx.session?.id ?? opts.session.id,
         name: `WebUI [${projectName}]`,
         source: 'webui',
         pid: process.pid,
       });
 
       webuiHeartbeatTimer = setInterval(() => {
-        mailbox.clientHeartbeat({ clientId: webuiClientId! }).catch(() => {
-          // best-effort — ignore heartbeat failures during shutdown
-        });
+        mailbox
+          .clientHeartbeat({
+            clientId: webuiClientId!,
+            sessionId: opts.agent.ctx.session?.id ?? opts.session.id,
+          })
+          .catch(() => {
+            // best-effort — ignore heartbeat failures during shutdown
+          });
       }, CLIENT_HEARTBEAT_MS);
       webuiHeartbeatTimer.unref();
 
@@ -743,17 +751,21 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
   const STREAM_COALESCE_MS = 16;
   const STREAM_COALESCE_MAX_CHARS = 8 * 1024;
   const currentSessionId = (): string => opts.agent.ctx.session?.id ?? opts.session.id;
-  const sessionPayload = <T extends Record<string, unknown>>(payload: T): T & { sessionId: string } => ({
-    ...payload,
-    sessionId: currentSessionId(),
-  });
+  const sessionPayload = <T extends Record<string, unknown>>(payload: T): T & { sessionId: string } => {
+    const provided = payload['sessionId'];
+    const sessionId = typeof provided === 'string' && provided.length > 0 ? provided : currentSessionId();
+    return { ...payload, sessionId };
+  };
   let textDeltaBuffer = '';
+  let textDeltaSessionId: string | undefined;
   let textDeltaTimer: ReturnType<typeof setTimeout> | null = null;
   let thinkingDeltaBuffer = '';
+  let thinkingDeltaSessionId: string | undefined;
   let thinkingDeltaTimer: ReturnType<typeof setTimeout> | null = null;
   const toolProgressBuffers = new Map<
     string,
     {
+      sessionId?: string | undefined;
       id: string;
       name: string;
       eventType: string;
@@ -769,10 +781,12 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     }
     if (!textDeltaBuffer) return;
     const text = textDeltaBuffer;
+    const sessionId = textDeltaSessionId;
     textDeltaBuffer = '';
+    textDeltaSessionId = undefined;
     broadcast({
       type: 'provider.text_delta',
-      payload: sessionPayload({ text, messageId: 'current' }),
+      payload: sessionPayload({ sessionId, text, messageId: 'current' }),
     });
   };
 
@@ -783,15 +797,21 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     }
     if (!thinkingDeltaBuffer) return;
     const text = thinkingDeltaBuffer;
+    const sessionId = thinkingDeltaSessionId;
     thinkingDeltaBuffer = '';
+    thinkingDeltaSessionId = undefined;
     broadcast({
       type: 'provider.thinking_delta',
-      payload: sessionPayload({ text }),
+      payload: sessionPayload({ sessionId, text }),
     });
   };
 
-  const queueTextDelta = (text: string): void => {
+  const queueTextDelta = (text: string, sessionId?: string | undefined): void => {
     if (!text) return;
+    if (textDeltaBuffer && textDeltaSessionId !== sessionId) {
+      flushTextDelta();
+    }
+    textDeltaSessionId = sessionId;
     textDeltaBuffer += text;
     if (textDeltaBuffer.length >= STREAM_COALESCE_MAX_CHARS) {
       flushTextDelta();
@@ -803,8 +823,12 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     }
   };
 
-  const queueThinkingDelta = (text: string): void => {
+  const queueThinkingDelta = (text: string, sessionId?: string | undefined): void => {
     if (!text) return;
+    if (thinkingDeltaBuffer && thinkingDeltaSessionId !== sessionId) {
+      flushThinkingDelta();
+    }
+    thinkingDeltaSessionId = sessionId;
     thinkingDeltaBuffer += text;
     if (thinkingDeltaBuffer.length >= STREAM_COALESCE_MAX_CHARS) {
       flushThinkingDelta();
@@ -825,6 +849,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     broadcast({
       type: 'tool.progress',
       payload: sessionPayload({
+        sessionId: buffered.sessionId,
         name: buffered.name,
         id: buffered.id,
         event: { type: buffered.eventType, text: buffered.text },
@@ -839,6 +864,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
   };
 
   const queueToolProgress = (payload: {
+    sessionId?: string | undefined;
     id: string;
     name: string;
     event: { type?: string | undefined; text?: string | undefined };
@@ -852,14 +878,17 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
 
     const eventType = payload.event.type ?? 'progress';
     const existing = toolProgressBuffers.get(payload.id);
+    if (existing && existing.sessionId !== payload.sessionId) flushToolProgress(payload.id);
     if (existing && existing.eventType !== eventType) flushToolProgress(payload.id);
     const buffered = toolProgressBuffers.get(payload.id) ?? {
+      sessionId: payload.sessionId,
       id: payload.id,
       name: payload.name,
       eventType,
       text: '',
       timer: null,
     };
+    buffered.sessionId = payload.sessionId;
     buffered.name = payload.name;
     buffered.text += buffered.text ? `\n${text}` : text;
     toolProgressBuffers.set(payload.id, buffered);
@@ -906,6 +935,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'iteration.started',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             index: e.index,
             ...(typeof maxIt === 'number' ? { maxIterations: maxIt } : {}),
           }),
@@ -917,13 +947,14 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       opts.events.on('iteration.completed', (e) => {
         broadcast({
           type: 'iteration.completed',
-          payload: sessionPayload({ index: e.index, totalIterations: e.index + 1 }),
+          payload: sessionPayload({ sessionId: e.sessionId, index: e.index, totalIterations: e.index + 1 }),
         });
       }),
       opts.events.on('iteration.limit_reached', (e) => {
         broadcast({
           type: 'iteration.limit_reached',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             currentIterations: e.currentIterations,
             currentLimit: e.currentLimit,
           }),
@@ -935,7 +966,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     eventUnsubscribers.push(
       opts.events.on('provider.text_delta', (e) => {
         flushThinkingDelta();
-        queueTextDelta(e.text);
+        queueTextDelta(e.text, e.sessionId);
       }),
     );
 
@@ -944,7 +975,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     // collapsible thinking log when the iteration ends.
     eventUnsubscribers.push(
       opts.events.on('provider.thinking_delta', (e) => {
-        queueThinkingDelta(e.text);
+        queueThinkingDelta(e.text, e.sessionId);
       }),
     );
 
@@ -952,7 +983,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       opts.events.on('provider.stream_error', (e) => {
         broadcast({
           type: 'provider.stream_error',
-          payload: sessionPayload({ eventType: e.eventType, message: e.msg }),
+          payload: sessionPayload({ sessionId: e.sessionId, eventType: e.eventType, message: e.msg }),
         });
       }),
     );
@@ -964,6 +995,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'tool.started',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             id: e.id,
             name: e.name,
             input: secretScrubber.scrubObject(e.input),
@@ -977,6 +1009,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     eventUnsubscribers.push(
       opts.events.on('tool.progress', (e) => {
         queueToolProgress({
+          sessionId: e.sessionId,
           name: e.name,
           id: e.id,
           event: e.event,
@@ -991,6 +1024,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'tool.executed',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             // Forward the tool_use id so the WebUI can correlate this with
             // the matching tool.started bubble for parallel tool calls.
             id: e.id,
@@ -1005,7 +1039,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         // Always broadcast current todos so the panel stays in sync.
         broadcast({
           type: 'todos.updated',
-          payload: sessionPayload({ todos: [...opts.agent.ctx.todos] }),
+          payload: sessionPayload({ sessionId: e.sessionId, todos: [...opts.agent.ctx.todos] }),
         });
 
         // After task/plan/todo tool executions, also broadcast those snapshots.
@@ -1018,7 +1052,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
                 const file = await loadTasks(taskPath);
                 broadcast({
                   type: 'tasks.updated',
-                  payload: sessionPayload({ tasks: file?.tasks ?? [] }),
+                  payload: sessionPayload({ sessionId: e.sessionId, tasks: file?.tasks ?? [] }),
                 });
               }
             } catch {
@@ -1032,9 +1066,10 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
                 broadcast({
                   type: 'plan.updated',
                   payload: sessionPayload({
+                    sessionId: e.sessionId,
                     plan: plan ?? {
                       version: 1,
-                      sessionId: currentSessionId(),
+                      sessionId: e.sessionId ?? currentSessionId(),
                       updatedAt: new Date().toISOString(),
                       items: [],
                     },
@@ -1054,6 +1089,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'tool.loop_detected',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             tools: e.tools,
             repeatCount: e.repeatCount,
             iteration: e.iteration,
@@ -1064,19 +1100,20 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       opts.events.on('trust.persisted', (e) => {
         broadcast({
           type: 'trust.persisted',
-          payload: sessionPayload({ tool: e.tool, pattern: e.pattern, decision: e.decision }),
+          payload: sessionPayload({ sessionId: e.sessionId, tool: e.tool, pattern: e.pattern, decision: e.decision }),
         });
       }),
       opts.events.on('delegate.started', (e) => {
         broadcast({
           type: 'delegate.started',
-          payload: sessionPayload({ target: e.target, task: e.task }),
+          payload: sessionPayload({ sessionId: e.sessionId, target: e.target, task: e.task }),
         });
       }),
       opts.events.on('delegate.completed', (e) => {
         broadcast({
           type: 'delegate.completed',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             target: e.target,
             task: e.task,
             ok: e.ok,
@@ -1099,6 +1136,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'provider.response',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             usage: e.usage,
             stopReason: e.stopReason,
             messageId: 'current',
@@ -1111,11 +1149,12 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       opts.events.on('ctx.pct', (e) => {
         broadcast({
           type: 'ctx.pct',
-          payload: sessionPayload({ load: e.load, tokens: e.tokens, maxContext: e.maxContext }),
+          payload: sessionPayload({ sessionId: e.sessionId, load: e.load, tokens: e.tokens, maxContext: e.maxContext }),
         });
         broadcast({
           type: 'subagent.event',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             kind: 'ctx_pct',
             subagentId: 'leader',
             load: e.load,
@@ -1127,7 +1166,18 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       opts.events.on('ctx.max_context', (e) => {
         broadcast({
           type: 'ctx.max_context',
-          payload: sessionPayload({ providerId: e.providerId, modelId: e.modelId, maxContext: e.maxContext }),
+          payload: sessionPayload({ sessionId: e.sessionId, providerId: e.providerId, modelId: e.modelId, maxContext: e.maxContext }),
+        });
+      }),
+      opts.events.on('context.repaired', (e) => {
+        broadcast({
+          type: 'context.repaired',
+          payload: sessionPayload({
+            sessionId: e.sessionId,
+            removedToolUses: e.removedToolUses,
+            removedToolResults: e.removedToolResults,
+            removedMessages: e.removedMessages,
+          }),
         });
       }),
       opts.events.on('token.threshold', (e) => {
@@ -1149,6 +1199,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'provider.retry',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             providerId: e.providerId,
             attempt: e.attempt,
             delayMs: e.delayMs,
@@ -1161,6 +1212,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'provider.error',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             providerId: e.providerId,
             status: e.status,
             description: e.description,
@@ -1172,6 +1224,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'provider.fallback',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             from: e.from,
             to: e.to,
             status: e.status,
@@ -1183,6 +1236,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'context.compacted',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             before: e.report.before,
             after: e.report.after,
             saved: Math.max(0, e.report.before - e.report.after),
@@ -1194,6 +1248,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'compaction.failed',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             message: e.err.message,
             aggressive: e.aggressive,
             level: e.level,
@@ -1268,6 +1323,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'session.rewound',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             toPromptIndex: e.toPromptIndex,
             revertedFiles: e.revertedFiles,
             removedEvents: e.removedEvents,
@@ -1278,6 +1334,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'checkpoint.written',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             promptIndex: e.promptIndex,
             promptPreview: e.promptPreview,
             ts: e.ts,
@@ -1288,13 +1345,13 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       opts.events.on('in_flight.started', (e) => {
         broadcast({
           type: 'in_flight.started',
-          payload: sessionPayload({ context: e.context, ts: e.ts }),
+          payload: sessionPayload({ sessionId: e.sessionId, context: e.context, ts: e.ts }),
         });
       }),
       opts.events.on('in_flight.ended', (e) => {
         broadcast({
           type: 'in_flight.ended',
-          payload: sessionPayload({ reason: e.reason, ts: e.ts }),
+          payload: sessionPayload({ sessionId: e.sessionId, reason: e.reason, ts: e.ts }),
         });
       }),
       opts.events.on('concurrency.changed', (e) => {
@@ -1314,6 +1371,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         broadcast({
           type: 'tool.confirm_needed',
           payload: sessionPayload({
+            sessionId: e.sessionId,
             id,
             toolName: e.tool?.name ?? 'unknown',
             input: secretScrubber.scrubObject(e.input),
@@ -1337,6 +1395,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         fleetConcurrency += 1;
         emitConcurrency();
         forwardSubagent('spawned', {
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           taskId: e.taskId,
           name: e.name,
@@ -1347,6 +1406,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       }),
       opts.events.on('subagent.task_started', (e) =>
         forwardSubagent('task_started', {
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           taskId: e.taskId,
           description: e.description,
@@ -1354,6 +1414,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       ),
       opts.events.on('subagent.tool_executed', (e) =>
         forwardSubagent('tool_executed', {
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           toolName: e.name,
           durationMs: e.durationMs,
@@ -1362,6 +1423,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       ),
       opts.events.on('subagent.iteration_summary', (e) =>
         forwardSubagent('iteration_summary', {
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           iteration: e.iteration,
           toolCalls: e.toolCalls,
@@ -1372,6 +1434,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       ),
       opts.events.on('subagent.budget_warning', (e) =>
         forwardSubagent('budget_warning', {
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           budgetKind: e.kind,
           used: e.used,
@@ -1380,6 +1443,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       ),
       opts.events.on('subagent.budget_extended', (e) =>
         forwardSubagent('budget_extended', {
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           budgetKind: e.kind,
           newLimit: e.newLimit,
@@ -1388,6 +1452,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       ),
       opts.events.on('subagent.ctx_pct', (e) =>
         forwardSubagent('ctx_pct', {
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           load: e.load,
           tokens: e.tokens,
@@ -1398,6 +1463,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         fleetConcurrency = Math.max(0, fleetConcurrency - 1);
         emitConcurrency();
         forwardSubagent('task_completed', {
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           status: e.status,
           iterations: e.iterations,
@@ -1414,6 +1480,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       broadcast({
         type: 'agent.timeline.message',
         payload: sessionPayload({
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           agentName: e.agentName,
           content: e.content,
@@ -1429,6 +1496,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       broadcast({
         type: 'agent.status_changed',
         payload: sessionPayload({
+          sessionId: e.sessionId,
           subagentId: e.subagentId,
           agentName: e.agentName,
           status: e.status,
@@ -1464,7 +1532,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       opts.events.onPattern('mailbox.*', (eventName, payload) => {
         broadcast({
           type: 'mailbox.event',
-          payload: { event: eventName, ...(payload as Record<string, unknown>) },
+          payload: sessionPayload({ event: eventName, ...(payload as Record<string, unknown>) }),
         });
       }),
     );
@@ -1474,7 +1542,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       opts.events.onPattern('brain.*', (eventName, payload) => {
         broadcast({
           type: 'brain.event',
-          payload: { event: eventName, ...(payload as Record<string, unknown>) },
+          payload: sessionPayload({ event: eventName, ...(payload as Record<string, unknown>) }),
         });
       }),
     );
@@ -1564,6 +1632,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
       (opts.agent.container.has(TOKENS.BrainArbiter)
         ? opts.agent.container.resolve(TOKENS.BrainArbiter)
         : undefined),
+    getSessionId: currentSessionId,
     send,
     broadcast,
     log: (m) => console.log(m),
@@ -1866,7 +1935,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
           if (++msgCount > rateLimitMax) {
             send(ws, {
               type: 'error',
-              payload: { phase: 'rate_limit', message: 'Too many messages. Please wait.' },
+              payload: sessionPayload({ phase: 'rate_limit', message: 'Too many messages. Please wait.' }),
             });
             return;
           }
@@ -2036,6 +2105,12 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
   const projectRootFor = () =>
     opts.projectRoot ?? (opts.agent.ctx as { projectRoot?: string }).projectRoot ?? '';
 
+  /** Validate an `auth.oauth.*` message's `kind` field. */
+  const oauthKindOf = (msg: unknown): 'chatgpt' | 'claude' | 'copilot' | null => {
+    const kind = (msg as { payload?: { kind?: unknown } })?.payload?.kind;
+    return kind === 'chatgpt' || kind === 'claude' || kind === 'copilot' ? kind : null;
+  };
+
   const wsRoutes: Record<string, WsRouteHandler> = {
     // ── Core connection ──
     user_message: (msg, ws) =>
@@ -2131,6 +2206,23 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     'provider.probe': (msg, ws) => {
       const m = msg as { payload: { providerId: string; timeoutMs?: number } };
       handleProviderProbe(wsHandlerCtx, ws, m.payload.providerId, m.payload.timeoutMs);
+    },
+
+    // ── Subscription OAuth login (ChatGPT / Claude / Copilot) ──
+    'auth.oauth.start': (msg, ws) => {
+      const kind = oauthKindOf(msg);
+      if (kind) void handleOAuthStart(wsHandlerCtx, ws, kind);
+    },
+    'auth.oauth.code': (msg, ws) => {
+      const kind = oauthKindOf(msg);
+      const input = (msg as { payload?: { input?: unknown } }).payload?.input;
+      if (kind && typeof input === 'string' && input.trim()) {
+        void handleOAuthCode(wsHandlerCtx, ws, kind, input);
+      }
+    },
+    'auth.oauth.cancel': (msg, ws) => {
+      const kind = oauthKindOf(msg);
+      if (kind) handleOAuthCancel(wsHandlerCtx, ws, kind);
     },
 
     // ── Todos / goals / plans / tasks ──

--- a/packages/cli/src/webui-server/ws-handlers/index.ts
+++ b/packages/cli/src/webui-server/ws-handlers/index.ts
@@ -120,6 +120,7 @@ export {
   handleProvidersSaved,
   broadcastSaved,
 } from './providers.js';
+export { handleOAuthStart, handleOAuthCode, handleOAuthCancel } from './oauth.js';
 export {
   handleGoalGet,
   handleSessionCheckpoints,

--- a/packages/cli/src/webui-server/ws-handlers/oauth.ts
+++ b/packages/cli/src/webui-server/ws-handlers/oauth.ts
@@ -1,0 +1,153 @@
+/**
+ * Subscription OAuth login (ChatGPT / Claude / Copilot) for the embedded
+ * WebUI server. Mirrors the standalone server's `oauth-handlers`, but persists
+ * through the `ProviderConfigStore` on `WsHandlerContext`.
+ *
+ * The flow engine (`@wrongstack/providers/oauth`) is IO-free — it drives the
+ * loopback / device-code protocol and returns a persistence-agnostic outcome
+ * that we upsert here. Progress is surfaced to the client as `auth.oauth.status`.
+ */
+
+import type { ProviderConfig } from '@wrongstack/core';
+import { toErrorMessage } from '@wrongstack/core/utils';
+import {
+  beginOAuthLogin,
+  type OAuthKind,
+  type OAuthLoginOutcome,
+  type OAuthSession,
+} from '@wrongstack/providers/oauth';
+import type { WebSocket } from 'ws';
+import { normalizeKeys, writeKeysBack } from '../provider-config.js';
+import type { WsHandlerContext } from './index.js';
+import { broadcastSaved } from './providers.js';
+
+type OAuthPhase =
+  | 'awaiting_browser'
+  | 'awaiting_code'
+  | 'exchanging'
+  | 'fetching_models'
+  | 'success'
+  | 'error';
+
+/** One in-flight session per kind, process-wide (single-user embedded server). */
+const oauthSessions = new Map<OAuthKind, OAuthSession>();
+
+function sendStatus(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  kind: OAuthKind,
+  phase: OAuthPhase,
+  extra: Record<string, unknown> = {},
+): void {
+  ctx.send(ws, { type: 'auth.oauth.status', payload: { kind, phase, ...extra } });
+}
+
+async function persistOutcome(ctx: WsHandlerContext, outcome: OAuthLoginOutcome): Promise<void> {
+  const providers = await ctx.providerStore.load();
+  const existing = providers[outcome.providerId];
+  const p: ProviderConfig = existing ? { ...existing } : { type: outcome.providerId };
+  p.family = outcome.family as ProviderConfig['family'];
+  if (!p.baseUrl) p.baseUrl = outcome.baseUrl;
+  p.models = [...outcome.models];
+  const keys = normalizeKeys(p).filter((k) => k.label !== outcome.apiKey.label);
+  keys.push(outcome.apiKey);
+  writeKeysBack(p, keys);
+  p.activeKey = outcome.apiKey.label;
+  providers[outcome.providerId] = p;
+  await ctx.providerStore.save(providers);
+  broadcastSaved(ctx, providers);
+}
+
+async function finish(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  kind: OAuthKind,
+  outcome: OAuthLoginOutcome | null,
+): Promise<void> {
+  if (!outcome) {
+    sendStatus(ctx, ws, kind, 'error', { message: 'Sign-in cancelled or timed out.' });
+    return;
+  }
+  sendStatus(ctx, ws, kind, 'fetching_models', { providerId: outcome.providerId });
+  await persistOutcome(ctx, outcome);
+  sendStatus(ctx, ws, kind, 'success', {
+    providerId: outcome.providerId,
+    message: `Signed in — saved as ${outcome.providerId} (${outcome.models.length} models).`,
+  });
+}
+
+export async function handleOAuthStart(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  kind: OAuthKind,
+): Promise<void> {
+  try {
+    oauthSessions.get(kind)?.close();
+    oauthSessions.delete(kind);
+
+    const session = await beginOAuthLogin(kind, { modelsRegistry: ctx.modelsRegistry });
+    oauthSessions.set(kind, session);
+
+    if (kind === 'copilot') {
+      sendStatus(ctx, ws, kind, 'awaiting_code', {
+        providerId: session.providerId,
+        verificationUri: session.verificationUri,
+        userCode: session.userCode,
+        bound: false,
+      });
+    } else {
+      sendStatus(ctx, ws, kind, 'awaiting_browser', {
+        providerId: session.providerId,
+        authorizeUrl: session.authorizeUrl,
+        bound: session.bound,
+      });
+    }
+
+    const drive = kind === 'copilot' || session.bound;
+    if (drive) {
+      void (async () => {
+        try {
+          const outcome = await session.waitForCompletion();
+          await finish(ctx, ws, kind, outcome);
+        } catch (err) {
+          sendStatus(ctx, ws, kind, 'error', { message: toErrorMessage(err) });
+        } finally {
+          if (oauthSessions.get(kind) === session) oauthSessions.delete(kind);
+        }
+      })();
+    }
+  } catch (err) {
+    sendStatus(ctx, ws, kind, 'error', { message: toErrorMessage(err) });
+  }
+}
+
+export async function handleOAuthCode(
+  ctx: WsHandlerContext,
+  ws: WebSocket,
+  kind: OAuthKind,
+  input: string,
+): Promise<void> {
+  const session = oauthSessions.get(kind);
+  if (!session) {
+    sendStatus(ctx, ws, kind, 'error', {
+      message: 'No active sign-in for this provider — start the login again.',
+    });
+    return;
+  }
+  try {
+    sendStatus(ctx, ws, kind, 'exchanging', { providerId: session.providerId });
+    const outcome = await session.completeWithCode(input);
+    await finish(ctx, ws, kind, outcome);
+  } catch (err) {
+    sendStatus(ctx, ws, kind, 'error', { message: toErrorMessage(err) });
+  } finally {
+    session.close();
+    if (oauthSessions.get(kind) === session) oauthSessions.delete(kind);
+  }
+}
+
+export function handleOAuthCancel(ctx: WsHandlerContext, ws: WebSocket, kind: OAuthKind): void {
+  oauthSessions.get(kind)?.close();
+  oauthSessions.delete(kind);
+  sendStatus(ctx, ws, kind, 'error', { message: 'Sign-in cancelled.' });
+}

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -19,6 +19,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./oauth": {
+      "types": "./dist/oauth/index.d.ts",
+      "import": "./dist/oauth/index.js"
     }
   },
   "files": [

--- a/packages/providers/src/oauth/chatgpt.ts
+++ b/packages/providers/src/oauth/chatgpt.ts
@@ -1,0 +1,292 @@
+/**
+ * ChatGPT — "Sign in with ChatGPT" OAuth (Authorization Code + PKCE).
+ *
+ * Headless port of the CLI's `openai-codex-oauth.ts` terminal flow. Drives the
+ * loopback authorization-code exchange and returns a persistence-agnostic
+ * {@link OAuthLoginOutcome}. See the CLI module's header for the protocol
+ * rationale (ChatGPT backend, JWT account-id claim, etc.).
+ */
+
+import {
+  CODEX_MODELS,
+  FetchError,
+  type ModelsRegistry,
+  ParseError,
+  type ProviderApiKey,
+} from '@wrongstack/core';
+import { extractAccountId } from '../openai-codex.js';
+import {
+  createState,
+  generatePkce,
+  type LoopbackServer,
+  parseAuthorizationInput,
+  startLoopbackServer,
+} from './shared.js';
+import type { BeginOAuthDeps, OAuthLoginOutcome, OAuthSession } from './types.js';
+
+// ── Codex OAuth constants (verified against the real Codex CLI) ─────────────
+
+const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const AUTH_BASE_URL = 'https://auth.openai.com';
+const AUTHORIZE_URL = `${AUTH_BASE_URL}/oauth/authorize`;
+const TOKEN_URL = `${AUTH_BASE_URL}/oauth/token`;
+const REDIRECT_PORT = 1455;
+const REDIRECT_HOST = '127.0.0.1';
+const REDIRECT_PATH = '/auth/callback';
+const REDIRECT_URI = `http://localhost:${REDIRECT_PORT}${REDIRECT_PATH}`;
+const SCOPE = 'openid profile email offline_access';
+const ORIGINATOR = 'wrongstack';
+export const CODEX_PROVIDER_ID = 'openai-codex';
+export const CODEX_BASE_URL = 'https://chatgpt.com/backend-api';
+
+interface CodexTokens {
+  access: string;
+  refresh: string;
+  /** Absolute expiry in epoch milliseconds. */
+  expires: number;
+}
+
+interface TokenEndpointResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  id_token?: string;
+}
+
+/** Build the full authorize URL with all Codex-required query params. */
+export function buildCodexAuthorizeUrl(challenge: string, state: string): string {
+  const url = new URL(AUTHORIZE_URL);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', CLIENT_ID);
+  url.searchParams.set('redirect_uri', REDIRECT_URI);
+  url.searchParams.set('scope', SCOPE);
+  url.searchParams.set('code_challenge', challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', state);
+  url.searchParams.set('id_token_add_organizations', 'true');
+  url.searchParams.set('codex_cli_simplified_flow', 'true');
+  url.searchParams.set('originator', ORIGINATOR);
+  return url.toString();
+}
+
+// ── Model discovery (live backend → catalog → inline fallback) ────────────────
+
+const FALLBACK_CODEX_MODELS: ReadonlyArray<{ id: string; name: string }> = CODEX_MODELS.map(
+  (m) => ({
+    id: m.id,
+    name: m.name,
+  }),
+);
+const CODEX_CATALOG_FAMILIES = new Set(['gpt-codex', 'gpt-codex-spark']);
+
+export function filterCurrentCodexModelIds(ids: Iterable<string>): string[] {
+  const available = new Set(ids);
+  return FALLBACK_CODEX_MODELS.map((m) => m.id).filter((id) => available.has(id));
+}
+
+async function fetchCodexModels(
+  accessToken: string,
+  baseUrl?: string | undefined,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const url = `${(baseUrl ?? CODEX_BASE_URL).replace(/\/+$/, '')}/models`;
+  try {
+    const res = await fetch(url, {
+      headers: {
+        accept: 'application/json',
+        authorization: `Bearer ${accessToken}`,
+        originator: 'wrongstack',
+        'OpenAI-Beta': 'responses=experimental',
+      },
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(8_000)])
+        : AbortSignal.timeout(8_000),
+    });
+    if (!res.ok) return [];
+    const json = (await res.json()) as
+      | { data?: Array<{ id?: string }> }
+      | { models?: Array<{ id?: string }> }
+      | null;
+    if (!json) return [];
+    const rawList: unknown[] =
+      'data' in json && Array.isArray(json.data)
+        ? (json.data as unknown[])
+        : 'models' in json && Array.isArray(json.models)
+          ? (json.models as unknown[])
+          : [];
+    const ids: string[] = [];
+    for (const entry of rawList) {
+      if (!entry || typeof entry !== 'object') continue;
+      const id = (entry as Record<string, unknown>).id;
+      if (typeof id === 'string' && id.length > 0) ids.push(id);
+    }
+    return ids;
+  } catch {
+    return [];
+  }
+}
+
+async function resolveCodexModels(
+  modelsRegistry: ModelsRegistry | undefined,
+  accessToken: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  // Tier 1 — live backend
+  const live = filterCurrentCodexModelIds(
+    await fetchCodexModels(accessToken, CODEX_BASE_URL, signal),
+  );
+  if (live.length > 0) return live;
+
+  // Tier 2 — models.dev catalog (best-effort; registry is optional)
+  if (modelsRegistry) {
+    try {
+      const openaiProvider = await modelsRegistry.getProvider('openai');
+      if (openaiProvider) {
+        const catalog = openaiProvider.models
+          .filter((m) => typeof m.family === 'string' && CODEX_CATALOG_FAMILIES.has(m.family))
+          .map((m) => m.id)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0);
+        const currentCatalog = filterCurrentCodexModelIds(catalog);
+        if (currentCatalog.length > 0) return currentCatalog;
+      }
+    } catch {
+      /* catalog unavailable — fall through */
+    }
+  }
+
+  // Tier 3 — inline fallback
+  return FALLBACK_CODEX_MODELS.map((m) => m.id);
+}
+
+// ── Token exchange ────────────────────────────────────────────────────────────
+
+async function readTokens(res: Response, op: string): Promise<CodexTokens> {
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new FetchError({
+      message: `Codex token ${op} failed (${res.status}): ${text || res.statusText}`,
+      status: res.status,
+      context: { provider: 'openai-codex', op, url: TOKEN_URL },
+    });
+  }
+  const json = (await res.json()) as TokenEndpointResponse | null;
+  if (!json?.access_token || !json.refresh_token || typeof json.expires_in !== 'number') {
+    throw new ParseError({
+      message: `Codex token ${op} response missing fields`,
+      source: 'openai-codex-token-response',
+      context: { op },
+    });
+  }
+  return {
+    access: json.access_token,
+    refresh: json.refresh_token,
+    expires: Date.now() + json.expires_in * 1000,
+  };
+}
+
+async function exchangeAuthorizationCode(
+  code: string,
+  verifier: string,
+  signal?: AbortSignal,
+): Promise<CodexTokens> {
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      code,
+      code_verifier: verifier,
+      redirect_uri: REDIRECT_URI,
+    }).toString(),
+    signal: signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(30_000)])
+      : AbortSignal.timeout(30_000),
+  });
+  return readTokens(res, 'exchange');
+}
+
+// ── Outcome assembly ──────────────────────────────────────────────────────────
+
+async function buildOutcome(
+  deps: BeginOAuthDeps | undefined,
+  tokens: CodexTokens,
+  signal?: AbortSignal,
+): Promise<OAuthLoginOutcome> {
+  const accountId = extractAccountId(tokens.access);
+  if (!accountId) {
+    throw new ParseError({
+      message:
+        'Signed in, but the token has no ChatGPT account id. This account may lack Codex/ChatGPT subscription access.',
+      source: 'openai-codex-token-response',
+    });
+  }
+  const models = await resolveCodexModels(deps?.modelsRegistry, tokens.access, signal);
+  const apiKey: ProviderApiKey = {
+    label: 'oauth-default',
+    apiKey: tokens.access,
+    createdAt: new Date().toISOString(),
+    authMethod: 'oauth',
+    expiresAt: new Date(tokens.expires).toISOString(),
+    refreshToken: tokens.refresh,
+    tokenType: 'bearer',
+    scope: SCOPE,
+    accountId,
+  };
+  return {
+    providerId: CODEX_PROVIDER_ID,
+    family: 'openai-codex',
+    baseUrl: CODEX_BASE_URL,
+    models,
+    apiKey,
+  };
+}
+
+// ── Session factory ────────────────────────────────────────────────────────────
+
+export async function beginChatGPTLogin(
+  deps: BeginOAuthDeps | undefined,
+  signal?: AbortSignal,
+): Promise<OAuthSession> {
+  const pkce = generatePkce();
+  const state = createState();
+  const authorizeUrl = buildCodexAuthorizeUrl(pkce.challenge, state);
+
+  const server: LoopbackServer = await startLoopbackServer({
+    port: REDIRECT_PORT,
+    host: REDIRECT_HOST,
+    path: REDIRECT_PATH,
+    expectedState: state,
+    signal,
+  });
+
+  return {
+    kind: 'chatgpt',
+    providerId: CODEX_PROVIDER_ID,
+    bound: server.bound,
+    authorizeUrl,
+    async waitForCompletion(waitSignal?: AbortSignal): Promise<OAuthLoginOutcome | null> {
+      if (!server.bound) return null;
+      const got = await server.waitForCode();
+      if (!got?.code) return null;
+      const tokens = await exchangeAuthorizationCode(got.code, pkce.verifier, waitSignal ?? signal);
+      return buildOutcome(deps, tokens, waitSignal ?? signal);
+    },
+    async completeWithCode(input: string, codeSignal?: AbortSignal): Promise<OAuthLoginOutcome> {
+      const parsed = parseAuthorizationInput(input);
+      if (parsed.state && parsed.state !== state) {
+        throw new Error('State mismatch — please restart the login flow.');
+      }
+      if (!parsed.code) throw new Error('No authorization code found in the pasted value.');
+      const tokens = await exchangeAuthorizationCode(
+        parsed.code,
+        pkce.verifier,
+        codeSignal ?? signal,
+      );
+      return buildOutcome(deps, tokens, codeSignal ?? signal);
+    },
+    close(): void {
+      server.close();
+    },
+  };
+}

--- a/packages/providers/src/oauth/claude.ts
+++ b/packages/providers/src/oauth/claude.ts
@@ -1,0 +1,207 @@
+/**
+ * Claude — "Sign in with Claude" OAuth (Authorization Code + PKCE), Claude
+ * Pro/Max subscription login. Headless port of the CLI's `anthropic-oauth.ts`.
+ *
+ * Anthropic quirks: authorize at claude.ai/oauth/authorize (`code=true`), the
+ * OAuth `state` IS the PKCE verifier, JSON token exchange at
+ * platform.claude.com/v1/oauth/token, loopback callback on :53692/callback.
+ */
+
+import { FetchError, ParseError, type ProviderApiKey } from '@wrongstack/core';
+import {
+  generatePkce,
+  type LoopbackServer,
+  parseAuthorizationInput,
+  startLoopbackServer,
+} from './shared.js';
+import type { BeginOAuthDeps, OAuthLoginOutcome, OAuthSession } from './types.js';
+
+const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const AUTHORIZE_URL = 'https://claude.ai/oauth/authorize';
+const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+const REDIRECT_PORT = 53692;
+const REDIRECT_HOST = '127.0.0.1';
+const REDIRECT_PATH = '/callback';
+const REDIRECT_URI = `http://localhost:${REDIRECT_PORT}${REDIRECT_PATH}`;
+const SCOPES =
+  'org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload';
+export const CLAUDE_PROVIDER_ID = 'anthropic-oauth';
+const CLAUDE_BASE_URL = 'https://api.anthropic.com';
+const DEFAULT_CLAUDE_MODELS = ['claude-sonnet-4-6', 'claude-opus-4-8'];
+
+interface ClaudeTokens {
+  access: string;
+  refresh: string;
+  expires: number;
+}
+
+/** Build the Claude authorize URL. Anthropic uses the PKCE verifier as `state`. */
+export function buildClaudeAuthorizeUrl(challenge: string, verifier: string): string {
+  const params = new URLSearchParams({
+    code: 'true',
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: REDIRECT_URI,
+    scope: SCOPES,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    state: verifier,
+  });
+  return `${AUTHORIZE_URL}?${params.toString()}`;
+}
+
+interface TokenJson {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+}
+
+async function readTokens(res: Response, op: string): Promise<ClaudeTokens> {
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new FetchError({
+      message: `Claude token ${op} failed (${res.status}): ${text || res.statusText}`,
+      status: res.status,
+      context: { provider: 'anthropic-oauth', op, url: TOKEN_URL },
+    });
+  }
+  const json = (await res.json()) as TokenJson | null;
+  if (!json?.access_token || !json.refresh_token || typeof json.expires_in !== 'number') {
+    throw new ParseError({
+      message: `Claude token ${op} response missing fields`,
+      source: 'anthropic-oauth-token-response',
+      context: { op },
+    });
+  }
+  return {
+    access: json.access_token,
+    refresh: json.refresh_token,
+    expires: Date.now() + json.expires_in * 1000,
+  };
+}
+
+async function exchangeAuthorizationCode(
+  code: string,
+  state: string,
+  verifier: string,
+  signal?: AbortSignal,
+): Promise<ClaudeTokens> {
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      code,
+      state,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: verifier,
+    }),
+    signal: signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(30_000)])
+      : AbortSignal.timeout(30_000),
+  });
+  return readTokens(res, 'exchange');
+}
+
+async function fetchClaudeModels(accessToken: string, signal?: AbortSignal): Promise<string[]> {
+  try {
+    const res = await fetch(`${CLAUDE_BASE_URL}/v1/models?limit=100`, {
+      headers: {
+        accept: 'application/json',
+        authorization: `Bearer ${accessToken}`,
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': 'claude-code-20250219,oauth-2025-04-20',
+      },
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(8_000)])
+        : AbortSignal.timeout(8_000),
+    });
+    if (!res.ok) return [];
+    const json = (await res.json()) as { data?: Array<{ id?: string }> } | null;
+    return (json?.data ?? [])
+      .map((m) => m.id)
+      .filter((id): id is string => typeof id === 'string' && id.startsWith('claude-'));
+  } catch {
+    return [];
+  }
+}
+
+async function buildOutcome(
+  tokens: ClaudeTokens,
+  signal?: AbortSignal,
+): Promise<OAuthLoginOutcome> {
+  const fetched = await fetchClaudeModels(tokens.access, signal);
+  const models = fetched.length > 0 ? fetched : DEFAULT_CLAUDE_MODELS;
+  const apiKey: ProviderApiKey = {
+    label: 'oauth-default',
+    apiKey: tokens.access,
+    createdAt: new Date().toISOString(),
+    authMethod: 'oauth',
+    expiresAt: new Date(tokens.expires).toISOString(),
+    refreshToken: tokens.refresh,
+    tokenType: 'bearer',
+    scope: SCOPES,
+  };
+  return {
+    providerId: CLAUDE_PROVIDER_ID,
+    family: 'anthropic-oauth',
+    baseUrl: CLAUDE_BASE_URL,
+    models,
+    apiKey,
+  };
+}
+
+export async function beginClaudeLogin(
+  _deps: BeginOAuthDeps | undefined,
+  signal?: AbortSignal,
+): Promise<OAuthSession> {
+  const { verifier, challenge } = generatePkce();
+  // Anthropic reuses the PKCE verifier as the OAuth state.
+  const state = verifier;
+  const authorizeUrl = buildClaudeAuthorizeUrl(challenge, verifier);
+
+  const server: LoopbackServer = await startLoopbackServer({
+    port: REDIRECT_PORT,
+    host: REDIRECT_HOST,
+    path: REDIRECT_PATH,
+    expectedState: state,
+    signal,
+  });
+
+  return {
+    kind: 'claude',
+    providerId: CLAUDE_PROVIDER_ID,
+    bound: server.bound,
+    authorizeUrl,
+    async waitForCompletion(waitSignal?: AbortSignal): Promise<OAuthLoginOutcome | null> {
+      if (!server.bound) return null;
+      const got = await server.waitForCode();
+      if (!got?.code) return null;
+      const tokens = await exchangeAuthorizationCode(
+        got.code,
+        state,
+        verifier,
+        waitSignal ?? signal,
+      );
+      return buildOutcome(tokens, waitSignal ?? signal);
+    },
+    async completeWithCode(input: string, codeSignal?: AbortSignal): Promise<OAuthLoginOutcome> {
+      const parsed = parseAuthorizationInput(input);
+      if (parsed.state && parsed.state !== state) {
+        throw new Error('State mismatch — please restart the login flow.');
+      }
+      if (!parsed.code) throw new Error('No authorization code found in the pasted value.');
+      const tokens = await exchangeAuthorizationCode(
+        parsed.code,
+        state,
+        verifier,
+        codeSignal ?? signal,
+      );
+      return buildOutcome(tokens, codeSignal ?? signal);
+    },
+    close(): void {
+      server.close();
+    },
+  };
+}

--- a/packages/providers/src/oauth/copilot.ts
+++ b/packages/providers/src/oauth/copilot.ts
@@ -1,0 +1,241 @@
+/**
+ * GitHub Copilot login — GitHub OAuth **device flow** (no loopback server).
+ * Headless port of the CLI's `github-copilot-oauth.ts`.
+ *
+ *   1. POST github.com/login/device/code → user_code + verification_uri.
+ *   2. Poll login/oauth/access_token until GitHub returns an OAuth token.
+ *   3. Exchange it at api.github.com/copilot_internal/v2/token for a
+ *      short-lived Copilot token. The GitHub OAuth token is the refresh token.
+ */
+
+import { FetchError, ParseError, type ProviderApiKey } from '@wrongstack/core';
+import { copilotBaseUrlFromToken, refreshCopilotToken } from '../github-copilot.js';
+import type { BeginOAuthDeps, OAuthLoginOutcome, OAuthSession } from './types.js';
+
+const CLIENT_ID = 'Iv1.b507a08c87ecfe98';
+const DEVICE_CODE_URL = 'https://github.com/login/device/code';
+const ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const COPILOT_HEADERS: Record<string, string> = {
+  'User-Agent': 'GitHubCopilotChat/0.35.0',
+  'Editor-Version': 'vscode/1.107.0',
+  'Editor-Plugin-Version': 'copilot-chat/0.35.0',
+  'Copilot-Integration-Id': 'vscode-chat',
+};
+const COPILOT_API_VERSION = '2026-06-01';
+export const COPILOT_PROVIDER_ID = 'github-copilot';
+const DEFAULT_COPILOT_MODELS = ['gpt-4o'];
+
+interface DeviceCode {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  interval: number;
+  expires_in: number;
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) return reject(new DOMException('Aborted', 'AbortError'));
+    const t = setTimeout(resolve, ms);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(t);
+        reject(new DOMException('Aborted', 'AbortError'));
+      },
+      { once: true },
+    );
+  });
+}
+
+async function startDeviceFlow(signal?: AbortSignal): Promise<DeviceCode> {
+  const res = await fetch(DEVICE_CODE_URL, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/x-www-form-urlencoded',
+      'user-agent': COPILOT_HEADERS['User-Agent']!,
+    },
+    body: new URLSearchParams({ client_id: CLIENT_ID, scope: 'read:user' }).toString(),
+    signal: signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(15_000)])
+      : AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    throw new FetchError({
+      message: `GitHub device-code request failed (${res.status})`,
+      status: res.status,
+      context: { provider: 'github-copilot', op: 'device-code', url: DEVICE_CODE_URL },
+    });
+  }
+  const json = (await res.json()) as Partial<DeviceCode> | null;
+  if (
+    !json?.device_code ||
+    !json.user_code ||
+    !json.verification_uri ||
+    typeof json.expires_in !== 'number'
+  ) {
+    throw new ParseError({
+      message: 'Invalid device-code response',
+      source: 'github-copilot-device-code-response',
+    });
+  }
+  return {
+    device_code: json.device_code,
+    user_code: json.user_code,
+    verification_uri: json.verification_uri,
+    interval: json.interval ?? 5,
+    expires_in: json.expires_in,
+  };
+}
+
+async function pollForGitHubToken(device: DeviceCode, signal: AbortSignal): Promise<string> {
+  let intervalMs = device.interval * 1000;
+  const expiresAt = Date.now() + device.expires_in * 1000;
+
+  while (Date.now() < expiresAt) {
+    await sleep(intervalMs, signal);
+    const res = await fetch(ACCESS_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/x-www-form-urlencoded',
+        'user-agent': COPILOT_HEADERS['User-Agent']!,
+      },
+      body: new URLSearchParams({
+        client_id: CLIENT_ID,
+        device_code: device.device_code,
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      }).toString(),
+      signal: AbortSignal.any([signal, AbortSignal.timeout(15_000)]),
+    });
+    const json = (await res.json().catch(() => ({}))) as {
+      access_token?: string;
+      error?: string;
+    };
+    if (json.access_token) return json.access_token;
+    if (json.error === 'authorization_pending') continue;
+    if (json.error === 'slow_down') {
+      intervalMs += 5_000;
+      continue;
+    }
+    throw new Error(`Device flow failed: ${json.error ?? 'unknown error'}`);
+  }
+  throw new FetchError({
+    message: 'Device code expired — please restart the login.',
+    status: 408,
+    context: { provider: 'github-copilot', op: 'device-code-poll', reason: 'expired' },
+  });
+}
+
+interface CopilotModelEntry {
+  id?: unknown;
+  is_chat_default?: unknown;
+  is_chat_fallback?: unknown;
+  vendor?: unknown;
+  supported_endpoints?: unknown;
+  policy?: { state?: unknown } | undefined;
+  capabilities?: { type?: unknown; supports?: { tool_calls?: unknown } | undefined } | undefined;
+}
+
+/** Whether a Copilot `/models` entry is a chat model drivable over this wire. */
+export function isUsableCopilotChatModel(item: CopilotModelEntry): boolean {
+  if (typeof item.id !== 'string' || item.id.length === 0) return false;
+  const cap = item.capabilities;
+  if (cap?.type !== 'chat') return false;
+  if (cap.supports?.tool_calls !== true) return false;
+  const eps = item.supported_endpoints;
+  if (Array.isArray(eps) && !eps.includes('/chat/completions')) return false;
+  if (item.policy?.state === 'disabled') return false;
+  if (item.vendor === 'Experimental') return false;
+  return true;
+}
+
+function copilotModelRank(item: CopilotModelEntry): number {
+  if (item.is_chat_default === true) return 0;
+  if (item.is_chat_fallback === true) return 1;
+  return 2;
+}
+
+async function fetchCopilotModels(copilotToken: string, signal?: AbortSignal): Promise<string[]> {
+  try {
+    const base = copilotBaseUrlFromToken(copilotToken);
+    const res = await fetch(`${base}/models`, {
+      headers: {
+        accept: 'application/json',
+        authorization: `Bearer ${copilotToken}`,
+        'X-GitHub-Api-Version': COPILOT_API_VERSION,
+        ...COPILOT_HEADERS,
+      },
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(8_000)])
+        : AbortSignal.timeout(8_000),
+    });
+    if (!res.ok) return [];
+    const json = (await res.json()) as { data?: CopilotModelEntry[] } | null;
+    const data = json?.data;
+    if (!Array.isArray(data)) return [];
+    const usable = data.filter(isUsableCopilotChatModel);
+    usable.sort((a, b) => copilotModelRank(a) - copilotModelRank(b));
+    return usable.map((m) => m.id as string);
+  } catch {
+    return [];
+  }
+}
+
+export async function beginCopilotLogin(
+  _deps: BeginOAuthDeps | undefined,
+  signal?: AbortSignal,
+): Promise<OAuthSession> {
+  const device = await startDeviceFlow(signal);
+
+  return {
+    kind: 'copilot',
+    providerId: COPILOT_PROVIDER_ID,
+    bound: false,
+    verificationUri: device.verification_uri,
+    userCode: device.user_code,
+    async waitForCompletion(waitSignal?: AbortSignal): Promise<OAuthLoginOutcome | null> {
+      const ac = new AbortController();
+      const upstream = waitSignal ?? signal;
+      if (upstream) {
+        if (upstream.aborted) ac.abort();
+        else upstream.addEventListener('abort', () => ac.abort(), { once: true });
+      }
+      let githubToken: string;
+      try {
+        githubToken = await pollForGitHubToken(device, ac.signal);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return null;
+        throw err;
+      }
+      const copilot = await refreshCopilotToken(githubToken, ac.signal);
+      const fetched = await fetchCopilotModels(copilot.token, ac.signal);
+      const models = fetched.length > 0 ? fetched : DEFAULT_COPILOT_MODELS;
+      const apiKey: ProviderApiKey = {
+        label: 'oauth-default',
+        apiKey: copilot.token,
+        createdAt: new Date().toISOString(),
+        authMethod: 'oauth',
+        expiresAt: new Date(copilot.expires).toISOString(),
+        refreshToken: githubToken,
+        tokenType: 'bearer',
+      };
+      return {
+        providerId: COPILOT_PROVIDER_ID,
+        family: 'github-copilot',
+        baseUrl: copilotBaseUrlFromToken(copilot.token),
+        models,
+        apiKey,
+      };
+    },
+    completeWithCode(): Promise<OAuthLoginOutcome> {
+      return Promise.reject(
+        new Error('GitHub Copilot uses a device-code flow — no redirect URL to paste.'),
+      );
+    },
+    close(): void {
+      /* device flow has no loopback to tear down */
+    },
+  };
+}

--- a/packages/providers/src/oauth/index.ts
+++ b/packages/providers/src/oauth/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Headless OAuth login engine — drives a subscription sign-in (ChatGPT /
+ * Claude / Copilot) to completion and returns a persistence-agnostic
+ * {@link OAuthLoginOutcome}. Shared by the CLI auth-menu (terminal IO) and
+ * both WebUI servers (WebSocket IO). Neither opens a browser nor writes config
+ * — that is the caller's job.
+ */
+
+import { beginChatGPTLogin } from './chatgpt.js';
+import { beginClaudeLogin } from './claude.js';
+import { beginCopilotLogin } from './copilot.js';
+import type { BeginOAuthDeps, OAuthKind, OAuthSession } from './types.js';
+
+export { buildCodexAuthorizeUrl, CODEX_BASE_URL, CODEX_PROVIDER_ID } from './chatgpt.js';
+export { buildClaudeAuthorizeUrl, CLAUDE_PROVIDER_ID } from './claude.js';
+export { COPILOT_PROVIDER_ID, isUsableCopilotChatModel } from './copilot.js';
+export {
+  generatePkce,
+  type LoopbackServer,
+  parseAuthorizationInput,
+  startLoopbackServer,
+} from './shared.js';
+export type {
+  BeginOAuthDeps,
+  OAuthKind,
+  OAuthLoginOutcome,
+  OAuthPhase,
+  OAuthSession,
+} from './types.js';
+
+/** Canonical provider id each login kind stores its credential under. */
+export const OAUTH_PROVIDER_IDS: Record<OAuthKind, string> = {
+  chatgpt: 'openai-codex',
+  claude: 'anthropic-oauth',
+  copilot: 'github-copilot',
+};
+
+/**
+ * Begin a subscription OAuth login. Returns a {@link OAuthSession} that is
+ * already listening (loopback flows) or carries the device code (copilot),
+ * so the caller can surface the authorize URL / user code immediately, then
+ * `await session.waitForCompletion()`.
+ */
+export function beginOAuthLogin(
+  kind: OAuthKind,
+  deps?: BeginOAuthDeps,
+  signal?: AbortSignal,
+): Promise<OAuthSession> {
+  switch (kind) {
+    case 'chatgpt':
+      return beginChatGPTLogin(deps, signal);
+    case 'claude':
+      return beginClaudeLogin(deps, signal);
+    case 'copilot':
+      return beginCopilotLogin(deps, signal);
+    default: {
+      const exhaustive: never = kind;
+      return Promise.reject(new Error(`Unknown OAuth kind: ${String(exhaustive)}`));
+    }
+  }
+}

--- a/packages/providers/src/oauth/shared.ts
+++ b/packages/providers/src/oauth/shared.ts
@@ -1,0 +1,212 @@
+/**
+ * Shared, IO-free primitives for the headless OAuth login engine.
+ *
+ * These were previously duplicated inside the CLI's `auth-menu/*-oauth.ts`
+ * terminal flows. They live here so BOTH the CLI and the two WebUI servers
+ * can drive a subscription sign-in without depending on terminal IO or a
+ * particular config-persistence layer.
+ *
+ * Nothing here opens a browser or writes config — the caller (CLI renderer
+ * or WebSocket handler) decides how to surface the authorize URL and how to
+ * persist the resulting {@link import('./index.js').OAuthLoginOutcome}.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+
+// ── PKCE ────────────────────────────────────────────────────────────────────
+
+export function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export interface Pkce {
+  verifier: string;
+  challenge: string;
+}
+
+/** Generate a PKCE verifier + S256 challenge. */
+export function generatePkce(): Pkce {
+  const verifier = base64url(randomBytes(32));
+  const challenge = base64url(createHash('sha256').update(verifier).digest());
+  return { verifier, challenge };
+}
+
+/** Random CSRF state (hex). */
+export function createState(): string {
+  return randomBytes(16).toString('hex');
+}
+
+// ── Manual-paste parsing ──────────────────────────────────────────────────────
+
+/**
+ * Parse a pasted authorization code or full redirect URL into `{ code, state }`.
+ * Handles three shapes: a full `http://localhost:PORT/...?code=&state=` URL, a
+ * bare `code#state` (Anthropic's hash convention), a `code=...&state=...` query
+ * fragment, or a bare code.
+ */
+export function parseAuthorizationInput(input: string): {
+  code?: string | undefined;
+  state?: string | undefined;
+} {
+  const value = input.trim();
+  if (!value) return {};
+  try {
+    const url = new URL(value);
+    return {
+      code: url.searchParams.get('code') ?? undefined,
+      state: url.searchParams.get('state') ?? undefined,
+    };
+  } catch {
+    /* not a URL */
+  }
+  if (value.includes('#')) {
+    const [code, state] = value.split('#', 2);
+    return { code, state };
+  }
+  if (value.includes('code=')) {
+    const params = new URLSearchParams(value);
+    return {
+      code: params.get('code') ?? undefined,
+      state: params.get('state') ?? undefined,
+    };
+  }
+  return { code: value };
+}
+
+// ── Loopback callback server ──────────────────────────────────────────────────
+
+export function callbackHtml(ok: boolean, message: string): string {
+  const heading = ok ? 'Authentication successful' : 'Authentication failed';
+  return (
+    `<!doctype html><html lang="en"><head><meta charset="utf-8"/>` +
+    `<title>${heading}</title><style>body{margin:0;min-height:100vh;display:flex;` +
+    `align-items:center;justify-content:center;background:#09090b;color:#fafafa;` +
+    `font-family:ui-sans-serif,system-ui,sans-serif;text-align:center}` +
+    `h1{font-size:26px;margin:0 0 8px}p{color:#a1a1aa}</style></head><body><main>` +
+    `<h1>${heading}</h1><p>${message}</p></main></body></html>`
+  );
+}
+
+export interface LoopbackServer {
+  /** Resolves with `{ code, state }`, or null if cancelled / failed to bind. */
+  waitForCode(): Promise<{ code: string; state: string } | null>;
+  close(): void;
+  /** True when the server bound to the port; false means the port was busy. */
+  readonly bound: boolean;
+}
+
+export interface LoopbackOptions {
+  port: number;
+  host: string;
+  /** Expected callback path, e.g. `/auth/callback` or `/callback`. */
+  path: string;
+  /** Expected OAuth `state` — a mismatch aborts the wait (CSRF guard). */
+  expectedState: string;
+  /** Abort (e.g. user cancel) → unblock the pending wait and tear down. */
+  signal?: AbortSignal | undefined;
+}
+
+/**
+ * Start a one-shot loopback HTTP server that captures the OAuth redirect.
+ * Resolves once listening (or once it fails to bind — in which case `bound`
+ * is false and the caller falls back to manual paste).
+ */
+export function startLoopbackServer(opts: LoopbackOptions): Promise<LoopbackServer> {
+  const { port, host, path, expectedState, signal } = opts;
+  let resolveCode: (v: { code: string; state: string } | null) => void = () => {};
+  const codePromise = new Promise<{ code: string; state: string } | null>((resolve) => {
+    let settled = false;
+    resolveCode = (v) => {
+      if (settled) return;
+      settled = true;
+      resolve(v);
+    };
+  });
+
+  const server: Server = createServer((req, res) => {
+    let url: URL;
+    try {
+      url = new URL(req.url ?? '', `http://${host}`);
+    } catch {
+      res.statusCode = 400;
+      res.end();
+      return;
+    }
+    if (url.pathname !== path) {
+      res.statusCode = 404;
+      res.setHeader('content-type', 'text/html; charset=utf-8');
+      res.end(callbackHtml(false, 'Callback route not found.'));
+      return;
+    }
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    const err = url.searchParams.get('error');
+    if (err) {
+      res.statusCode = 400;
+      res.end(callbackHtml(false, `Authorization error: ${err}`));
+      resolveCode(null);
+      return;
+    }
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    if (state !== expectedState) {
+      res.statusCode = 400;
+      res.end(callbackHtml(false, 'State mismatch — please restart the login.'));
+      resolveCode(null);
+      return;
+    }
+    if (!code) {
+      res.statusCode = 400;
+      res.end(callbackHtml(false, 'Missing authorization code.'));
+      return;
+    }
+    res.statusCode = 200;
+    res.end(callbackHtml(true, 'You can close this window and return to WrongStack.'));
+    resolveCode({ code, state });
+  });
+
+  const onAbort = (): void => {
+    resolveCode(null);
+    try {
+      server.close();
+    } catch {
+      /* ignore */
+    }
+  };
+  if (signal) {
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+  }
+
+  return new Promise<LoopbackServer>((resolve) => {
+    server.on('error', () => {
+      // Port busy / cannot bind — signal manual fallback.
+      resolveCode(null);
+      resolve({
+        bound: false,
+        waitForCode: () => Promise.resolve(null),
+        close: () => {
+          try {
+            server.close();
+          } catch {
+            /* ignore */
+          }
+        },
+      });
+    });
+    server.listen(port, host, () => {
+      resolve({
+        bound: true,
+        waitForCode: () => codePromise,
+        close: () => {
+          resolveCode(null);
+          try {
+            server.close();
+          } catch {
+            /* ignore */
+          }
+        },
+      });
+    });
+  });
+}

--- a/packages/providers/src/oauth/types.ts
+++ b/packages/providers/src/oauth/types.ts
@@ -1,0 +1,80 @@
+/**
+ * Public types for the headless OAuth login engine.
+ *
+ * The engine drives a subscription sign-in (ChatGPT / Claude / Copilot) to
+ * completion and returns a {@link OAuthLoginOutcome} — a persistence-agnostic
+ * description of the provider + credential to save. The caller persists it
+ * with whatever config store it owns (CLI `mutateConfigProviders`, WebUI
+ * provider stores), so the engine never touches config files.
+ */
+
+import type { ModelsRegistry, ProviderApiKey } from '@wrongstack/core';
+
+/** Which subscription login to run. */
+export type OAuthKind = 'chatgpt' | 'claude' | 'copilot';
+
+/** Progress phase surfaced to the caller while a flow is in motion. */
+export type OAuthPhase =
+  | 'awaiting_browser'
+  | 'awaiting_code'
+  | 'exchanging'
+  | 'fetching_models'
+  | 'success'
+  | 'error';
+
+/**
+ * Everything needed to persist a successful login. Free of any IO — the
+ * caller upserts `apiKey` onto the provider keyed by `providerId` and sets the
+ * `family` / `baseUrl` / `models` fields.
+ */
+export interface OAuthLoginOutcome {
+  /** Canonical provider id: openai-codex | anthropic-oauth | github-copilot. */
+  providerId: string;
+  /** Wire family to stamp on the provider config. */
+  family: string;
+  /** Default base URL (only applied when the provider has none yet). */
+  baseUrl: string;
+  /** Discovered model ids (live backend → catalog → fallback). */
+  models: string[];
+  /** The credential to upsert (label `oauth-default`, `authMethod: 'oauth'`). */
+  apiKey: ProviderApiKey;
+}
+
+/**
+ * A live login session. For loopback flows (chatgpt/claude) the session is
+ * already listening on the callback port; for the device flow (copilot) it
+ * carries the user code to display. The caller surfaces `authorizeUrl` /
+ * `userCode`, then awaits {@link waitForCompletion}.
+ */
+export interface OAuthSession {
+  kind: OAuthKind;
+  /** Canonical provider id the outcome will be stored under. */
+  providerId: string;
+  /** True when a loopback listener bound; false → manual paste required. */
+  bound: boolean;
+  /** Loopback flows (chatgpt/claude): URL to open in the browser. */
+  authorizeUrl?: string | undefined;
+  /** Device flow (copilot): URL the user visits to enter the code. */
+  verificationUri?: string | undefined;
+  /** Device flow (copilot): the code the user types at `verificationUri`. */
+  userCode?: string | undefined;
+  /**
+   * Drive the flow to completion: await the loopback callback (chatgpt/claude)
+   * or poll the device endpoint (copilot), then exchange + fetch models.
+   * Resolves with the outcome, or `null` if cancelled / expired.
+   */
+  waitForCompletion(signal?: AbortSignal): Promise<OAuthLoginOutcome | null>;
+  /**
+   * Manual-paste fallback for loopback flows (port busy / remote browser):
+   * submit the pasted redirect URL or code. Throws on the device flow.
+   */
+  completeWithCode(input: string, signal?: AbortSignal): Promise<OAuthLoginOutcome>;
+  /** Tear down any loopback listener / cancel a pending wait. */
+  close(): void;
+}
+
+/** Optional dependencies for {@link OAuthKind} flows. */
+export interface BeginOAuthDeps {
+  /** Used by the ChatGPT flow's tier-2 model lookup (best-effort). */
+  modelsRegistry?: ModelsRegistry | undefined;
+}

--- a/packages/providers/tests/oauth.test.ts
+++ b/packages/providers/tests/oauth.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildClaudeAuthorizeUrl,
+  buildCodexAuthorizeUrl,
+  generatePkce,
+  isUsableCopilotChatModel,
+  OAUTH_PROVIDER_IDS,
+  parseAuthorizationInput,
+} from '../src/oauth/index.js';
+
+describe('oauth engine — pkce', () => {
+  it('generates a verifier and S256 challenge', () => {
+    const a = generatePkce();
+    const b = generatePkce();
+    expect(a.verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(a.challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(a.verifier).not.toEqual(a.challenge);
+    expect(a.verifier).not.toEqual(b.verifier); // random per call
+  });
+});
+
+describe('oauth engine — authorize URLs', () => {
+  it('codex authorize url carries PKCE + state + originator', () => {
+    const url = new URL(buildCodexAuthorizeUrl('CHAL', 'STATE'));
+    expect(url.origin).toBe('https://auth.openai.com');
+    expect(url.searchParams.get('code_challenge')).toBe('CHAL');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('state')).toBe('STATE');
+    expect(url.searchParams.get('redirect_uri')).toBe('http://localhost:1455/auth/callback');
+    expect(url.searchParams.get('originator')).toBe('wrongstack');
+  });
+
+  it('claude authorize url reuses the verifier as state and uses :53692 callback', () => {
+    const url = new URL(buildClaudeAuthorizeUrl('CHAL', 'VERIFIER'));
+    expect(url.origin).toBe('https://claude.ai');
+    expect(url.searchParams.get('state')).toBe('VERIFIER');
+    expect(url.searchParams.get('code')).toBe('true');
+    expect(url.searchParams.get('redirect_uri')).toBe('http://localhost:53692/callback');
+  });
+});
+
+describe('oauth engine — parseAuthorizationInput', () => {
+  it('parses a full redirect URL', () => {
+    expect(
+      parseAuthorizationInput('http://localhost:1455/auth/callback?code=abc&state=xyz'),
+    ).toEqual({
+      code: 'abc',
+      state: 'xyz',
+    });
+  });
+  it('parses a code#state hash form', () => {
+    expect(parseAuthorizationInput('abc#xyz')).toEqual({ code: 'abc', state: 'xyz' });
+  });
+  it('parses a bare code', () => {
+    expect(parseAuthorizationInput('justacode')).toEqual({ code: 'justacode' });
+  });
+  it('returns empty for blank input', () => {
+    expect(parseAuthorizationInput('   ')).toEqual({});
+  });
+});
+
+describe('oauth engine — copilot model filter', () => {
+  const chat = {
+    id: 'gpt-4o',
+    capabilities: { type: 'chat', supports: { tool_calls: true } },
+  };
+  it('accepts a tool-calling chat model', () => {
+    expect(isUsableCopilotChatModel(chat)).toBe(true);
+  });
+  it('rejects embeddings / non-chat', () => {
+    expect(
+      isUsableCopilotChatModel({ id: 'text-embedding', capabilities: { type: 'embeddings' } }),
+    ).toBe(false);
+  });
+  it('rejects /responses-only ids', () => {
+    expect(isUsableCopilotChatModel({ ...chat, supported_endpoints: ['/responses'] })).toBe(false);
+  });
+  it('rejects disabled-policy models', () => {
+    expect(isUsableCopilotChatModel({ ...chat, policy: { state: 'disabled' } })).toBe(false);
+  });
+});
+
+describe('oauth engine — provider id map', () => {
+  it('maps each kind to its canonical provider id', () => {
+    expect(OAUTH_PROVIDER_IDS).toEqual({
+      chatgpt: 'openai-codex',
+      claude: 'anthropic-oauth',
+      copilot: 'github-copilot',
+    });
+  });
+});

--- a/packages/providers/tsup.config.ts
+++ b/packages/providers/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/oauth/index.ts'],
   format: ['esm'],
   dts: true,
   sourcemap: true,

--- a/packages/webui/src/components/SettingsPanel/OAuthLoginSection.tsx
+++ b/packages/webui/src/components/SettingsPanel/OAuthLoginSection.tsx
@@ -1,0 +1,267 @@
+import { Bot, CheckCircle2, Code2, ExternalLink, Loader2, Sparkles, XCircle } from 'lucide-react';
+import { type ReactNode, useCallback, useEffect, useState } from 'react';
+import { toast } from '@/components/Toaster';
+import type { WrongStackWebSocketClient } from '@/lib/ws-client';
+import type { WSServerMessage } from '@/types';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+
+type OAuthKind = 'chatgpt' | 'claude' | 'copilot';
+
+type OAuthPhase =
+  | 'idle'
+  | 'awaiting_browser'
+  | 'awaiting_code'
+  | 'exchanging'
+  | 'fetching_models'
+  | 'success'
+  | 'error';
+
+interface OAuthState {
+  phase: OAuthPhase;
+  providerId?: string | undefined;
+  authorizeUrl?: string | undefined;
+  verificationUri?: string | undefined;
+  userCode?: string | undefined;
+  bound?: boolean | undefined;
+  message?: string | undefined;
+}
+
+interface ProviderMeta {
+  kind: OAuthKind;
+  label: string;
+  subtitle: string;
+  icon: ReactNode;
+}
+
+const PROVIDERS: ProviderMeta[] = [
+  {
+    kind: 'chatgpt',
+    label: 'ChatGPT',
+    subtitle: 'Plus / Pro / Team → openai-codex',
+    icon: <Sparkles className="h-5 w-5" />,
+  },
+  {
+    kind: 'claude',
+    label: 'Claude',
+    subtitle: 'Pro / Max → anthropic-oauth',
+    icon: <Bot className="h-5 w-5" />,
+  },
+  {
+    kind: 'copilot',
+    label: 'GitHub Copilot',
+    subtitle: 'Copilot → github-copilot',
+    icon: <Code2 className="h-5 w-5" />,
+  },
+];
+
+const ACTIVE_PHASES: OAuthPhase[] = [
+  'awaiting_browser',
+  'awaiting_code',
+  'exchanging',
+  'fetching_models',
+];
+
+export interface OAuthLoginSectionProps {
+  ws: WrongStackWebSocketClient;
+}
+
+/**
+ * Subscription sign-in (ChatGPT / Claude / Copilot). Self-contained: subscribes
+ * to `auth.oauth.status` and drives the server-side OAuth engine over the WS
+ * client. Loopback flows (ChatGPT/Claude) open the authorize URL in a new tab
+ * and capture the redirect on the server's loopback; the Copilot device flow
+ * shows a user code. A manual-paste fallback covers a busy loopback port or a
+ * remotely-accessed WebUI.
+ */
+export function OAuthLoginSection({ ws }: OAuthLoginSectionProps) {
+  const [states, setStates] = useState<Record<OAuthKind, OAuthState>>({
+    chatgpt: { phase: 'idle' },
+    claude: { phase: 'idle' },
+    copilot: { phase: 'idle' },
+  });
+  const [pasteValue, setPasteValue] = useState('');
+  const [showPaste, setShowPaste] = useState<OAuthKind | null>(null);
+
+  useEffect(() => {
+    const off = ws.on('auth.oauth.status', (msg: WSServerMessage) => {
+      if (msg.type !== 'auth.oauth.status') return;
+      const p = msg.payload as { kind: OAuthKind; phase: OAuthPhase } & OAuthState;
+      setStates((prev) => ({ ...prev, [p.kind]: { ...p } }));
+      if (p.phase === 'success') {
+        toast.success(p.message ?? `Signed in — ${p.providerId ?? p.kind}`);
+        setShowPaste(null);
+        setPasteValue('');
+      } else if (p.phase === 'error') {
+        toast.error(p.message ?? 'Sign-in failed');
+      }
+    });
+    return () => off?.();
+  }, [ws]);
+
+  const start = useCallback(
+    (kind: OAuthKind) => {
+      setStates((prev) => ({
+        ...prev,
+        [kind]: { phase: kind === 'copilot' ? 'awaiting_code' : 'awaiting_browser' },
+      }));
+      ws.startOAuth(kind);
+    },
+    [ws],
+  );
+
+  const cancel = useCallback(
+    (kind: OAuthKind) => {
+      ws.cancelOAuth(kind);
+      setStates((prev) => ({ ...prev, [kind]: { phase: 'idle' } }));
+      setShowPaste(null);
+    },
+    [ws],
+  );
+
+  const submitPaste = useCallback(
+    (kind: OAuthKind) => {
+      const input = pasteValue.trim();
+      if (!input) return;
+      ws.submitOAuthCode(kind, input);
+      setStates((prev) => ({ ...prev, [kind]: { ...prev[kind], phase: 'exchanging' } }));
+    },
+    [pasteValue, ws],
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3">
+        <p className="text-xs text-amber-600 dark:text-amber-400">
+          Sign in with a subscription instead of an API key. Using a subscription outside its
+          official client may violate the provider's Terms — your account could be rate-limited or
+          banned. An API key is the sanctioned path for programmatic use.
+        </p>
+      </div>
+
+      {PROVIDERS.map((meta) => {
+        const st = states[meta.kind];
+        const busy = ACTIVE_PHASES.includes(st.phase);
+        return (
+          <div key={meta.kind} className="rounded-lg border border-border p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3 min-w-0">
+                <span className="text-muted-foreground">{meta.icon}</span>
+                <div className="min-w-0">
+                  <div className="font-medium">{meta.label}</div>
+                  <div className="text-xs text-muted-foreground truncate">{meta.subtitle}</div>
+                </div>
+              </div>
+              {!busy ? (
+                <Button size="sm" onClick={() => start(meta.kind)}>
+                  Sign in
+                </Button>
+              ) : (
+                <Button size="sm" variant="ghost" onClick={() => cancel(meta.kind)}>
+                  Cancel
+                </Button>
+              )}
+            </div>
+
+            {/* Flow detail */}
+            {st.phase === 'awaiting_browser' && (
+              <div className="mt-3 space-y-2 border-t pt-3">
+                <div className="flex items-center gap-2 text-sm">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                  <span>Waiting for you to sign in…</span>
+                </div>
+                {st.authorizeUrl && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => window.open(st.authorizeUrl, '_blank', 'noopener,noreferrer')}
+                  >
+                    <ExternalLink className="h-3.5 w-3.5 mr-1" />
+                    Open sign-in page
+                  </Button>
+                )}
+                <div>
+                  <button
+                    type="button"
+                    className="text-xs text-muted-foreground underline"
+                    onClick={() => setShowPaste(showPaste === meta.kind ? null : meta.kind)}
+                  >
+                    {st.bound === false
+                      ? 'Loopback port busy — paste the redirect URL'
+                      : 'Browser can’t reach this server? Paste the redirect URL'}
+                  </button>
+                  {showPaste === meta.kind && (
+                    <div className="mt-2 flex gap-2">
+                      <Input
+                        placeholder="http://localhost:.../callback?code=…"
+                        value={pasteValue}
+                        onChange={(e) => setPasteValue(e.target.value)}
+                        className="font-mono text-xs"
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') submitPaste(meta.kind);
+                        }}
+                      />
+                      <Button
+                        size="sm"
+                        onClick={() => submitPaste(meta.kind)}
+                        disabled={!pasteValue.trim()}
+                      >
+                        Submit
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {st.phase === 'awaiting_code' && (
+              <div className="mt-3 space-y-2 border-t pt-3">
+                <p className="text-sm text-muted-foreground">
+                  Enter this code at the verification page:
+                </p>
+                <div className="font-mono text-2xl font-bold tracking-widest">
+                  {st.userCode ?? '…'}
+                </div>
+                {st.verificationUri && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => window.open(st.verificationUri, '_blank', 'noopener,noreferrer')}
+                  >
+                    <ExternalLink className="h-3.5 w-3.5 mr-1" />
+                    Open verification page
+                  </Button>
+                )}
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <span>Waiting for authorization…</span>
+                </div>
+              </div>
+            )}
+
+            {(st.phase === 'exchanging' || st.phase === 'fetching_models') && (
+              <div className="mt-3 flex items-center gap-2 border-t pt-3 text-sm">
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                <span>{st.phase === 'exchanging' ? 'Exchanging tokens…' : 'Fetching models…'}</span>
+              </div>
+            )}
+
+            {st.phase === 'success' && (
+              <div className="mt-3 flex items-center gap-2 border-t pt-3 text-sm text-green-600">
+                <CheckCircle2 className="h-4 w-4" />
+                <span>{st.message ?? 'Signed in.'}</span>
+              </div>
+            )}
+
+            {st.phase === 'error' && st.message && (
+              <div className="mt-3 flex items-center gap-2 border-t pt-3 text-sm text-destructive">
+                <XCircle className="h-4 w-4" />
+                <span>{st.message}</span>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/webui/src/components/SettingsPanel/ProviderSection.tsx
+++ b/packages/webui/src/components/SettingsPanel/ProviderSection.tsx
@@ -1,5 +1,3 @@
-import { cn } from '@/lib/utils';
-import type { WrongStackWebSocketClient } from '@/lib/ws-client';
 import {
   CheckCircle2,
   Eye,
@@ -9,10 +7,16 @@ import {
   Loader2,
   Plus,
   Trash2,
+  XCircle,
 } from 'lucide-react';
-import { useState, useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from '@/components/Toaster';
+import { cn } from '@/lib/utils';
+import type { WrongStackWebSocketClient } from '@/lib/ws-client';
+import type { WSServerMessage } from '@/types';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { OAuthLoginSection } from './OAuthLoginSection';
 import { ProviderModelsPanel } from './ProviderModelsPanel';
 
 // ── Types (shared with index) ──
@@ -72,7 +76,12 @@ export interface ProviderSectionProps {
   /** Called to set a key as active. */
   onSetActiveKey: (providerId: string, label: string) => void;
   /** Called to add a custom provider. */
-  onAddProvider: (id: string, family: string, baseUrl?: string | undefined, apiKey?: string) => void;
+  onAddProvider: (
+    id: string,
+    family: string,
+    baseUrl?: string | undefined,
+    apiKey?: string,
+  ) => void;
   /** Called to remove a saved provider. */
   onRemoveProvider: (providerId: string) => void;
   /** Called when a saved provider model is picked. */
@@ -131,13 +140,63 @@ export function ProviderSection({
 
   const handleAddProvider = useCallback(() => {
     if (!newProviderId.trim()) return;
-    onAddProvider(newProviderId.trim(), newProviderFamily, newProviderBaseUrl || undefined, newProviderApiKey || undefined);
+    onAddProvider(
+      newProviderId.trim(),
+      newProviderFamily,
+      newProviderBaseUrl || undefined,
+      newProviderApiKey || undefined,
+    );
     setNewProviderId('');
     setNewProviderFamily('openai-compatible');
     setNewProviderBaseUrl('');
     setNewProviderApiKey('');
     setShowAddProviderForm(false);
   }, [onAddProvider, newProviderId, newProviderFamily, newProviderBaseUrl, newProviderApiKey]);
+
+  // ── Inline catalog keying + save-time probe ──
+  const [inlineKeyFor, setInlineKeyFor] = useState<string | null>(null);
+  const [inlineKeyValue, setInlineKeyValue] = useState('');
+  const [inlineKeyReveal, setInlineKeyReveal] = useState(false);
+  const [probeResults, setProbeResults] = useState<
+    Record<string, { ok: boolean; status: string; detail?: string | undefined }>
+  >({});
+
+  const savedIds = useMemo(() => new Set(savedProviders.map((s) => s.id)), [savedProviders]);
+
+  useEffect(() => {
+    const off = ws.on('provider.probe', (msg: WSServerMessage) => {
+      if (msg.type !== 'provider.probe') return;
+      const p = msg.payload as { providerId: string; ok: boolean; status: string; detail?: string };
+      // `no_base_url` / `no_provider` aren't actionable for cloud providers —
+      // skip them so we never show a misleading red mark.
+      if (p.status === 'no_base_url' || p.status === 'no_provider') return;
+      setProbeResults((prev) => ({
+        ...prev,
+        [p.providerId]: { ok: p.ok, status: p.status, detail: p.detail },
+      }));
+    });
+    return () => off?.();
+  }, [ws]);
+
+  const handleInlineKeySave = useCallback(
+    (p: CatalogProvider) => {
+      const key = inlineKeyValue.trim();
+      if (!key) return;
+      if (savedIds.has(p.id)) {
+        onAddKey(p.id, 'default', key);
+      } else {
+        onAddProvider(p.id, p.family, p.apiBase ?? undefined, key);
+      }
+      setInlineKeyValue('');
+      setInlineKeyFor(null);
+      setInlineKeyReveal(false);
+      toast.success(`Saved key for ${p.name}`);
+      // Probe shortly after so the config write lands first. Only meaningful
+      // when the provider exposes a base URL to hit.
+      if (p.apiBase) setTimeout(() => ws.probeProvider(p.id, 6000), 700);
+    },
+    [inlineKeyValue, savedIds, onAddKey, onAddProvider, ws],
+  );
 
   // ── Filter + group catalog ──
 
@@ -165,6 +224,25 @@ export function ProviderSection({
 
   return (
     <div className="space-y-4">
+      {/* Subscription sign-in (ChatGPT / Claude / Copilot) */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <Key className="h-4 w-4 text-muted-foreground" />
+          Subscription login
+        </h3>
+        <OAuthLoginSection ws={ws} />
+      </div>
+
+      <div className="pt-2 border-t">
+        <h3 className="text-sm font-semibold mb-1 flex items-center gap-2">
+          <Globe className="h-4 w-4 text-muted-foreground" />
+          API key providers
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          Pick a provider from the catalog and add an API key, or manage saved providers.
+        </p>
+      </div>
+
       {/* Provider source toggle */}
       <div className="flex gap-2 mb-4">
         <Button
@@ -205,60 +283,145 @@ export function ProviderSection({
             </div>
           ) : (
             PROVIDER_FAMILIES.map((family) => {
-                const providers = catalogByFamily[family];
-                if (!providers?.length) return null;
-                return (
-                  <div key={family} className="space-y-2">
-                    <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-                      {family}
-                    </h3>
-                    <div className="grid grid-cols-1 gap-2">
-                      {providers.map((p) => (
-                        <button
-                          type="button"
+              const providers = catalogByFamily[family];
+              if (!providers?.length) return null;
+              return (
+                <div key={family} className="space-y-2">
+                  <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                    {family}
+                  </h3>
+                  <div className="grid grid-cols-1 gap-2">
+                    {providers.map((p) => {
+                      const probe = probeResults[p.id];
+                      const selected = activeProvider === p.id;
+                      return (
+                        <div
                           key={p.id}
-                          onClick={() => onSelectProvider(p.id)}
                           className={cn(
-                            'flex flex-col items-start p-3 rounded-lg border text-left transition-all',
-                            activeProvider === p.id
+                            'rounded-lg border transition-all',
+                            selected
                               ? 'border-primary bg-primary/5 ring-2 ring-primary/20'
-                              : 'border-border hover:bg-muted',
+                              : 'border-border',
                           )}
                         >
-                          <div className="flex w-full justify-between items-start">
-                            <div>
-                              <span className="font-medium">{p.name}</span>
-                              <span className="ml-2 text-xs text-muted-foreground">
-                                ({p.id})
-                              </span>
+                          <button
+                            type="button"
+                            onClick={() => onSelectProvider(p.id)}
+                            className={cn(
+                              'flex w-full flex-col items-start p-3 text-left rounded-lg',
+                              !selected && 'hover:bg-muted',
+                            )}
+                          >
+                            <div className="flex w-full justify-between items-start">
+                              <div>
+                                <span className="font-medium">{p.name}</span>
+                                <span className="ml-2 text-xs text-muted-foreground">({p.id})</span>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                {p.hasApiKey && (
+                                  <span className="text-xs bg-green-500/10 text-green-600 px-2 py-0.5 rounded">
+                                    <Key className="h-3 w-3 inline mr-1" />
+                                    Configured
+                                  </span>
+                                )}
+                                {probe && (
+                                  <span
+                                    className={cn(
+                                      'text-xs px-2 py-0.5 rounded inline-flex items-center gap-1',
+                                      probe.ok
+                                        ? 'bg-green-500/10 text-green-600'
+                                        : 'bg-destructive/10 text-destructive',
+                                    )}
+                                    title={probe.detail ?? probe.status}
+                                  >
+                                    {probe.ok ? (
+                                      <CheckCircle2 className="h-3 w-3" />
+                                    ) : (
+                                      <XCircle className="h-3 w-3" />
+                                    )}
+                                    {probe.ok ? 'Reachable' : probe.status}
+                                  </span>
+                                )}
+                                {p.envVars[0] && (
+                                  <span className="text-xs text-muted-foreground">
+                                    ENV: {p.envVars[0]}
+                                  </span>
+                                )}
+                                {selected && <CheckCircle2 className="h-4 w-4 text-primary" />}
+                              </div>
                             </div>
-                            <div className="flex items-center gap-2">
-                              {p.hasApiKey && (
-                                <span className="text-xs bg-green-500/10 text-green-600 px-2 py-0.5 rounded">
-                                  <Key className="h-3 w-3 inline mr-1" />
-                                  Configured
-                                </span>
-                              )}
-                              {p.envVars[0] && (
-                                <span className="text-xs text-muted-foreground">
-                                  ENV: {p.envVars[0]}
-                                </span>
-                              )}
-                              {activeProvider === p.id && (
-                                <CheckCircle2 className="h-4 w-4 text-primary" />
+                            <div className="text-xs text-muted-foreground mt-1">
+                              {p.modelCount} models
+                              {p.apiBase && ` · ${p.apiBase}`}
+                            </div>
+                          </button>
+
+                          {/* Inline key entry — only when selected and not yet keyed. */}
+                          {selected && !p.hasApiKey && (
+                            <div className="px-3 pb-3 -mt-1 space-y-2">
+                              {inlineKeyFor === p.id ? (
+                                <>
+                                  <div className="flex gap-2">
+                                    <Input
+                                      autoFocus
+                                      type={inlineKeyReveal ? 'text' : 'password'}
+                                      placeholder={`${p.name} API key`}
+                                      value={inlineKeyValue}
+                                      onChange={(e) => setInlineKeyValue(e.target.value)}
+                                      className="text-sm"
+                                      onKeyDown={(e) => {
+                                        if (e.key === 'Enter') handleInlineKeySave(p);
+                                      }}
+                                    />
+                                    <Button
+                                      size="icon"
+                                      variant="ghost"
+                                      onClick={() => setInlineKeyReveal((v) => !v)}
+                                    >
+                                      {inlineKeyReveal ? (
+                                        <EyeOff className="h-4 w-4" />
+                                      ) : (
+                                        <Eye className="h-4 w-4" />
+                                      )}
+                                    </Button>
+                                    <Button
+                                      size="sm"
+                                      onClick={() => handleInlineKeySave(p)}
+                                      disabled={!inlineKeyValue.trim()}
+                                    >
+                                      Save
+                                    </Button>
+                                  </div>
+                                  {p.envVars[0] && (
+                                    <p className="text-xs text-muted-foreground">
+                                      Or set{' '}
+                                      <code className="bg-muted px-1 rounded">{p.envVars[0]}</code>{' '}
+                                      in the environment instead.
+                                    </p>
+                                  )}
+                                </>
+                              ) : (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => {
+                                    setInlineKeyFor(p.id);
+                                    setInlineKeyValue('');
+                                  }}
+                                >
+                                  <Key className="h-3.5 w-3.5 mr-1" />
+                                  Add API key
+                                </Button>
                               )}
                             </div>
-                          </div>
-                          <div className="text-xs text-muted-foreground mt-1">
-                            {p.modelCount} models
-                            {p.apiBase && ` · ${p.apiBase}`}
-                          </div>
-                        </button>
-                      ))}
-                    </div>
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
-                );
-              })
+                </div>
+              );
+            })
           )}
         </div>
       )}
@@ -337,7 +500,9 @@ export function ProviderSection({
                 <div className="flex justify-between items-start">
                   <div>
                     <h4 className="font-medium">{sp.id}</h4>
-                    {sp.family && <span className="text-xs text-muted-foreground">{sp.family}</span>}
+                    {sp.family && (
+                      <span className="text-xs text-muted-foreground">{sp.family}</span>
+                    )}
                   </div>
                   <div className="flex gap-2">
                     <Button size="icon" variant="ghost" onClick={() => onRemoveProvider(sp.id)}>
@@ -380,7 +545,10 @@ export function ProviderSection({
                   )}
 
                   {sp.apiKeys.map((key) => (
-                    <div key={key.label} className="flex items-center justify-between p-2 bg-muted/50 rounded">
+                    <div
+                      key={key.label}
+                      className="flex items-center justify-between p-2 bg-muted/50 rounded"
+                    >
                       <div>
                         <span className="text-sm font-medium">{key.label}</span>
                         {key.isActive && (
@@ -388,15 +556,25 @@ export function ProviderSection({
                             Active
                           </span>
                         )}
-                        <div className="text-xs text-muted-foreground font-mono">{key.maskedKey}</div>
+                        <div className="text-xs text-muted-foreground font-mono">
+                          {key.maskedKey}
+                        </div>
                       </div>
                       <div className="flex gap-1">
                         {!key.isActive && (
-                          <Button size="sm" variant="ghost" onClick={() => onSetActiveKey(sp.id, key.label)}>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => onSetActiveKey(sp.id, key.label)}
+                          >
                             Set Active
                           </Button>
                         )}
-                        <Button size="icon" variant="ghost" onClick={() => onDeleteKey(sp.id, key.label)}>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => onDeleteKey(sp.id, key.label)}
+                        >
                           <Trash2 className="h-3 w-3 text-destructive" />
                         </Button>
                       </div>
@@ -423,7 +601,11 @@ export function ProviderSection({
                           variant="ghost"
                           onClick={() => setShowNewKeyValue(!showNewKeyValue)}
                         >
-                          {showNewKeyValue ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                          {showNewKeyValue ? (
+                            <EyeOff className="h-4 w-4" />
+                          ) : (
+                            <Eye className="h-4 w-4" />
+                          )}
                         </Button>
                       </div>
                       <div className="flex gap-2">

--- a/packages/webui/src/lib/ws-client.ts
+++ b/packages/webui/src/lib/ws-client.ts
@@ -510,6 +510,23 @@ export class WrongStackWebSocketClient {
     this.send({ type: 'provider.remove', payload: { providerId } });
   }
 
+  // ---- Subscription OAuth login (ChatGPT / Claude / Copilot) ----
+
+  /** Begin a subscription sign-in; progress arrives as `auth.oauth.status`. */
+  startOAuth(kind: 'chatgpt' | 'claude' | 'copilot') {
+    this.send({ type: 'auth.oauth.start', payload: { kind } });
+  }
+
+  /** Manual-paste fallback for loopback flows (port busy / remote browser). */
+  submitOAuthCode(kind: 'chatgpt' | 'claude' | 'copilot', input: string) {
+    this.send({ type: 'auth.oauth.code', payload: { kind, input } });
+  }
+
+  /** Cancel an in-flight subscription sign-in. */
+  cancelOAuth(kind: 'chatgpt' | 'claude' | 'copilot') {
+    this.send({ type: 'auth.oauth.cancel', payload: { kind } });
+  }
+
   /** Run a health probe against a saved provider's `/v1/models`. */
   probeProvider(providerId: string, timeoutMs?: number) {
     this.send({

--- a/packages/webui/src/server/provider-handlers.ts
+++ b/packages/webui/src/server/provider-handlers.ts
@@ -1,6 +1,12 @@
 import type { WebSocket } from 'ws';
-import type { ProviderConfig } from '@wrongstack/core';
+import type { ModelsRegistry, ProviderConfig } from '@wrongstack/core';
 import { DefaultSecretScrubber } from '@wrongstack/core';
+import {
+  beginOAuthLogin,
+  type OAuthKind,
+  type OAuthLoginOutcome,
+  type OAuthSession,
+} from '@wrongstack/providers/oauth';
 import { probeLocalLlm } from '@wrongstack/runtime/probe';
 import { loadSavedProviders, saveProviders } from './provider-config-io.js';
 import { toErrorMessage } from '@wrongstack/core/utils';
@@ -12,6 +18,7 @@ import {
   removeProvider as removeProviderRecord,
   maskedKey,
   normalizeKeys,
+  writeKeysBack,
 } from './provider-keys.js';
 import type { ConnectedClient, WSServerMessage } from './types.js';
 import { send, sendResult, errMessage } from './ws-utils.js';
@@ -83,6 +90,8 @@ export interface ProviderHandlerDeps {
   broadcast: (clients: Map<WebSocket, ConnectedClient>, msg: WSServerMessage) => void;
   /** Connected WebUI clients map */
   clients: Map<WebSocket, ConnectedClient>;
+  /** Used by the ChatGPT OAuth flow's tier-2 model lookup (best-effort). */
+  modelsRegistry?: ModelsRegistry | undefined;
 }
 
 export function createProviderHandlers(deps: ProviderHandlerDeps) {
@@ -299,6 +308,127 @@ export function createProviderHandlers(deps: ProviderHandlerDeps) {
     }
   }
 
+  // ── Subscription OAuth login (ChatGPT / Claude / Copilot) ──────────────────
+  //
+  // One in-flight session per kind, shared across clients (single-user). A
+  // second start for the same kind closes the prior one. The engine
+  // (@wrongstack/providers/oauth) is IO-free — persistence is local below.
+
+  const oauthSessions = new Map<OAuthKind, OAuthSession>();
+
+  function sendOAuthStatus(
+    ws: WebSocket,
+    kind: OAuthKind,
+    phase: 'awaiting_browser' | 'awaiting_code' | 'exchanging' | 'fetching_models' | 'success' | 'error',
+    extra: Record<string, unknown> = {},
+  ): void {
+    send(ws, { type: 'auth.oauth.status', payload: { kind, phase, ...extra } });
+  }
+
+  /** Persist a successful login by upserting the OAuth credential. */
+  async function persistOAuthOutcome(outcome: OAuthLoginOutcome): Promise<void> {
+    const providers = await loadConfigProviders();
+    const existing = providers[outcome.providerId];
+    const p: ProviderConfig = existing ? { ...existing } : { type: outcome.providerId };
+    p.family = outcome.family as ProviderConfig['family'];
+    if (!p.baseUrl) p.baseUrl = outcome.baseUrl;
+    p.models = [...outcome.models];
+    const keys = normalizeKeys(p).filter((k) => k.label !== outcome.apiKey.label);
+    keys.push(outcome.apiKey);
+    writeKeysBack(p, keys);
+    p.activeKey = outcome.apiKey.label;
+    providers[outcome.providerId] = p;
+    await saveConfigProviders(providers);
+    broadcastSaved(providers);
+  }
+
+  async function finishOAuth(
+    ws: WebSocket,
+    kind: OAuthKind,
+    outcome: OAuthLoginOutcome | null,
+  ): Promise<void> {
+    if (!outcome) {
+      sendOAuthStatus(ws, kind, 'error', { message: 'Sign-in cancelled or timed out.' });
+      return;
+    }
+    sendOAuthStatus(ws, kind, 'fetching_models', { providerId: outcome.providerId });
+    await persistOAuthOutcome(outcome);
+    sendOAuthStatus(ws, kind, 'success', {
+      providerId: outcome.providerId,
+      message: `Signed in — saved as ${outcome.providerId} (${outcome.models.length} models).`,
+    });
+  }
+
+  async function handleOAuthStart(ws: WebSocket, kind: OAuthKind): Promise<void> {
+    try {
+      oauthSessions.get(kind)?.close();
+      oauthSessions.delete(kind);
+
+      const session = await beginOAuthLogin(kind, { modelsRegistry: deps.modelsRegistry });
+      oauthSessions.set(kind, session);
+
+      if (kind === 'copilot') {
+        sendOAuthStatus(ws, kind, 'awaiting_code', {
+          providerId: session.providerId,
+          verificationUri: session.verificationUri,
+          userCode: session.userCode,
+          bound: false,
+        });
+      } else {
+        sendOAuthStatus(ws, kind, 'awaiting_browser', {
+          providerId: session.providerId,
+          authorizeUrl: session.authorizeUrl,
+          bound: session.bound,
+        });
+      }
+
+      // Drive to completion in the background when there is something to wait
+      // for: the copilot device poll, or a bound loopback callback. When the
+      // loopback could not bind, we wait for a manual `auth.oauth.code` paste.
+      const drive = kind === 'copilot' || session.bound;
+      if (drive) {
+        void (async () => {
+          try {
+            const outcome = await session.waitForCompletion();
+            await finishOAuth(ws, kind, outcome);
+          } catch (err) {
+            sendOAuthStatus(ws, kind, 'error', { message: errMessage(err) });
+          } finally {
+            if (oauthSessions.get(kind) === session) oauthSessions.delete(kind);
+          }
+        })();
+      }
+    } catch (err) {
+      sendOAuthStatus(ws, kind, 'error', { message: errMessage(err) });
+    }
+  }
+
+  async function handleOAuthCode(ws: WebSocket, kind: OAuthKind, input: string): Promise<void> {
+    const session = oauthSessions.get(kind);
+    if (!session) {
+      sendOAuthStatus(ws, kind, 'error', {
+        message: 'No active sign-in for this provider — start the login again.',
+      });
+      return;
+    }
+    try {
+      sendOAuthStatus(ws, kind, 'exchanging', { providerId: session.providerId });
+      const outcome = await session.completeWithCode(input);
+      await finishOAuth(ws, kind, outcome);
+    } catch (err) {
+      sendOAuthStatus(ws, kind, 'error', { message: errMessage(err) });
+    } finally {
+      session.close();
+      if (oauthSessions.get(kind) === session) oauthSessions.delete(kind);
+    }
+  }
+
+  function handleOAuthCancel(ws: WebSocket, kind: OAuthKind): void {
+    oauthSessions.get(kind)?.close();
+    oauthSessions.delete(kind);
+    sendOAuthStatus(ws, kind, 'error', { message: 'Sign-in cancelled.' });
+  }
+
   return {
     handleKeyUpsert,
     handleKeyDelete,
@@ -309,6 +439,9 @@ export function createProviderHandlers(deps: ProviderHandlerDeps) {
     handleProviderUndoClear,
     handleProviderUpdate,
     handleProviderProbe,
+    handleOAuthStart,
+    handleOAuthCode,
+    handleOAuthCancel,
     loadConfigProviders,
   };
 }

--- a/packages/webui/src/server/provider-routes.ts
+++ b/packages/webui/src/server/provider-routes.ts
@@ -41,6 +41,14 @@ function invalidPayload(ws: WebSocket, type: string): true {
   return true;
 }
 
+const OAUTH_KINDS = new Set(['chatgpt', 'claude', 'copilot']);
+function oauthKind(payload: Record<string, unknown> | null): 'chatgpt' | 'claude' | 'copilot' | null {
+  const kind = payload?.['kind'];
+  return typeof kind === 'string' && OAUTH_KINDS.has(kind)
+    ? (kind as 'chatgpt' | 'claude' | 'copilot')
+    : null;
+}
+
 export async function handleProviderRoute(
   ws: WebSocket,
   msg: WSClientMessage,
@@ -160,6 +168,29 @@ export async function handleProviderRoute(
       const timeoutMs = payload ? optionalNumber(payload, 'timeoutMs') : null;
       if (!providerId || timeoutMs === null) return invalidPayload(ws, msg.type);
       await routes.providerHandlers.handleProviderProbe(ws, providerId, timeoutMs);
+      return true;
+    }
+
+    case 'auth.oauth.start': {
+      const kind = oauthKind(asPayloadRecord(msg));
+      if (!kind) return invalidPayload(ws, msg.type);
+      await routes.providerHandlers.handleOAuthStart(ws, kind);
+      return true;
+    }
+
+    case 'auth.oauth.code': {
+      const payload = asPayloadRecord(msg);
+      const kind = oauthKind(payload);
+      const input = payload ? requiredString(payload, 'input') : null;
+      if (!kind || !input) return invalidPayload(ws, msg.type);
+      await routes.providerHandlers.handleOAuthCode(ws, kind, input);
+      return true;
+    }
+
+    case 'auth.oauth.cancel': {
+      const kind = oauthKind(asPayloadRecord(msg));
+      if (!kind) return invalidPayload(ws, msg.type);
+      routes.providerHandlers.handleOAuthCancel(ws, kind);
       return true;
     }
 

--- a/packages/webui/src/server/routes.ts
+++ b/packages/webui/src/server/routes.ts
@@ -286,6 +286,7 @@ export function buildRoutes(
     setConfigWriteLock: state.setConfigWriteLock,
     broadcast: (msg) => broadcast(state.getClients(), msg),
     clients: state.getClients(),
+    modelsRegistry: deps.modelsRegistry,
   });
 
   const providerRoutes: ProviderRouteHandlers = {
@@ -724,12 +725,13 @@ export function buildRoutes(
       try {
         const decision = await deps.brain.decide({
           id: `brain-ask-${Date.now().toString(36)}`,
+          sessionId: deps.context.session?.id,
           source: 'user',
           question,
           risk: 'medium',
           fallback: 'ask_human',
         });
-        send(ws, { type: 'brain.answer', payload: { question, decision } });
+        send(ws, { type: 'brain.answer', payload: { sessionId: deps.context.session?.id, question, decision } });
       } catch (err) {
         sendResult(ws, false, `Brain consultation failed: ${errMessage(err)}`);
       }

--- a/packages/webui/src/types.ts
+++ b/packages/webui/src/types.ts
@@ -739,6 +739,33 @@ export interface WSKeyOperationResult {
   };
 }
 
+/** Which subscription OAuth login a flow is running. */
+export type OAuthKind = 'chatgpt' | 'claude' | 'copilot';
+
+/**
+ * Progress for an in-flight subscription OAuth login, broadcast in reply to
+ * `auth.oauth.start` / `auth.oauth.code`. `phase` drives the UI:
+ *  - `awaiting_browser` — loopback flows: open `authorizeUrl` in a new tab.
+ *  - `awaiting_code` — copilot device flow: show `userCode` + `verificationUri`.
+ *  - `exchanging` / `fetching_models` — spinner states.
+ *  - `success` — `providerId` is now saved (the `providers.saved` broadcast follows).
+ *  - `error` — `message` carries the reason.
+ */
+export interface WSAuthOAuthStatus {
+  type: 'auth.oauth.status';
+  payload: {
+    kind: OAuthKind;
+    phase: 'awaiting_browser' | 'awaiting_code' | 'exchanging' | 'fetching_models' | 'success' | 'error';
+    providerId?: string | undefined;
+    authorizeUrl?: string | undefined;
+    verificationUri?: string | undefined;
+    userCode?: string | undefined;
+    /** True when a loopback listener bound (false → manual paste needed). */
+    bound?: boolean | undefined;
+    message?: string | undefined;
+  };
+}
+
 export interface WSFilesList {
   type: 'files.list';
   payload: {
@@ -867,7 +894,7 @@ export interface WSEternalIteration {
 
 export interface WSAgentTimelineMessage {
   type: 'agent.timeline.message';
-  payload: {
+  payload: SessionScopedPayload & {
     subagentId: string;
     agentName: string;
     content: string;
@@ -881,7 +908,7 @@ export interface WSAgentTimelineMessage {
 
 export interface WSAgentStatusChanged {
   type: 'agent.status_changed';
-  payload: {
+  payload: SessionScopedPayload & {
     subagentId: string;
     agentName: string;
     status: 'spawned' | 'running' | 'completed' | 'failed' | 'timeout' | 'stopped' | 'budget_exhausted';
@@ -1131,6 +1158,9 @@ export type WSClientMessage =
       };
     }
   | { type: 'provider.probe'; payload: { providerId: string; timeoutMs?: number | undefined } }
+  | { type: 'auth.oauth.start'; payload: { kind: OAuthKind } }
+  | { type: 'auth.oauth.code'; payload: { kind: OAuthKind; input: string } }
+  | { type: 'auth.oauth.cancel'; payload: { kind: OAuthKind } }
   | { type: 'tools.list' }
   | { type: 'memory.list' }
   | { type: 'memory.remember'; payload: { text: string; scope?: MemoryScope | undefined } }
@@ -1313,6 +1343,7 @@ export type WSServerMessage =
   | WSSavedProviders
   | WSProviderProbe
   | WSKeyOperationResult
+  | WSAuthOAuthStatus
   | WSFilesList
   | { type: 'files.tree'; payload: { root: string; tree: unknown[]; error?: string | undefined } }
   | { type: 'files.read'; payload: { filePath: string; content: string; error?: string | undefined } }
@@ -1349,7 +1380,7 @@ export type WSServerMessage =
   | WSEternalIteration
   | WSAgentTimelineMessage
   | WSAgentStatusChanged
-  | { type: 'subagent.event'; payload: Record<string, unknown> & { kind: string } }
+  | { type: 'subagent.event'; payload: SessionScopedPayload & Record<string, unknown> & { kind: string } }
   | WSWorktreeState
   | WSWorktreeEvent
   | WSWorktreeOrphans
@@ -1382,13 +1413,13 @@ export type WSServerMessage =
   | { type: 'projects.selected'; payload: { root: string; name: string; message: string } }
   | { type: 'working_dir.changed'; payload: { cwd: string; projectRoot: string } }
   | { type: 'brain.status'; payload: { maxAutoRisk: string; log: Array<{ at: number; kind: string; question: string; outcome: string }> } }
-  | { type: 'brain.answer'; payload: { question: string; decision: { type: string; optionId?: string | undefined; text?: string | undefined; rationale?: string | undefined; reason?: string | undefined; prompt?: string | undefined } } }
-  | { type: 'brain.event'; payload: Record<string, unknown> & { event: string } }
+  | { type: 'brain.answer'; payload: SessionScopedPayload & { question: string; decision: { type: string; optionId?: string | undefined; text?: string | undefined; rationale?: string | undefined; reason?: string | undefined; prompt?: string | undefined } } }
+  | { type: 'brain.event'; payload: SessionScopedPayload & Record<string, unknown> & { event: string } }
   | { type: 'session.damaged'; payload: { sessionId: string; detail: string } }
-  | { type: 'session.rewound'; payload: { toPromptIndex: number; revertedFiles: string[]; removedEvents: number } }
-  | { type: 'checkpoint.written'; payload: { promptIndex: number; promptPreview: string; ts: string; fileCount: number } }
-  | { type: 'in_flight.started'; payload: { context: string; ts: string } }
-  | { type: 'in_flight.ended'; payload: { reason: 'clean' | 'aborted' | 'recovered'; ts: string } }
+  | { type: 'session.rewound'; payload: SessionScopedPayload & { toPromptIndex: number; revertedFiles: string[]; removedEvents: number } }
+  | { type: 'checkpoint.written'; payload: SessionScopedPayload & { promptIndex: number; promptPreview: string; ts: string; fileCount: number } }
+  | { type: 'in_flight.started'; payload: SessionScopedPayload & { context: string; ts: string } }
+  | { type: 'in_flight.ended'; payload: SessionScopedPayload & { reason: 'clean' | 'aborted' | 'recovered'; ts: string } }
   | { type: 'model.refine_result'; payload: { refined: string; english: string; error?: string | undefined } }
   // ── Coordinator / autonomous fleet events ──────────────────────────────
   | { type: 'coordinator.status'; payload: { status: 'idle' | 'running' | 'draining' | 'stopped'; mode?: string; subagentCount?: number; taskQueue?: { pending: number; running: number; completed: number; failed: number } } }


### PR DESCRIPTION
## What

Adds **Sign in with ChatGPT / Claude / Copilot** to WebUI Settings → Provider on **both** WebUI servers (standalone `wstackui` + embedded `wstack --webui`), plus a **key-entry UX refresh** (inline catalog keying + save-time reachability probe).

Until now the subscription OAuth logins existed only in the CLI (`auth-menu/*-oauth.ts`), hard-wired to terminal IO — no WebUI surface at all.

## How

- **Shared engine** — new headless, IO-free OAuth engine at `@wrongstack/providers/oauth` (new `./oauth` subpath export). `beginOAuthLogin(kind, {modelsRegistry})` → `OAuthSession` → persistence-agnostic `OAuthLoginOutcome` (provider patch + `ProviderApiKey`). Loopback flows (ChatGPT `:1455`, Claude `:53692`) + Copilot device-flow. Lives in providers (not runtime) because the Copilot flow needs `refreshCopilotToken`, and both CLI + webui depend on providers.
- **Both servers** — `auth.oauth.start|code|cancel {kind}` ↔ `auth.oauth.status {kind,phase,…}`. Standalone: `provider-handlers.ts` + `provider-routes.ts` (live `buildRoutes` path). Embedded: new `ws-handlers/oauth.ts` + `webui-server.ts` dispatch. Each persists via its own provider store, then `broadcastSaved`; the live provider hot-reloads via `watchProviderConfig` (no restart).
- **Frontend** — `OAuthLoginSection.tsx` (opens the authorize URL in a new tab + manual-paste fallback for remote/port-busy; Copilot shows a user code). `ProviderSection.tsx` refresh: inline per-card API-key entry (no more forced trip to the Saved tab) + a reachability ✓/✗ badge from `provider.probe`.

## Notes

- **CLI auth-menu deliberately not refactored** — its exports back existing tests + `wiring/provider.ts`; rewriting tested working code for DRY-only gain wasn't worth the risk. Engine files carry "Headless port of CLI's X" headers.
- **Loopback locality**: `localhost` callbacks only reach the WebUI when browser + server share a machine (the normal case). Manual-paste fallback + Copilot device-flow cover remote access — surfaced in the UI copy.

## Verification

- `pnpm run typecheck` — exit 0 (all packages)
- Full `pnpm test` — green: providers 420/420 (incl. new `oauth.test.ts` ×12), webui 1906/1906, cli 2222 pass / 10 skip
- Builds (providers/webui/cli) — exit 0
- Zero new biome violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)