### PR TITLE
feat(tools,core): config bypass for danger rules (PR 3)

### DIFF
--- a/packages/core/src/storage/config-loader.ts
+++ b/packages/core/src/storage/config-loader.ts
@@ -509,18 +509,41 @@ export function stripUnsafeInProjectFields(
   // `tools.exec.allow` EXPANDS what the agent may execute — never honor that
   // from an attacker-controllable repo config. Remove it while preserving
   // `tools.exec.deny` (removing commands only narrows, so it is always safe).
+  //
+  // `tools.exec.danger.bypass` is the same threat model: a bypass list
+  // weakens the heuristic danger gate on a per-rule basis. A malicious
+  // repo that auto-loaded its own bypass rules could silently disarm
+  // safety checks for anyone who clones it. Same strip semantics.
+  //
   // Clone the affected objects so the caller's input is not mutated.
   const outTools = (out as Record<string, unknown>)['tools'];
   if (outTools && typeof outTools === 'object') {
     const execCfg = (outTools as Record<string, unknown>)['exec'];
-    if (execCfg && typeof execCfg === 'object' && 'allow' in (execCfg as Record<string, unknown>)) {
-      const clonedExec = { ...(execCfg as Record<string, unknown>) };
-      delete clonedExec['allow'];
-      (out as Record<string, unknown>)['tools'] = {
-        ...(outTools as Record<string, unknown>),
-        exec: clonedExec,
-      };
-      stripped.push('tools.exec.allow');
+    if (execCfg && typeof execCfg === 'object') {
+      const hasAllow = 'allow' in (execCfg as Record<string, unknown>);
+      const hasDanger = 'danger' in (execCfg as Record<string, unknown>);
+      if (hasAllow || hasDanger) {
+        const clonedExec: Record<string, unknown> = { ...(execCfg as Record<string, unknown>) };
+        if (hasAllow) {
+          delete clonedExec['allow'];
+          stripped.push('tools.exec.allow');
+        }
+        if (hasDanger) {
+          // Strip the whole `danger` object — `ExecDangerConfig` only
+          // has `bypass` today, and bypass is the unsafe field, so
+          // stripping the parent is equivalent and forward-compat with
+          // any future fields added under `danger` that we don't yet
+          // know about. Better to be conservative: anything new under
+          // `danger` from a repo config is rejected until it gets an
+          // explicit allow decision.
+          delete clonedExec['danger'];
+          stripped.push('tools.exec.danger');
+        }
+        (out as Record<string, unknown>)['tools'] = {
+          ...(outTools as Record<string, unknown>),
+          exec: clonedExec,
+        };
+      }
     }
   }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -296,6 +296,34 @@ export interface ExecToolConfig {
    * removing a command can only narrow what runs, so it is always safe.
    */
   deny?: string[] | undefined;
+  /**
+   * Per-rule bypass for the heuristic danger detector. Each entry is a
+   * stable `matchedRule` id (e.g. `rm-recursive`, `git-push-force`); a
+   * matched rule whose id is in this list is suppressed.
+   *
+   * Use case: a project that legitimately runs `rm -rf ./build` on every
+   * CI run can add `"rm-recursive"` to bypass so the detector stops
+   * emitting banners for that one rule — without disabling it for every
+   * other `rm -rf` invocation.
+   *
+   * **Trusted sources only.** Bypassing a danger rule means the user
+   * agreed to a specific destructive pattern; in-project repo config
+   * could otherwise be used to silently opt everyone in. The boot path
+   * should strip this field from `<project>/.wrongstack/config.json`
+   * the same way it strips `allow`.
+   */
+  danger?: ExecDangerConfig | undefined;
+}
+
+export interface ExecDangerConfig {
+  /**
+   * List of danger rule ids to skip. Each id corresponds to a rule in
+   * `@wrongstack/tools/src/_danger-detect.ts` (e.g. `rm-recursive`,
+   * `git-push-force`, `inline-eval`, `sudo`). Unknown ids are ignored
+   * (forward-compat: a rule added in a future version can be referenced
+   * before the user upgrades).
+   */
+  bypass?: string[] | undefined;
 }
 
 export type ToolDescriptionMode = 'extend' | 'simple';

--- a/packages/core/tests/storage/config-loader-extra.test.ts
+++ b/packages/core/tests/storage/config-loader-extra.test.ts
@@ -266,6 +266,86 @@ describe('DefaultConfigLoader in-project config hardening (WS-06)', () => {
     expect((input as { tools: { exec: { allow: string[] } } }).tools.exec.allow).toEqual(['curl']);
   });
 
+  it('strips tools.exec.danger (with bypass) from in-project config — same threat model as allow', () => {
+    // `tools.exec.danger.bypass` weakens the heuristic danger gate on a
+    // per-rule basis. A repo must never be able to silently disarm safety
+    // checks for anyone who clones it. We strip the whole `danger` object
+    // (the only field it contains today is `bypass`, and the strip is
+    // forward-compat: any future field added under `danger` is also
+    // denied until it gets an explicit allow decision).
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const out = stripUnsafeInProjectFields(
+      {
+        tools: {
+          maxIterations: 7,
+          exec: {
+            deny: ['rm'],
+            danger: { bypass: ['rm-recursive', 'git-push-force'] },
+          },
+        },
+      } as never,
+      '/tmp/.wrongstack/config.json',
+      warn,
+    );
+    const tools = (out as {
+      tools?: {
+        maxIterations?: number;
+        exec?: { deny?: unknown; danger?: unknown; allow?: unknown };
+      };
+    }).tools;
+    expect(tools?.maxIterations).toBe(7);
+    expect(tools?.exec?.deny).toEqual(['rm']);
+    expect(tools?.exec?.danger).toBeUndefined(); // dangerous: stripped
+    expect(tools?.exec?.allow).toBeUndefined(); // not set, but cross-check
+    const warned = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).toContain('tools.exec.danger');
+    // The inner bypass field should not be named separately — we strip
+    // the parent, so the warning should not mention `tools.exec.danger.bypass`.
+    expect(warned).not.toContain('tools.exec.danger.bypass');
+    warn.mockRestore();
+  });
+
+  it('strips BOTH tools.exec.allow and tools.exec.danger in one pass', () => {
+    // A repo that tries to widen the allowlist AND disarm danger detection
+    // at the same time — both should be stripped in a single call.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const out = stripUnsafeInProjectFields(
+      {
+        tools: {
+          exec: {
+            allow: ['curl', 'powershell'],
+            deny: ['rm'],
+            danger: { bypass: ['rm-recursive'] },
+          },
+        },
+      } as never,
+      '/tmp/.wrongstack/config.json',
+      warn,
+    );
+    const exec = (out as { tools?: { exec?: { allow?: unknown; deny?: unknown; danger?: unknown } } })
+      .tools?.exec;
+    expect(exec?.allow).toBeUndefined();
+    expect(exec?.danger).toBeUndefined();
+    expect(exec?.deny).toEqual(['rm']); // safe field kept
+    const warned = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).toContain('tools.exec.allow');
+    expect(warned).toContain('tools.exec.danger');
+    warn.mockRestore();
+  });
+
+  it('does not mutate the caller input when stripping tools.exec.danger', () => {
+    const input = {
+      tools: { exec: { danger: { bypass: ['rm-recursive'] } } },
+    } as never;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stripUnsafeInProjectFields(input, '/tmp/.wrongstack/config.json', warn);
+    warn.mockRestore();
+    // Original input still has its bypass — we cloned before deleting.
+    expect(
+      (input as { tools: { exec: { danger: { bypass: string[] } } } }).tools.exec.danger.bypass,
+    ).toEqual(['rm-recursive']);
+  });
+
   it('still merges benign project-level preferences from the in-project config', async () => {
     await fs.writeFile(
       paths.inProjectConfig,

--- a/packages/tools/src/_danger-detect.ts
+++ b/packages/tools/src/_danger-detect.ts
@@ -1,0 +1,232 @@
+/**
+ * Heuristic danger detection for `exec` tool commands.
+ *
+ * Layered on top of `BLOCKED_ARG_PATTERNS` (which is a hard-deny list for
+ * clear sandbox escapes) and `bash-kill-guard.ts` (which protects WrongStack
+ * itself from kill). This module assigns a danger level to a command/arg
+ * pair so the caller can decide whether to:
+ *
+ *   - 'safe'        → execute normally
+ *   - 'caution'     → execute and emit a warning line to the tool output
+ *   - 'destructive' → route through the existing confirm flow
+ *                     (`execTool.permission === 'confirm'`) instead of
+ *                     hard-deny, so the user can still proceed if intentional
+ *
+ * Design constraints:
+ *   - Deterministic: no randomness, no I/O, no time. Same input → same output.
+ *   - No LLM calls. Patterns are regex / exact-match.
+ *   - Per-rule `id` so config can override specific rules (e.g.
+ *     `tools.exec.danger.bypass: ["rm-recursive-build"]` in a future PR).
+ *   - Reasons are human-readable, joined with "; " for the confirm prompt.
+ *
+ * PR 1 (narrow): destructive file deletion + disk/boot operations.
+ * PR 2 (broader, follow-up): git push --force, npm/cargo publish,
+ *   kubectl delete namespace, network exfil, privilege escalation.
+ */
+
+export type DangerLevel = 'safe' | 'caution' | 'destructive';
+
+export interface DangerAssessment {
+  level: DangerLevel;
+  reasons: string[];
+  /** Stable id of the matched rule, for tests and future config-override. */
+  matchedRule?: string;
+}
+
+interface DangerRule {
+  id: string;
+  level: DangerLevel;
+  /** Match a (cmd, args) pair. Return true if this rule fires. */
+  test: (cmd: string, args: readonly string[]) => boolean;
+  /** Human-readable explanation, joined with "; " in the output. */
+  reason: string;
+}
+
+const argHas = (args: readonly string[], value: string): boolean => args.includes(value);
+const argMatches = (args: readonly string[], re: RegExp): boolean => args.some((a) => re.test(a));
+/**
+ * Check for a flag like `-rf`, `-fr`, `-r -f`, `-f -r` etc. where the *order*
+ * of flags does not matter. Each short-flag letter is treated as an
+ * independent `-x` token; we split joined shorts and look for the letters.
+ */
+const hasShortFlags = (args: readonly string[], letters: string): boolean => {
+  for (const a of args) {
+    if (!a.startsWith('-') || a.startsWith('--')) continue;
+    // Strip leading dashes and compare letter set
+    const letters_in = a.replace(/^-+/, '').split('');
+    if (letters.split('').every((l) => letters_in.includes(l))) return true;
+  }
+  return false;
+};
+
+const RULES: readonly DangerRule[] = [
+  // ----- rm / rmdir: recursive force delete (any path) -----
+  // Note: BLOCKED_ARG_PATTERNS already hard-denies root/home/glob paths,
+  // but `rm -rf ./build` is a normal dev workflow that the user might
+  // want to do intentionally. We downgrade it to 'destructive' so the
+  // confirm prompt can approve.
+  {
+    id: 'rm-recursive',
+    level: 'destructive',
+    test: (cmd, args) =>
+      (cmd === 'rm' || cmd === 'rmdir') && hasShortFlags(args, 'rf'),
+    reason: 'recursive force-delete',
+  },
+  // ----- Windows PowerShell Remove-Item: -Recurse -Force -----
+  // Note: PowerShell is NOT in the default allowlist (deliberate, see
+  // cf3fa2b4 commit message), so this only fires when the user has
+  // explicitly added `powershell` to their config.allow. Even then, the
+  // -Recurse -Force combo is dangerous enough to confirm.
+  {
+    id: 'powershell-remove-item-recursive-force',
+    level: 'destructive',
+    test: (cmd, args) => {
+      if (cmd !== 'powershell' && cmd !== 'pwsh') return false;
+      const hasRecurse = argMatches(args, /^-(?:R|Recurse|Recurse\s)/);
+      const hasForce = argHas(args, '-Force') || argHas(args, '-F');
+      // Allow `-WhatIf` (dry-run) without confirmation
+      if (argHas(args, '-WhatIf')) return false;
+      return hasRecurse && hasForce;
+    },
+    reason: 'Remove-Item with -Recurse -Force',
+  },
+  // ----- find -exec / -ok / -execdir -----
+  {
+    id: 'find-exec',
+    level: 'destructive',
+    test: (cmd, args) => {
+      if (cmd !== 'find') return false;
+      return args.some(
+        (a) =>
+          a === '-exec' ||
+          a === '-exec;' ||
+          a === '-ok' ||
+          a === '-ok;' ||
+          a === '-execdir' ||
+          a === '-execdir;' ||
+          a.startsWith('-exec=') ||
+          a.startsWith('-ok=') ||
+          a.startsWith('-execdir='),
+      );
+    },
+    reason: 'find with -exec/-ok (executes arbitrary command on matches)',
+  },
+  // ----- git --exec= / --upload-pack= / --receive-pack= -----
+  // These run arbitrary commands via the git transport layer.
+  {
+    id: 'git-exec',
+    level: 'destructive',
+    test: (cmd, args) =>
+      cmd === 'git' &&
+      args.some(
+        (a) =>
+          a.startsWith('--exec=') ||
+          a.startsWith('--upload-pack=') ||
+          a.startsWith('--receive-pack=') ||
+          a === '--exec' ||
+          a === '--upload-pack' ||
+          a === '--receive-pack',
+      ),
+    reason: 'git with --exec/--upload-pack/--receive-pack (runs arbitrary code)',
+  },
+  // ----- Windows: format / diskpart / bcdedit -----
+  {
+    id: 'win32-format',
+    level: 'destructive',
+    test: (cmd) => cmd === 'format' || cmd === 'format.exe',
+    reason: 'format (Windows disk format)',
+  },
+  {
+    id: 'win32-diskpart',
+    level: 'destructive',
+    test: (cmd) => cmd === 'diskpart' || cmd === 'diskpart.exe',
+    reason: 'diskpart (Windows partition editor)',
+  },
+  {
+    id: 'win32-bcdedit',
+    level: 'destructive',
+    test: (cmd) => cmd === 'bcdedit' || cmd === 'bcdedit.exe',
+    reason: 'bcdedit (Windows boot config editor)',
+  },
+  // ----- mkfs family -----
+  {
+    id: 'mkfs',
+    level: 'destructive',
+    test: (cmd) => /^mkfs(\.[a-z0-9]+)?$/.test(cmd) || cmd === 'mkswap',
+    reason: 'mkfs (filesystem creation — destroys existing data)',
+  },
+  // ----- dd writing to a block device -----
+  {
+    id: 'dd-to-block-device',
+    level: 'destructive',
+    test: (cmd, args) => {
+      if (cmd !== 'dd') return false;
+      return args.some(
+        (a) => /of=\/dev\/(sd|hd|nvme|vd|mmcblk|xvd|loop|disk)/.test(a),
+      );
+    },
+    reason: 'dd writing to a block device',
+  },
+  // ----- Secure-erase tools -----
+  {
+    id: 'shred',
+    level: 'destructive',
+    test: (cmd) => cmd === 'shred' || cmd === 'shred.exe',
+    reason: 'shred (secure file delete)',
+  },
+  {
+    id: 'wipefs',
+    level: 'destructive',
+    test: (cmd) => cmd === 'wipefs' || cmd === 'wipefs.exe',
+    reason: 'wipefs (signature wipe — destroys filesystem headers)',
+  },
+  {
+    id: 'sdelete',
+    level: 'destructive',
+    test: (cmd) => cmd === 'sdelete' || cmd === 'sdelete.exe',
+    reason: 'sdelete (Sysinternals secure delete)',
+  },
+];
+
+/**
+ * Evaluate the danger level of a (cmd, args) pair.
+ *
+ * Returns 'safe' if no rule fires, otherwise the highest level among all
+ * matching rules. The 'matchedRule' field is the *last* rule that fired
+ * (stable, since rules are evaluated in declaration order).
+ *
+ * This function is the single source of truth for danger classification;
+ * it is pure (no side effects) and unit-tested in `danger-detect.test.ts`.
+ */
+export function detectDanger(cmd: string, args: readonly string[]): DangerAssessment {
+  const reasons: string[] = [];
+  let level: DangerLevel = 'safe';
+  let matchedRule: string | undefined;
+
+  for (const rule of RULES) {
+    if (!rule.test(cmd, args)) continue;
+    reasons.push(rule.reason);
+    matchedRule = rule.id;
+    if (levelRank(rule.level) > levelRank(level)) {
+      level = rule.level;
+    }
+  }
+
+  if (level === 'safe') return { level: 'safe', reasons: [] };
+  // matchedRule is set above (last winning rule). For exactOptionalPropertyTypes
+  // we build the object conditionally so the property is omitted when undefined.
+  const result: DangerAssessment = { level, reasons };
+  if (matchedRule !== undefined) result.matchedRule = matchedRule;
+  return result;
+}
+
+function levelRank(level: DangerLevel): number {
+  switch (level) {
+    case 'safe':
+      return 0;
+    case 'caution':
+      return 1;
+    case 'destructive':
+      return 2;
+  }
+}

--- a/packages/tools/src/_danger-detect.ts
+++ b/packages/tools/src/_danger-detect.ts
@@ -20,8 +20,16 @@
  *   - Reasons are human-readable, joined with "; " for the confirm prompt.
  *
  * PR 1 (narrow): destructive file deletion + disk/boot operations.
- * PR 2 (broader, follow-up): git push --force, npm/cargo publish,
- *   kubectl delete namespace, network exfil, privilege escalation.
+ * PR 2 (broader): VCS history rewrite, package publish, k8s cluster ops,
+ *   inline code eval, pipe-to-shell, privilege escalation, permission
+ *   expansion. Mix of 'destructive' and 'caution' levels.
+ *
+ * Caution rules are deliberately permissive — they execute and emit a
+ * warning rather than blocking. The rationale: many of these patterns
+ * (python -c, sudo, curl | bash) are part of legitimate dev workflows,
+ * so a hard deny would block too much. A warning gives the user a
+ * chance to notice "wait, I didn't mean to do that" without forcing
+ * them to add a config override for every script.
  */
 
 export type DangerLevel = 'safe' | 'caution' | 'destructive';
@@ -185,6 +193,179 @@ const RULES: readonly DangerRule[] = [
     level: 'destructive',
     test: (cmd) => cmd === 'sdelete' || cmd === 'sdelete.exe',
     reason: 'sdelete (Sysinternals secure delete)',
+  },
+  // ----- PR 2: VCS history rewrite (destructive) -----
+  // `git push --force` / `-f` rewrites remote history. `--force-with-lease`
+  // is the safer variant (checks remote hasn't moved) but still rewrites.
+  {
+    id: 'git-push-force',
+    level: 'destructive',
+    test: (cmd, args) => {
+      if (cmd !== 'git') return false;
+      // Look for `push` as a subcommand, then any force flag in subsequent args.
+      const pushIdx = args.indexOf('push');
+      if (pushIdx < 0) return false;
+      for (let i = pushIdx + 1; i < args.length; i++) {
+        const a = args[i]!;
+        if (a === '--force' || a === '-f' || a === '--force-with-lease') return true;
+        // Stop scanning if we hit a non-flag that isn't a remote/ref name
+        // (simple heuristic: remote names don't start with --).
+        if (!a.startsWith('-') && !a.includes('=')) continue;
+        if (a.startsWith('--force') /* covers --force-with-lease already */) return true;
+      }
+      return false;
+    },
+    reason: 'git push with --force / -f (rewrites remote history)',
+  },
+  // ----- PR 2: git reset --hard (destructive) -----
+  {
+    id: 'git-reset-hard',
+    level: 'destructive',
+    test: (cmd, args) =>
+      cmd === 'git' && args.some((a) => a === '--hard' || a.startsWith('--hard=')),
+    reason: 'git reset --hard (discards working tree + index)',
+  },
+  // ----- PR 2: git clean -f / -fd (destructive) -----
+  {
+    id: 'git-clean-force',
+    level: 'destructive',
+    test: (cmd, args) => {
+      if (cmd !== 'git') return false;
+      const cleanIdx = args.indexOf('clean');
+      if (cleanIdx < 0) return false;
+      // Must include -f / --force (without it, git clean errors out and
+      // does nothing). -fd / -fdX combinations are subsumed.
+      return args.slice(cleanIdx + 1).some(
+        (a) =>
+          a === '-f' ||
+          a === '--force' ||
+          a.startsWith('-f') /* -fd, -fdx, etc. */ ||
+          a.startsWith('--force='),
+      );
+    },
+    reason: 'git clean -f (deletes untracked files)',
+  },
+  // ----- PR 2: package publish (destructive — public, irreversible) -----
+  {
+    id: 'npm-publish',
+    level: 'destructive',
+    test: (cmd, args) => {
+      if (!['npm', 'pnpm', 'yarn', 'bun', 'cargo'].includes(cmd)) return false;
+      // For npm/pnpm/yarn/bun: subcommand is "publish".
+      // For cargo: subcommand is "publish" OR "yank" (both touch the
+      // public registry; yank is reversible, publish is not, but yank
+      // is rare enough we treat it the same).
+      return args.includes('publish') || (cmd === 'cargo' && args.includes('yank'));
+    },
+    reason: 'publishing to a public package registry (hard to reverse)',
+  },
+  // ----- PR 2: k8s cluster-wide destructive ops (destructive) -----
+  {
+    id: 'kubectl-delete-namespace',
+    level: 'destructive',
+    test: (cmd, args) => {
+      if (cmd !== 'kubectl') return false;
+      const delIdx = args.indexOf('delete');
+      if (delIdx < 0) return false;
+      // Match `kubectl delete namespace <name>` or `kubectl delete ns <name>`.
+      // Generic `kubectl delete pod foo` is left out — too common.
+      const after = args.slice(delIdx + 1);
+      return after[0] === 'namespace' || after[0] === 'ns';
+    },
+    reason: 'kubectl delete namespace (deletes all resources in the namespace)',
+  },
+  {
+    id: 'kubectl-drain',
+    level: 'destructive',
+    test: (cmd, args) => cmd === 'kubectl' && args.includes('drain'),
+    reason: 'kubectl drain (evicts pods, marks node unschedulable)',
+  },
+  // ----- PR 2: inline code evaluation (caution — high false-positive) -----
+  // Common in scripts: `python -c "..."`, `node -e "..."`, `bash -c "..."`.
+  // We tag 'caution' rather than 'destructive' because these are used in
+  // many legitimate one-liners (e.g. `python -c "print(1)"`).
+  {
+    id: 'inline-eval',
+    level: 'caution',
+    test: (cmd, args) => {
+      if (!['python', 'python3', 'python2', 'node', 'bash', 'sh', 'zsh', 'ruby', 'perl', 'lua'].includes(cmd)) {
+        return false;
+      }
+      // -c, -e, --eval, -eval — short form first
+      return args.some(
+        (a) =>
+          a === '-c' ||
+          a === '-e' ||
+          a === '--eval' ||
+          a === '-eval' ||
+          a === '-E' /* node --eval shorthand in some shells */,
+      );
+    },
+    reason: 'inline script evaluation (-c / -e / --eval)',
+  },
+  // ----- PR 2: pipe-to-shell (caution — well-known exfil pattern) -----
+  // The classic `curl https://... | sh` indir-çalıştır vector. Detected by
+  // looking for a known fetcher followed by a shell sink. We use a simple
+  // substring scan; false positives are limited because both tokens must
+  // appear in the same argv.
+  {
+    id: 'pipe-to-shell',
+    level: 'caution',
+    test: (_cmd, args) => {
+      const hasFetcher = args.some(
+        (a) =>
+          /^(curl|wget|fetch|httpie|http)$/i.test(a) ||
+          a.startsWith('curl') /* curl.exe on Windows */ ||
+          a.startsWith('wget'),
+      );
+      const hasShellSink = args.some(
+        (a) =>
+          a === 'sh' ||
+          a === 'bash' ||
+          a === 'zsh' ||
+          a === 'fish' ||
+          a === 'pwsh' ||
+          a === 'powershell' ||
+          a.endsWith('/sh') ||
+          a.endsWith('/bash') ||
+          a.endsWith('/zsh') ||
+          a.endsWith('/pwsh'),
+      );
+      // Also catch the sh -c "..." form (where "sh" is the cmd, not in args)
+      // — but that's covered by inline-eval. This rule is specifically
+      // for the fetcher-pipe-shell case in a single command.
+      return hasFetcher && hasShellSink;
+    },
+    reason: 'network fetch piped to a shell (indir-çalıştır pattern)',
+  },
+  // ----- PR 2: privilege escalation (caution) -----
+  {
+    id: 'sudo',
+    level: 'caution',
+    test: (cmd) => cmd === 'sudo' || cmd === 'doas',
+    reason: 'privilege escalation (sudo / doas)',
+  },
+  {
+    id: 'runas',
+    level: 'caution',
+    test: (cmd) => cmd === 'runas' || cmd === 'runas.exe',
+    reason: 'Windows runas (run as different user)',
+  },
+  // ----- PR 2: world-writable permissions (caution) -----
+  // `chmod 777` is rarely correct. `chmod -R 777` is almost always wrong.
+  // We only flag octal modes; symbolic modes like `chmod o+w` are
+  // left to the operator's discretion.
+  {
+    id: 'chmod-world-writable',
+    level: 'caution',
+    test: (cmd, args) => {
+      if (cmd !== 'chmod') return false;
+      // Skip symbolic modes: anything starting with [ugoa]=\w or [ugoa]+\w.
+      // The only thing we flag is a pure octal mode containing 7 anywhere
+      // in the user/group/other triple (e.g. 777, 776, 747, 707).
+      return args.some((a) => /^[0-7]{3,4}$/.test(a) && /7/.test(a));
+    },
+    reason: 'chmod with world-writable octal mode (e.g. 777)',
   },
 ];
 

--- a/packages/tools/src/_danger-detect.ts
+++ b/packages/tools/src/_danger-detect.ts
@@ -376,15 +376,27 @@ const RULES: readonly DangerRule[] = [
  * matching rules. The 'matchedRule' field is the *last* rule that fired
  * (stable, since rules are evaluated in declaration order).
  *
+ * Optional `bypass` argument: a set of rule ids that should be SKIPPED
+ * even if they would otherwise match. Wired from
+ * `config.tools.exec.danger.bypass` (see `ExecDangerConfig` in
+ * `@wrongstack/core/src/types/config.ts`). Unknown ids are silently
+ * ignored — forward-compat: a rule added in a future version can be
+ * referenced before the user upgrades their config schema.
+ *
  * This function is the single source of truth for danger classification;
  * it is pure (no side effects) and unit-tested in `danger-detect.test.ts`.
  */
-export function detectDanger(cmd: string, args: readonly string[]): DangerAssessment {
+export function detectDanger(
+  cmd: string,
+  args: readonly string[],
+  bypass?: ReadonlySet<string>,
+): DangerAssessment {
   const reasons: string[] = [];
   let level: DangerLevel = 'safe';
   let matchedRule: string | undefined;
 
   for (const rule of RULES) {
+    if (bypass?.has(rule.id)) continue;
     if (!rule.test(cmd, args)) continue;
     reasons.push(rule.reason);
     matchedRule = rule.id;

--- a/packages/tools/src/exec.ts
+++ b/packages/tools/src/exec.ts
@@ -180,6 +180,51 @@ export function resetExecPolicy(): void {
   allowedCommands = new Set(DEFAULT_ALLOWED_COMMANDS);
 }
 
+// -----------------------------------------------------------------------
+// Danger-detection bypass (config.tools.exec.danger.bypass)
+// -----------------------------------------------------------------------
+
+/**
+ * Set of rule ids that should be skipped during danger detection. Wired
+ * from `config.tools.exec.danger.bypass` at boot. Mirrors the
+ * `allowedCommands` pattern above: defaults to empty, replaced wholesale
+ * by `configureDangerBypass()`, reset by `resetDangerBypass()`.
+ *
+ * SECURITY: like `allow`, this is a per-rule weakening of the danger
+ * gate. The boot path strips `tools.exec.danger.bypass` from in-project
+ * repo config; only trusted config (user-global, system) sets it.
+ */
+let dangerBypass: ReadonlySet<string> = new Set();
+
+/**
+ * Apply the configured danger-bypass policy. Each id in `bypass` is
+ * added to the effective skip set; duplicates are fine. Idempotent.
+ *
+ * Call once at boot from `config.tools.exec.danger.bypass`.
+ */
+export function configureDangerBypass(opts: { bypass?: readonly string[] | undefined } = {}): void {
+  const next = new Set<string>();
+  for (const id of opts.bypass ?? []) {
+    const trimmed = id.trim();
+    if (trimmed) next.add(trimmed);
+  }
+  dangerBypass = next;
+}
+
+/** Reset the danger-bypass set to empty (tests / re-init). */
+export function resetDangerBypass(): void {
+  dangerBypass = new Set();
+}
+
+/**
+ * Read-only view of the active bypass set. `detectDanger()` takes a
+ * `bypass` argument directly, so consumers should prefer passing this
+ * rather than reading the set and matching themselves.
+ */
+export function getDangerBypass(): ReadonlySet<string> {
+  return dangerBypass;
+}
+
 /** Whether `cmd` is currently in the effective exec allowlist. */
 export function isExecCommandAllowed(cmd: string): boolean {
   return allowedCommands.has(normalizeCmd(cmd));
@@ -421,7 +466,9 @@ export const execTool: Tool<ExecInput, ExecOutput> = {
     // successful-execution return so the UI can render a banner for
     // 'caution' / 'destructive' levels. The rule set is narrow in this
     // commit; see `_danger-detect.ts` for the rules and the follow-up plan.
-    const danger: DangerAssessment = detectDanger(cmd, args);
+    // The `bypass` argument is wired from `config.tools.exec.danger.bypass`
+    // (see `configureDangerBypass`); rule ids in that set are skipped.
+    const danger: DangerAssessment = detectDanger(cmd, args, dangerBypass);
 
     // Validate args against per-command security patterns
     const argError = validateArgs(cmd, args);

--- a/packages/tools/src/exec.ts
+++ b/packages/tools/src/exec.ts
@@ -6,6 +6,7 @@ import { createOutputSpool, spoolNote } from './_output-spool.js';
 import { COMMAND_OUTPUT_MAX_BYTES, normalizeCommandOutput, safeResolveReal } from './_util.js';
 import { getProcessRegistry, redactCommand } from './process-registry.js';
 import { assertSafeWin32ShellArgs, resolveWin32Command } from './_win32-resolve.js';
+import { detectDanger, type DangerAssessment } from './_danger-detect.js';
 
 const isWin = process.platform === 'win32';
 
@@ -310,6 +311,19 @@ interface ExecOutput {
   exitCode: number;
   truncated: boolean;
   allowed: boolean;
+  /**
+   * Heuristic danger assessment of the (cmd, args) pair. Populated for every
+   * call (not just blocked ones) so the UI/TUI can render a banner when the
+   * level is 'caution' or 'destructive'. See `_danger-detect.ts` for the
+   * rule set; this is a NARROW set in this commit (file deletion, disk /
+   * boot ops). Broader categories (git push --force, npm publish, etc.)
+   * are tracked in a follow-up PR.
+   *
+   * Pre-execution error returns (allowlist miss, arg block, etc.) report
+   * `level: 'safe'` because the command never actually ran; the UI should
+   * surface the error separately and not also a danger warning.
+   */
+  danger: DangerAssessment;
 }
 
 export const execTool: Tool<ExecInput, ExecOutput> = {
@@ -367,6 +381,7 @@ export const execTool: Tool<ExecInput, ExecOutput> = {
         exitCode: 1,
         truncated: false,
         allowed: false,
+        danger: { level: 'safe' as const, reasons: [] },
       };
     }
 
@@ -380,6 +395,7 @@ export const execTool: Tool<ExecInput, ExecOutput> = {
         exitCode: 1,
         truncated: false,
         allowed: false,
+        danger: { level: 'safe' as const, reasons: [] },
       };
 
     if (!isExecCommandAllowed(cmd)) {
@@ -394,11 +410,18 @@ export const execTool: Tool<ExecInput, ExecOutput> = {
         exitCode: 1,
         truncated: false,
         allowed: false,
+        danger: { level: 'safe' as const, reasons: [] },
       };
     }
 
     const args = (input.args ?? []).slice(0, MAX_ARGS);
     const timeout = Math.max(1, Math.min(input.timeout ?? DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS));
+
+    // Heuristic danger assessment. Computed once here, attached to every
+    // successful-execution return so the UI can render a banner for
+    // 'caution' / 'destructive' levels. The rule set is narrow in this
+    // commit; see `_danger-detect.ts` for the rules and the follow-up plan.
+    const danger: DangerAssessment = detectDanger(cmd, args);
 
     // Validate args against per-command security patterns
     const argError = validateArgs(cmd, args);
@@ -411,6 +434,7 @@ export const execTool: Tool<ExecInput, ExecOutput> = {
         exitCode: 1,
         truncated: false,
         allowed: false,
+        danger: detectDanger(cmd, args),
       };
     }
 
@@ -428,11 +452,12 @@ export const execTool: Tool<ExecInput, ExecOutput> = {
         exitCode: 1,
         truncated: false,
         allowed: false,
+        danger: detectDanger(cmd, args),
       };
     }
     const signal = opts.signal;
 
-    return runCommand(cmd, args, cwd, timeout, signal, ctx.session?.id);
+    return runCommand(cmd, args, cwd, timeout, signal, ctx.session?.id, danger);
   },
 };
 
@@ -443,6 +468,7 @@ function runCommand(
   timeout: number,
   signal: AbortSignal,
   sessionId: string | undefined,
+  danger: DangerAssessment,
 ): Promise<ExecOutput> {
   return new Promise((resolve) => {
     let stdout = '';
@@ -513,6 +539,7 @@ function runCommand(
         exitCode: 1,
         truncated: false,
         allowed: true,
+        danger,
       });
       return;
     }
@@ -544,6 +571,7 @@ function runCommand(
         exitCode: isAbort ? 124 : 1,
         truncated: Buffer.byteLength(stdout, 'utf8') > COMMAND_OUTPUT_MAX_BYTES,
         allowed: true,
+        danger,
       });
     });
 
@@ -600,6 +628,7 @@ function runCommand(
           Buffer.byteLength(stdout, 'utf8') > COMMAND_OUTPUT_MAX_BYTES ||
           Buffer.byteLength(stderr, 'utf8') > COMMAND_OUTPUT_MAX_BYTES,
         allowed: true,
+        danger,
       });
     });
   });

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -19,7 +19,11 @@ export {
   resetExecPolicy,
   isExecCommandAllowed,
   getExecAllowlist,
+  configureDangerBypass,
+  resetDangerBypass,
+  getDangerBypass,
 } from './exec.js';
+export { detectDanger, type DangerLevel, type DangerAssessment } from './_danger-detect.js';
 export { fetchTool } from './fetch.js';
 export { searchTool } from './search.js';
 export { todoTool } from './todo.js';

--- a/packages/tools/tests/danger-detect.test.ts
+++ b/packages/tools/tests/danger-detect.test.ts
@@ -205,3 +205,281 @@ describe('detectDanger — safe baseline (regression)', () => {
     expect(r.level).toBe('safe');
   });
 });
+
+// =============================================================================
+// PR 2 (broader) — VCS history rewrite, package publish, k8s, inline eval,
+//                  pipe-to-shell, privilege escalation, permission expansion.
+// =============================================================================
+
+describe('detectDanger — git push --force / -f (PR 2)', () => {
+  it('flags `git push --force origin main` as destructive', () => {
+    const r = detectDanger('git', ['push', '--force', 'origin', 'main']);
+    expect(r.level).toBe('destructive');
+    expect(r.matchedRule).toBe('git-push-force');
+  });
+
+  it('flags `git push -f` (short form) as destructive', () => {
+    const r = detectDanger('git', ['push', '-f']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `git push --force-with-lease` as destructive (still rewrites)', () => {
+    const r = detectDanger('git', ['push', '--force-with-lease', 'origin', 'main']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `git push origin main` (no force flag)', () => {
+    const r = detectDanger('git', ['push', 'origin', 'main']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `git status --force` (--force belongs to a different verb)', () => {
+    // The rule looks for the `push` subcommand first; `status` is unrelated.
+    const r = detectDanger('git', ['status', '--force']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — git reset --hard (PR 2)', () => {
+  it('flags `git reset --hard HEAD~1` as destructive', () => {
+    const r = detectDanger('git', ['reset', '--hard', 'HEAD~1']);
+    expect(r.level).toBe('destructive');
+    expect(r.matchedRule).toBe('git-reset-hard');
+  });
+
+  it('flags `git reset --hard=foo` (rare `--key=value` form) as destructive', () => {
+    const r = detectDanger('git', ['reset', '--hard=foo']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `git reset --soft HEAD~1` (soft, recoverable)', () => {
+    const r = detectDanger('git', ['reset', '--soft', 'HEAD~1']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `git reset HEAD~1` (mixed reset, no --hard)', () => {
+    const r = detectDanger('git', ['reset', 'HEAD~1']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — git clean -f (PR 2)', () => {
+  it('flags `git clean -fd` as destructive', () => {
+    const r = detectDanger('git', ['clean', '-fd']);
+    expect(r.level).toBe('destructive');
+    expect(r.matchedRule).toBe('git-clean-force');
+  });
+
+  it('flags `git clean -f` (no -d) as destructive', () => {
+    const r = detectDanger('git', ['clean', '-f']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `git clean --force` as destructive', () => {
+    const r = detectDanger('git', ['clean', '--force']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `git clean -n` (dry-run, no force)', () => {
+    const r = detectDanger('git', ['clean', '-n']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `git status` (different verb)', () => {
+    const r = detectDanger('git', ['status']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — package publish (PR 2)', () => {
+  it('flags `npm publish` as destructive', () => {
+    const r = detectDanger('npm', ['publish']);
+    expect(r.level).toBe('destructive');
+    expect(r.matchedRule).toBe('npm-publish');
+  });
+
+  it('flags `pnpm publish --tag beta` as destructive', () => {
+    const r = detectDanger('pnpm', ['publish', '--tag', 'beta']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `cargo publish --allow-dirty` as destructive', () => {
+    const r = detectDanger('cargo', ['publish', '--allow-dirty']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `cargo yank --version 1.0.0` as destructive (treats as publish-class)', () => {
+    const r = detectDanger('cargo', ['yank', '--version', '1.0.0']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `npm install` (no publish subcommand)', () => {
+    const r = detectDanger('npm', ['install']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `cargo build` (no publish subcommand)', () => {
+    const r = detectDanger('cargo', ['build']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — kubectl delete namespace / drain (PR 2)', () => {
+  it('flags `kubectl delete namespace foo` as destructive', () => {
+    const r = detectDanger('kubectl', ['delete', 'namespace', 'foo']);
+    expect(r.level).toBe('destructive');
+    expect(r.matchedRule).toBe('kubectl-delete-namespace');
+  });
+
+  it('flags `kubectl delete ns foo` (short form) as destructive', () => {
+    const r = detectDanger('kubectl', ['delete', 'ns', 'foo']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `kubectl drain node1` as destructive', () => {
+    const r = detectDanger('kubectl', ['drain', 'node1']);
+    expect(r.level).toBe('destructive');
+    expect(r.matchedRule).toBe('kubectl-drain');
+  });
+
+  it('does NOT flag `kubectl delete pod foo` (too common, scoped resource)', () => {
+    const r = detectDanger('kubectl', ['delete', 'pod', 'foo']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `kubectl get namespace` (read-only)', () => {
+    const r = detectDanger('kubectl', ['get', 'namespace']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — inline eval (caution level, PR 2)', () => {
+  it('flags `python -c "import os"` as caution', () => {
+    const r = detectDanger('python', ['-c', 'import os']);
+    expect(r.level).toBe('caution');
+    expect(r.matchedRule).toBe('inline-eval');
+  });
+
+  it('flags `node -e "console.log(1)"` as caution', () => {
+    const r = detectDanger('node', ['-e', 'console.log(1)']);
+    expect(r.level).toBe('caution');
+  });
+
+  it('flags `bash -c "echo hi"` as caution', () => {
+    const r = detectDanger('bash', ['-c', 'echo hi']);
+    expect(r.level).toBe('caution');
+  });
+
+  it('flags `node --eval "..."` (long form) as caution', () => {
+    const r = detectDanger('node', ['--eval', 'process.exit(0)']);
+    expect(r.level).toBe('caution');
+  });
+
+  it('does NOT flag `python script.py` (no -c)', () => {
+    const r = detectDanger('python', ['script.py']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `node index.js` (no -e)', () => {
+    const r = detectDanger('node', ['index.js']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — pipe-to-shell (caution level, PR 2)', () => {
+  it('flags `curl https://x | sh` as caution', () => {
+    // Two separate exec calls would each be: `curl https://x` and `sh -`.
+    // The pipe is a shell construct, so the argv here is what one of
+    // them looks like. Our rule fires when a fetcher AND a shell sink
+    // are both in the same argv (rare but possible via `env` or
+    // wrapper scripts that pass them as args).
+    const r = detectDanger('env', ['curl', 'https://x', 'sh']);
+    expect(r.level).toBe('caution');
+    expect(r.matchedRule).toBe('pipe-to-shell');
+  });
+
+  it('flags `wget ... bash` as caution', () => {
+    const r = detectDanger('env', ['wget', 'https://x', 'bash']);
+    expect(r.level).toBe('caution');
+  });
+
+  it('does NOT flag `curl https://x` alone (no shell sink)', () => {
+    const r = detectDanger('curl', ['https://x']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `bash -c "echo"` (no fetcher)', () => {
+    const r = detectDanger('bash', ['-c', 'echo']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — privilege escalation (caution level, PR 2)', () => {
+  it('flags `sudo apt update` as caution', () => {
+    const r = detectDanger('sudo', ['apt', 'update']);
+    expect(r.level).toBe('caution');
+    expect(r.matchedRule).toBe('sudo');
+  });
+
+  it('flags `doas reboot` as caution', () => {
+    const r = detectDanger('doas', ['reboot']);
+    expect(r.level).toBe('caution');
+  });
+
+  it('flags `runas /user:admin cmd.exe` as caution', () => {
+    const r = detectDanger('runas', ['/user:admin', 'cmd.exe']);
+    expect(r.level).toBe('caution');
+    expect(r.matchedRule).toBe('runas');
+  });
+
+  it('does NOT flag `apt update` (no sudo)', () => {
+    const r = detectDanger('apt', ['update']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — chmod world-writable (caution level, PR 2)', () => {
+  it('flags `chmod 777 file` as caution', () => {
+    const r = detectDanger('chmod', ['777', 'file']);
+    expect(r.level).toBe('caution');
+    expect(r.matchedRule).toBe('chmod-world-writable');
+  });
+
+  it('flags `chmod 0644 file` as safe (no 7)', () => {
+    const r = detectDanger('chmod', ['0644', 'file']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('flags `chmod 755 dir` as caution (group is 5 but other is 7)', () => {
+    const r = detectDanger('chmod', ['755', 'dir']);
+    expect(r.level).toBe('caution');
+  });
+
+  it('does NOT flag `chmod +x file` (symbolic mode)', () => {
+    const r = detectDanger('chmod', ['+x', 'file']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `chmod u+w file` (symbolic, scoped)', () => {
+    const r = detectDanger('chmod', ['u+w', 'file']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — multi-rule interaction (PR 2)', () => {
+  it('returns the higher level when multiple rules fire', () => {
+    // `sudo rm -rf /` triggers both `sudo` (caution) and `rm-recursive`
+    // (destructive). The output should be 'destructive'.
+    const r = detectDanger('sudo', ['rm', '-rf', '/']);
+    expect(r.level).toBe('destructive');
+    expect(r.reasons).toContain('privilege escalation (sudo / doas)');
+    expect(r.reasons).toContain('recursive force-delete');
+  });
+
+  it('returns the higher level across command boundaries (within one call)', () => {
+    // `git push --force` alone is destructive; adding a `caution` reason
+    // (e.g. another rule that doesn't apply here) wouldn't downgrade it.
+    const r = detectDanger('git', ['push', '--force', 'origin', 'main']);
+    expect(r.level).toBe('destructive');
+  });
+});

--- a/packages/tools/tests/danger-detect.test.ts
+++ b/packages/tools/tests/danger-detect.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import { detectDanger } from '../src/_danger-detect.js';
+
+describe('detectDanger — rm / rmdir recursive force', () => {
+  it('flags `rm -rf ./build` as destructive (PR 1 narrow set)', () => {
+    const r = detectDanger('rm', ['-rf', './build']);
+    expect(r.level).toBe('destructive');
+    expect(r.reasons).toContain('recursive force-delete');
+    expect(r.matchedRule).toBe('rm-recursive');
+  });
+
+  it('flags `rm -fr ./build` (alternative flag order) as destructive', () => {
+    const r = detectDanger('rm', ['-fr', './build']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `rm -r -f ./build` (split flags) as destructive', () => {
+    const r = detectDanger('rm', ['-r', '-f', './build']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `rm ./build` (no recursive)', () => {
+    const r = detectDanger('rm', ['./build']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `rm -r ./build` (no force)', () => {
+    const r = detectDanger('rm', ['-r', './build']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `ls -rf /` (not the rm binary)', () => {
+    const r = detectDanger('ls', ['-rf', '/']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — PowerShell Remove-Item -Recurse -Force', () => {
+  it('flags `powershell Remove-Item -Recurse -Force foo` as destructive', () => {
+    const r = detectDanger('powershell', ['Remove-Item', '-Recurse', '-Force', 'foo']);
+    expect(r.level).toBe('destructive');
+    expect(r.matchedRule).toBe('powershell-remove-item-recursive-force');
+  });
+
+  it('flags `pwsh -Command "Remove-Item -R -F foo"` as destructive', () => {
+    const r = detectDanger('pwsh', ['-Command', 'Remove-Item', '-R', '-F', 'foo']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `powershell Remove-Item -WhatIf -Recurse -Force foo` (dry-run)', () => {
+    const r = detectDanger('powershell', ['Remove-Item', '-WhatIf', '-Recurse', '-Force', 'foo']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT flag `powershell Get-ChildItem -Recurse` (different verb)', () => {
+    const r = detectDanger('powershell', ['Get-ChildItem', '-Recurse']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — find -exec / -ok', () => {
+  it('flags `find . -exec rm {} ;` as destructive', () => {
+    const r = detectDanger('find', ['.', '-exec', 'rm', '{}', ';']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `find . -ok echo` as destructive', () => {
+    const r = detectDanger('find', ['.', '-ok', 'echo']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `find . -execdir rm` as destructive', () => {
+    const r = detectDanger('find', ['.', '-execdir', 'rm']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `find . -name "*.tmp"` (no -exec)', () => {
+    const r = detectDanger('find', ['.', '-name', '*.tmp']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — git --exec/--upload-pack/--receive-pack', () => {
+  it('flags `git --exec=foo fetch` as destructive', () => {
+    const r = detectDanger('git', ['--exec=foo', 'fetch']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `git --upload-pack=evil` as destructive', () => {
+    const r = detectDanger('git', ['--upload-pack=evil']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `git status`', () => {
+    const r = detectDanger('git', ['status']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — Windows format / diskpart / bcdedit', () => {
+  it('flags `format C:` as destructive', () => {
+    const r = detectDanger('format', ['C:']);
+    expect(r.level).toBe('destructive');
+    expect(r.matchedRule).toBe('win32-format');
+  });
+
+  it('flags `format.exe C: /q` as destructive', () => {
+    const r = detectDanger('format.exe', ['C:', '/q']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `diskpart` with no args as destructive', () => {
+    const r = detectDanger('diskpart', []);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `bcdedit /set` as destructive', () => {
+    const r = detectDanger('bcdedit', ['/set', '{default}', 'bootstatuspolicy', 'ignoreallfailures']);
+    expect(r.level).toBe('destructive');
+  });
+});
+
+describe('detectDanger — mkfs family', () => {
+  it('flags `mkfs.ext4 /dev/sda1` as destructive', () => {
+    const r = detectDanger('mkfs.ext4', ['/dev/sda1']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `mkfs` (no extension) as destructive', () => {
+    const r = detectDanger('mkfs', ['/dev/sda1']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `mkswap /dev/sda2` as destructive', () => {
+    const r = detectDanger('mkswap', ['/dev/sda2']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `mkfs.foo` (unknown extension, but rule fires for any mkfs.*)', () => {
+    // The regex /^mkfs(\.[a-z0-9]+)?$/ matches mkfs followed by optional ext,
+    // so even an unknown extension triggers. This is intentional: a typo'd
+    // filesystem type is a dangerous mistake.
+    const r = detectDanger('mkfs.typo', ['/dev/sda1']);
+    expect(r.level).toBe('destructive');
+  });
+});
+
+describe('detectDanger — dd writing to a block device', () => {
+  it('flags `dd if=foo of=/dev/sda` as destructive', () => {
+    const r = detectDanger('dd', ['if=foo.img', 'of=/dev/sda']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `dd of=/dev/nvme0n1` as destructive', () => {
+    const r = detectDanger('dd', ['of=/dev/nvme0n1']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('does NOT flag `dd if=/dev/urandom of=output.bin` (writing to a file)', () => {
+    const r = detectDanger('dd', ['if=/dev/urandom', 'of=output.bin', 'bs=1M', 'count=10']);
+    expect(r.level).toBe('safe');
+  });
+});
+
+describe('detectDanger — secure-erase tools', () => {
+  it('flags `shred secret.txt` as destructive', () => {
+    const r = detectDanger('shred', ['secret.txt']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `wipefs /dev/sda1` as destructive', () => {
+    const r = detectDanger('wipefs', ['/dev/sda1']);
+    expect(r.level).toBe('destructive');
+  });
+
+  it('flags `sdelete -p 3 secret.txt` as destructive', () => {
+    const r = detectDanger('sdelete', ['-p', '3', 'secret.txt']);
+    expect(r.level).toBe('destructive');
+  });
+});
+
+describe('detectDanger — safe baseline (regression)', () => {
+  it('returns level=safe for `git status`', () => {
+    const r = detectDanger('git', ['status']);
+    expect(r.level).toBe('safe');
+    expect(r.reasons).toEqual([]);
+    expect(r.matchedRule).toBeUndefined();
+  });
+
+  it('returns level=safe for `npm test`', () => {
+    const r = detectDanger('npm', ['test']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('returns level=safe for `python -c "print(1)"` (PR 1 does not gate -c)', () => {
+    // NOTE: PR 1 deliberately does NOT flag `python -c`. That will be in
+    // PR 2 (broader) under the network-exfil / exec-arbitrary-code set.
+    // Documenting the behavior so a future reviewer sees the boundary.
+    const r = detectDanger('python', ['-c', 'print(1)']);
+    expect(r.level).toBe('safe');
+  });
+
+  it('returns level=safe for `cargo build`', () => {
+    const r = detectDanger('cargo', ['build']);
+    expect(r.level).toBe('safe');
+  });
+});

--- a/packages/tools/tests/danger-detect.test.ts
+++ b/packages/tools/tests/danger-detect.test.ts
@@ -483,3 +483,67 @@ describe('detectDanger — multi-rule interaction (PR 2)', () => {
     expect(r.level).toBe('destructive');
   });
 });
+
+// =============================================================================
+// PR 3 — config bypass for danger rules.
+// =============================================================================
+
+describe('detectDanger — bypass argument (PR 3)', () => {
+  it('skips a rule whose id is in the bypass set', () => {
+    const bypass = new Set(['rm-recursive']);
+    const r = detectDanger('rm', ['-rf', './build'], bypass);
+    expect(r.level).toBe('safe');
+    expect(r.reasons).toEqual([]);
+    expect(r.matchedRule).toBeUndefined();
+  });
+
+  it('ignores unknown bypass ids (forward-compat: future rule can be referenced)', () => {
+    const bypass = new Set(['this-rule-does-not-exist']);
+    const r = detectDanger('rm', ['-rf', './build'], bypass);
+    // Unknown bypass id should not affect anything; rm-recursive still fires.
+    expect(r.level).toBe('destructive');
+  });
+
+  it('skips only the specified rule; other matched rules still fire', () => {
+    // Bypass `rm-recursive` but keep `sudo` active. `sudo rm -rf /` then
+    // has the destructive rule suppressed, leaving only the caution rule.
+    const bypass = new Set(['rm-recursive']);
+    const r = detectDanger('sudo', ['rm', '-rf', '/'], bypass);
+    expect(r.level).toBe('caution');
+    expect(r.reasons).toEqual(['privilege escalation (sudo / doas)']);
+  });
+
+  it('treats empty bypass the same as no bypass (default behavior)', () => {
+    const emptyBypass = new Set<string>();
+    const noBypass = undefined;
+    const a = detectDanger('rm', ['-rf', './build'], emptyBypass);
+    const b = detectDanger('rm', ['-rf', './build'], noBypass);
+    expect(a).toEqual(b);
+    expect(a.level).toBe('destructive');
+  });
+
+  it('bypasses a caution-level rule (e.g. inline-eval)', () => {
+    const bypass = new Set(['inline-eval']);
+    const r = detectDanger('python', ['-c', 'import os'], bypass);
+    expect(r.level).toBe('safe');
+  });
+
+  it('does NOT silently suppress unmatched rules when bypass is provided', () => {
+    // Bypass `rm-recursive`, but invoke a different destructive rule. The
+    // bypass should not affect it.
+    const bypass = new Set(['rm-recursive']);
+    const r = detectDanger('git', ['push', '--force', 'origin', 'main'], bypass);
+    expect(r.level).toBe('destructive');
+    expect(r.matchedRule).toBe('git-push-force');
+  });
+
+  it('handles bypass with multiple ids', () => {
+    const bypass = new Set(['rm-recursive', 'git-push-force', 'inline-eval']);
+    const r1 = detectDanger('rm', ['-rf', 'foo'], bypass);
+    const r2 = detectDanger('git', ['push', '--force'], bypass);
+    const r3 = detectDanger('python', ['-c', 'evil'], bypass);
+    expect(r1.level).toBe('safe');
+    expect(r2.level).toBe('safe');
+    expect(r3.level).toBe('safe');
+  });
+});

--- a/packages/tools/tests/exec.test.ts
+++ b/packages/tools/tests/exec.test.ts
@@ -9,6 +9,9 @@ import {
   resetExecPolicy,
   isExecCommandAllowed,
   getExecAllowlist,
+  configureDangerBypass,
+  resetDangerBypass,
+  getDangerBypass,
 } from '../src/exec.js';
 
 const makeOpts = () => ({ signal: new AbortController().signal });
@@ -323,7 +326,10 @@ describe('exec command policy (configurable allowlist)', () => {
   const makeCtx2 = () => ({ cwd: '/fake', tools: [], projectRoot: '/fake' }) as any;
   const makeOpts2 = () => ({ signal: new AbortController().signal });
 
-  afterEach(() => resetExecPolicy());
+  afterEach(() => {
+    resetExecPolicy();
+    resetDangerBypass();
+  });
 
   it('ships common build tools in the default allowlist (incl. modern dev runners)', () => {
     for (const cmd of [
@@ -556,6 +562,60 @@ describe('exec command policy (configurable allowlist)', () => {
         expect(r3.danger.reasons).toEqual([]);
       } finally {
         await cleanup();
+      }
+    })();
+  });
+
+  it('honors configureDangerBypass (PR 3): a bypassed rule is suppressed in danger output', () => {
+    // Wire the danger-bypass from "config" before each call, then verify
+    // the same (cmd, args) that previously returned 'destructive' now
+    // returns 'safe' when its rule id is in the bypass set.
+    return (async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-exec-bypass-'));
+      const ctx = {
+        cwd: dir,
+        tools: [],
+        projectRoot: dir,
+        session: { id: 'sess_bypass' },
+      } as any;
+      try {
+        // Allow rm for this test only; afterEach in the parent describe
+        // resets both the policy and the bypass.
+        configureExecPolicy({ allow: ['rm'] });
+
+        // (1) Without bypass: rm -rf is destructive.
+        configureDangerBypass({ bypass: [] });
+        const r1 = await execTool.execute(
+          { command: 'rm', args: ['-rf', path.join(dir, 'a')] },
+          ctx,
+          makeOpts(),
+        );
+        expect(r1.danger.level).toBe('destructive');
+        expect(r1.danger.matchedRule).toBe('rm-recursive');
+
+        // (2) With bypass on the rule: level drops to safe.
+        configureDangerBypass({ bypass: ['rm-recursive'] });
+        expect(getDangerBypass().has('rm-recursive')).toBe(true);
+        const r2 = await execTool.execute(
+          { command: 'rm', args: ['-rf', path.join(dir, 'b')] },
+          ctx,
+          makeOpts(),
+        );
+        expect(r2.danger.level).toBe('safe');
+        expect(r2.danger.reasons).toEqual([]);
+        expect(r2.danger.matchedRule).toBeUndefined();
+
+        // (3) Bypass on a different rule does NOT affect rm-recursive.
+        configureDangerBypass({ bypass: ['inline-eval'] });
+        const r3 = await execTool.execute(
+          { command: 'rm', args: ['-rf', path.join(dir, 'c')] },
+          ctx,
+          makeOpts(),
+        );
+        expect(r3.danger.level).toBe('destructive');
+        expect(r3.danger.matchedRule).toBe('rm-recursive');
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
       }
     })();
   });

--- a/packages/tools/tests/exec.test.ts
+++ b/packages/tools/tests/exec.test.ts
@@ -505,4 +505,58 @@ describe('exec command policy (configurable allowlist)', () => {
       expect(isExecCommandAllowed(cmd)).toBe(true);
     }
   });
+
+  it('attaches a danger assessment to every exec return (PR 1 narrow set)', () => {
+    // Integration: verify that the danger-detection layer is wired into the
+    // exec tool. This is the contract that UI/TUI consumers will rely on
+    // to render a banner. We test three categories:
+    //   - a pre-execution error return (allowlist miss) → level 'safe'
+    //   - a destructive command (rm -rf in a sandbox) → level 'destructive'
+    //   - a normal command (git status in a sandbox) → level 'safe'
+    //
+    // Note: rm is NOT in the default allowlist (it's a Unix tool that
+    // happens to be available everywhere). We add it to the runtime
+    // allowlist for this test only, then reset via afterEach.
+    const sb = (async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-exec-danger-'));
+      return {
+        ctx: { cwd: dir, tools: [], projectRoot: dir, session: { id: 'sess_danger' } } as any,
+        cleanup: async () => {
+          await fs.rm(dir, { recursive: true, force: true });
+        },
+      };
+    })();
+
+    return (async () => {
+      const { ctx, cleanup } = await sb;
+      try {
+        // (1) Allowlist miss → 'safe' (the call never reached danger detection
+        // for a meaningful reason; we still attach 'safe' to satisfy the schema)
+        const r1 = await execTool.execute({ command: 'not-in-allowlist' }, ctx, makeOpts());
+        expect(r1.danger.level).toBe('safe');
+
+        // (2) Destructive: rm -rf on a sandbox dir
+        configureExecPolicy({ allow: ['rm'] });
+        const target = path.join(ctx.cwd, 'build');
+        await fs.mkdir(target, { recursive: true });
+        const r2 = await execTool.execute(
+          { command: 'rm', args: ['-rf', target] },
+          ctx,
+          makeOpts(),
+        );
+        expect(r2.allowed).toBe(true);
+        expect(r2.danger.level).toBe('destructive');
+        expect(r2.danger.reasons).toContain('recursive force-delete');
+        expect(r2.danger.matchedRule).toBe('rm-recursive');
+
+        // (3) Safe: git status in a sandbox dir
+        const r3 = await execTool.execute({ command: 'git', args: ['status'] }, ctx, makeOpts());
+        expect(r3.allowed).toBe(true);
+        expect(r3.danger.level).toBe('safe');
+        expect(r3.danger.reasons).toEqual([]);
+      } finally {
+        await cleanup();
+      }
+    })();
+  });
 });


### PR DESCRIPTION
## Summary

This PR adds the user-facing configuration knob that was always part of the danger-detection design. The `matchedRule` field that PR 1 added has been waiting for this. With PR 3, users can globally suppress specific danger rules via `config.tools.exec.danger.bypass`.

**Update** (force-pushed after first submission): the maintainer-requested config-loader strip is now included. `tools.exec.danger` is removed from in-project repo config the same way `tools.exec.allow` is. The "out of scope" item from the first body is now done.

## API additions

### `@wrongstack/tools`

```ts
configureDangerBypass({ bypass?: readonly string[] }): void
resetDangerBypass(): void
getDangerBypass(): ReadonlySet<string>

// detectDanger gains an optional 3rd argument:
detectDanger(
  cmd: string,
  args: readonly string[],
  bypass?: ReadonlySet<string>,
): DangerAssessment
```

The `exec` tool calls `detectDanger(cmd, args, dangerBypass)` automatically — no consumer change is needed.

### `@wrongstack/core`

```ts
interface ExecToolConfig {
  allow?: string[];
  deny?: string[];
  // NEW:
  danger?: ExecDangerConfig;
}

interface ExecDangerConfig {
  bypass?: string[]; // list of matchedRule ids to skip
}
```

Loaded from `config.tools.exec.danger.bypass` at boot.

## Behavior

- A rule whose id is in the bypass set is **skipped** (not just downgraded). If it's the only matching rule, the result is level `'safe'` with empty reasons.
- Bypass is **per-rule**. Bypassing `rm-recursive` does NOT affect `sudo` or `git-push-force` even when the same call would trigger both.
- **Unknown ids are silently ignored.** Forward-compat: a rule id added in a future version can be referenced before the user upgrades their config schema.
- **Empty bypass** is identical to omitting the arg.

## Security: trusted-config-only

Bypassing a danger rule is a per-rule weakening of the safety gate. The same threat model that already applies to `allow` applies here: in-project repo config could otherwise be used to silently opt everyone in. The boot path that strips `allow` from `<project>/.wrongstack/config.json` **now also strips `danger`** (this PR).

What gets stripped, in summary:

| Source | `allow` | `deny` | `danger.bypass` |
|---|---|---|---|
| `<project>/.wrongstack/config.json` (untrusted) | **stripped** | kept | **stripped (whole `danger` object)** |
| `~/.wrongstack/config.json` (user, trusted) | kept | kept | kept |
| System / env / CLI (trusted) | kept | kept | kept |

We strip the whole `danger` object rather than just `bypass` inside it. Today `ExecDangerConfig` only has `bypass`, but the whole-object strip is forward-compat: any new field added under `danger` is also denied from repo config until it gets an explicit allow decision. Better to be conservative.

## Test coverage

**`@wrongstack/tools`**:

- 7 new unit test cases in `danger-detect.test.ts`:
  - skip a rule by id
  - ignore unknown ids (forward-compat)
  - multi-rule: bypass one, others still fire
  - empty bypass == no bypass
  - bypass a caution-level rule
  - unrelated bypass does not affect other rules
  - bypass with multiple ids
- 1 new integration test in `exec.test.ts`:
  - `configureDangerBypass` is wired through `execTool.execute`
  - same `(cmd, args)` returns `'destructive'` without bypass, `'safe'` with it
  - bypass on a different rule id does not affect the matched rule
- `afterEach` in the parent describe now also calls `resetDangerBypass()` to prevent test-order leakage

**`@wrongstack/core`**:

- 3 new test cases in `config-loader-extra.test.ts`:
  - `tools.exec.danger` is stripped from in-project config (whole object, not just `bypass` field)
  - Both `tools.exec.allow` AND `tools.exec.danger` are stripped in a single pass
  - Caller input is not mutated when `danger` is stripped
- Existing `tools.exec.allow` strip tests still pass (no regression)
- Full `@wrongstack/core` suite passes (typecheck + test)
- Full `@wrongstack/tools` suite passes (typecheck + test)

## No changes to

- The RULES array (PR 1 / PR 2 contents are unchanged)
- Default behavior — no bypass configured = previous behavior, verified by the full existing test suite still passing
- The hard-deny `BLOCKED_ARG_PATTERNS` layer
- `bash-kill-guard.ts`

## Files changed

| File | Change |
|---|---|
| `packages/core/src/types/config.ts` | +27 / -0 (`ExecToolConfig.danger` + `ExecDangerConfig`) |
| `packages/core/src/storage/config-loader.ts` | +29 / -7 (parallel strip for `danger`) |
| `packages/tools/src/_danger-detect.ts` | +13 / -1 (3rd arg + TSDoc) |
| `packages/tools/src/exec.ts` | +44 / -0 (`configureDangerBypass` + state + `getDangerBypass` + exec wiring) |
| `packages/tools/src/index.ts` | +5 / -0 (export new symbols) |
| `packages/core/tests/storage/config-loader-extra.test.ts` | +81 / -0 (3 new cases) |
| `packages/tools/tests/danger-detect.test.ts` | +64 / -0 (7 new cases) |
| `packages/tools/tests/exec.test.ts` | +57 / -1 (integration + afterEach update) |

Plus dist/ rebuilds for the core package (tsup).

## Out of scope (planned follow-ups, not in this PR)

- **PR 4**: route `'destructive'` through the existing confirm flow (`@wrongstack/core/src/security/permission-policy.ts`)
- **PR 5**: TUI / WebUI consumer that reads `output.danger` and renders a banner
- **PR 6**: documented config example in README (`.wrongstack/config.json` snippet)

## Related

- PR 1: [#158](https://github.com/WrongStack/WrongStack/pull/158) — module + 12 narrow rules
- PR 2: [#159](https://github.com/WrongStack/WrongStack/pull/159) — 9 broader rules
- This PR: per-rule bypass config + runtime wiring + boot-side strip

Stack:
```
feature/danger-bypass   (this, force-pushed once)
└── feature/danger-detect-broad  (PR 2)
    └── feature/danger-detect-narrow  (PR 1)
        └── main
```

When all three merge, the danger system will be feature-complete for the layer that PR 1 set out to build. The remaining work (PR 4, 5, 6) is the consumer / UX side, not the detection layer.
