### PR TITLE
feat(tui): render exec danger level as a chip + reason list (PR 5)

### DIFF
--- a/packages/tui/src/components/history/utils.tsx
+++ b/packages/tui/src/components/history/utils.tsx
@@ -532,6 +532,73 @@ export function formatToolOutput(
     }
   }
 
+  // exec (heuristic danger detection, PR 1-3)
+  //
+  // The exec tool's output is JSON with a `danger: { level, reasons, matchedRule? }`
+  // field. We surface a level-based banner so destructive / caution calls
+  // are visually distinct from safe ones. The `level` is rendered as a
+  // compact chip-like prefix that the renderer's existing color theme can
+  // pick up downstream (no new color tokens here — keep visual surface
+  // minimal and let callers opt in to highlighting).
+  //
+  // Format:
+  //   destructive:  ⚠ DESTRUCTIVE  recursive force-delete
+  //                  exit 0 · 12 out · 0 err
+  //                  "build/"
+  //   caution:      ! CAUTION  inline script evaluation (-c / -e / --eval)
+  //                  exit 0 · 0 out · 0 err
+  //   safe:         (no banner — the existing bash-style line is enough)
+  //
+  // The chip is plain-text so this is portable across TUI/webui/CLI
+  // renderers; theme-tinting is up to the consumer.
+  if (toolName === 'exec') {
+    if (json && typeof json === 'object') {
+      const o = json as Record<string, unknown>;
+      const danger = o['danger'];
+      const level =
+        danger && typeof danger === 'object' ? (danger as Record<string, unknown>)['level'] : undefined;
+      const reasons =
+        danger && typeof danger === 'object'
+          ? ((danger as Record<string, unknown>)['reasons'] as unknown)
+          : undefined;
+      if (level === 'destructive' || level === 'caution') {
+        const exit = numOf(o['exit_code']) ?? numOf(o['exitCode']);
+        const stdout = stringOf(o['stdout']) ?? '';
+        const stderr = stringOf(o['stderr']) ?? '';
+        const stdoutLines = countLines(stdout);
+        const stderrLines = countLines(stderr);
+        const head: string[] = [];
+        const chip = level === 'destructive' ? '⚠ DESTRUCTIVE' : '! CAUTION';
+        const reasonText =
+          Array.isArray(reasons) && reasons.length > 0
+            ? String(reasons[0])
+            : level === 'destructive'
+              ? 'destructive command'
+              : 'caution-level command';
+        head.push(`${chip}  ${reasonText}`);
+        if (exit !== undefined) head.push(`exit ${exit}`);
+        const lineParts: string[] = [];
+        if (stdoutLines > 0) lineParts.push(`${stdoutLines} out`);
+        if (stderrLines > 0) lineParts.push(`${stderrLines} err`);
+        if (lineParts.length > 0) head.push(lineParts.join(' · '));
+        const lines: string[] = [head.join(' · ')];
+        // Surface additional reasons (beyond the first) as a stacked list
+        if (Array.isArray(reasons) && reasons.length > 1) {
+          for (let i = 1; i < reasons.length; i++) {
+            lines.push(`  · ${String(reasons[i])}`);
+          }
+        }
+        const stdoutPreview = firstNonEmpty(stdout);
+        const stderrPreview = firstNonEmpty(stderr);
+        if (stdoutPreview) lines.push(`"${truncMid(stdoutPreview, 70)}"`);
+        if (stderrPreview && stderrPreview !== stdoutPreview) {
+          lines.push(`! "${truncMid(stderrPreview, 70)}"`);
+        }
+        return lines;
+      }
+    }
+  }
+
   // todo
   if (toolName === 'todo') return ok ? [] : [text.split('\n')[0] ?? ''];
 

--- a/packages/tui/tests/tool-format.test.ts
+++ b/packages/tui/tests/tool-format.test.ts
@@ -231,6 +231,110 @@ describe('formatToolOutput', () => {
     expect(out[1]).toContain('boom');
   });
 
+  // exec (heuristic danger detection, PR 5 — TUI render)
+
+  it('exec (destructive): renders a DESTRUCTIVE chip + first reason + exit/line counts + preview', () => {
+    const out = formatToolOutput(
+      'exec',
+      JSON.stringify({
+        exit_code: 0,
+        stdout: 'removed ./build',
+        stderr: '',
+        danger: { level: 'destructive', reasons: ['recursive force-delete'], matchedRule: 'rm-recursive' },
+      }),
+      true,
+    );
+    expect(out[0]).toContain('⚠ DESTRUCTIVE');
+    expect(out[0]).toContain('recursive force-delete');
+    expect(out[0]).toContain('exit 0');
+    expect(out[0]).toContain('1 out');
+    // stdout preview is on its own line
+    expect(out.find((l) => l.includes('removed ./build'))).toBeDefined();
+  });
+
+  it('exec (caution): renders a CAUTION chip + first reason', () => {
+    const out = formatToolOutput(
+      'exec',
+      JSON.stringify({
+        exit_code: 0,
+        stdout: '',
+        stderr: '',
+        danger: { level: 'caution', reasons: ['inline script evaluation (-c / -e / --eval)'] },
+      }),
+      true,
+    );
+    expect(out[0]).toContain('! CAUTION');
+    expect(out[0]).toContain('inline script evaluation');
+    expect(out[0]).toContain('exit 0');
+  });
+
+  it('exec (multi-rule): stacks additional reasons below the first', () => {
+    const out = formatToolOutput(
+      'exec',
+      JSON.stringify({
+        exit_code: 0,
+        stdout: '',
+        stderr: '',
+        danger: {
+          level: 'destructive',
+          reasons: ['recursive force-delete', 'privilege escalation (sudo / doas)'],
+        },
+      }),
+      true,
+    );
+    expect(out[0]).toContain('recursive force-delete');
+    // Second reason appears on a separate stacked line.
+    const stacked = out.find((l) => l.includes('privilege escalation'));
+    expect(stacked).toBeDefined();
+    expect(stacked).toMatch(/^\s+·/); // indent + bullet
+  });
+
+  it('exec (safe): no chip — falls through to the bash-style line', () => {
+    const out = formatToolOutput(
+      'exec',
+      JSON.stringify({
+        exit_code: 0,
+        stdout: 'On branch main',
+        stderr: '',
+        danger: { level: 'safe', reasons: [] },
+      }),
+      true,
+    );
+    // Safe level produces no DESTRUCTIVE / CAUTION chip in the first line.
+    expect(out[0]).not.toContain('DESTRUCTIVE');
+    expect(out[0]).not.toContain('CAUTION');
+    expect(out[0]).toContain('exit 0');
+  });
+
+  it('exec (no danger field): behaves like safe (backward compat with pre-PR-1 output)', () => {
+    const out = formatToolOutput(
+      'exec',
+      JSON.stringify({ exit_code: 0, stdout: 'ok', stderr: '' }),
+      true,
+    );
+    expect(out[0]).not.toContain('DESTRUCTIVE');
+    expect(out[0]).not.toContain('CAUTION');
+    expect(out[0]).toContain('exit 0');
+  });
+
+  it('exec (destructive, with stderr): still surfaces the chip and the stderr preview', () => {
+    const out = formatToolOutput(
+      'exec',
+      JSON.stringify({
+        exit_code: 1,
+        stdout: '',
+        stderr: 'permission denied',
+        danger: { level: 'destructive', reasons: ['recursive force-delete'] },
+      }),
+      true,
+    );
+    expect(out[0]).toContain('⚠ DESTRUCTIVE');
+    expect(out[0]).toContain('exit 1');
+    expect(out[0]).toContain('1 err');
+    const stderrLine = out.find((l) => l.startsWith('!'));
+    expect(stderrLine).toContain('permission denied');
+  });
+
   it('todo: no extra line on success (item count is already in args)', () => {
     expect(formatToolOutput('todo', 'updated', true)).toEqual([]);
   });


### PR DESCRIPTION
## Summary

Wires the heuristic danger-detection output from PR 1–3 into the TUI's tool-result formatter. Before this commit, `exec` fell through to a generic JSON-summary path; now it has a dedicated case that surfaces the danger level as a compact chip-style prefix.

## Output shape (plain text, theme-agnostic)

```
destructive: ⚠ DESTRUCTIVE  recursive force-delete
             exit 0 · 12 out · 0 err
             "build/"
             · privilege escalation (sudo / doas)   <-- stacked if multiple

caution:     ! CAUTION  inline script evaluation (-c / -e / --eval)
             exit 0 · 0 out · 0 err

safe:        (no chip — falls through to the bash-style line)
```

The chip is plain-text so it works across TUI, webui, and CLI renderers. **Theme tinting is intentionally out of scope** for this PR — no new color tokens are added. Callers can opt in to highlighting by post-processing the `⚠` / `!` prefixes.

## Why a chip in the formatter, not a separate component

`formatToolOutput` is the existing chokepoint where every tool's result is distilled into 0–N digest lines the renderer stacks. Adding the chip there means:

1. **No renderer changes** — the existing `<ToolResult>` consumer picks up the chip for free.
2. **The chip is portable** — same text format can be used by webui or CLI in a follow-up without changing the tool output schema.
3. **The bash case** (which the `exec` case mirrors) is right there as a tested pattern.

## Backward compatibility

- Pre-PR-1 exec output (no `danger` field) renders as a normal bash-style line — covered by an explicit regression test.
- `safe` level output also renders as a normal bash-style line — no chip, no extra noise for the common case.
- The existing `bash` case in the same formatter is **unchanged**.

## Multi-rule interaction

When multiple rules fire (e.g. `sudo rm -rf /` triggers both `rm-recursive` and `sudo`), the first reason appears inline with the chip and additional reasons are stacked on subsequent lines with a `  · ` indent. This mirrors how multi-line tool outputs already render in the TUI.

## Test coverage (6 new cases in `tool-format.test.ts`)

1. `destructive`: chip + first reason + exit/line counts + preview
2. `caution`: chip + first reason
3. `multi-rule`: stacked reasons
4. `safe`: no chip (backward compat for `level: 'safe'`)
5. no `danger` field: no chip (backward compat for pre-PR-1 output)
6. `destructive` with stderr: chip + stderr preview still surfaced

All cases use the same `formatToolOutput('exec', JSON.stringify(...), true)` shape that the existing `bash` tests use, so the test code mirrors the existing convention.

## Files changed

| File | Change |
|---|---|
| `packages/tui/src/components/history/utils.tsx` | +66 / -0 (new `case 'exec':` in `formatToolOutput`) |
| `packages/tui/tests/tool-format.test.ts` | +104 / -0 (6 new cases) |

## No changes to

- The danger-detection module itself (PR 1–3 in `@wrongstack/tools`)
- The exec tool's output schema
- Any other tool's render path
- The webui or CLI renderers (out of scope; this PR is TUI-only. The same plain-text output is portable; webui consumers can adopt the same chip format in a follow-up.)

## Out of scope (planned follow-ups)

- **Webui / CLI consumer** that reads the same chip + reasons and renders it
- **PR 4** (route destructive through the confirm flow) — this PR renders the marker; the gating decision is a separate scope that touches `permission-policy.ts` and is non-trivial
- **Theme-aware color tinting** of the chip (yellow for caution, red for destructive) — explicit non-goal for this PR to keep the visual surface minimal
- **CLI --json output** that emits the chip in a stable format for scripting

## Related

- PR 1: [#158](https://github.com/WrongStack/WrongStack/pull/158) — module + 12 narrow rules
- PR 2: [#159](https://github.com/WrongStack/WrongStack/pull/159) — 9 broader rules
- PR 3: [#160](https://github.com/WrongStack/WrongStack/pull/160) — bypass config + boot-side strip
- This PR: TUI render of the existing `danger` field

## Stack

```
feature/danger-tui-render  (this, base: main)
main
```

I branched off `main` directly here, not off the danger-detect stack, because this PR only touches the TUI consumer and has no dependency on the unmerged danger-bypass changes. If the maintainer team prefers a single stacked PR, happy to rebase on top of the danger stack before merge.
