### PR TITLE
fix(coordination): spawn fresh mailbox bridge on dead-PID stale locks

### DIFF
--- a/packages/cli/src/mailbox-bridge-bootstrap.ts
+++ b/packages/cli/src/mailbox-bridge-bootstrap.ts
@@ -108,10 +108,13 @@ export async function tryAcquireMailboxBridge(
       source: 'joined',
     };
   }
-  if (existing.kind === 'probe-failed') {
-    // Lock exists with a recorded PID, but /healthz didn't respond.
-    // Return the recorded URL/token anyway — the caller's request
-    // layer will surface a real error if the bridge is truly dead.
+  if (existing.kind === 'probe-failed' && existing.pidAlive) {
+    // Lock exists, the recorded PID is ALIVE, but /healthz didn't
+    // respond — the bridge may be booting, wedged, or the PID was
+    // reused. Return the recorded URL/token anyway; the caller's
+    // request layer surfaces a real error if the bridge is truly
+    // dead. We must NOT spawn a second bridge here: a live PID still
+    // owns the lock, and racing it risks a port conflict.
     return {
       url: existing.lock.url,
       token: existing.lock.token,
@@ -120,8 +123,16 @@ export async function tryAcquireMailboxBridge(
       source: 'unhealthy',
     };
   }
+  // `existing.kind === 'probe-failed' && !existing.pidAlive` is a
+  // STALE lock: the owning process is gone but the lock file was
+  // never cleaned up (e.g. the bridge crashed or the machine was
+  // hard-rebooted). Treat it exactly like `absent` and fall through
+  // to Phase 2 — spawning `wstack mailbox serve` runs `acquireOrJoin`,
+  // which unlinks the stale lock and reacquires the slot. Without
+  // this, a stale lock would wedge every boot into `unhealthy`
+  // forever and no bridge would ever come up.
 
-  // Phase 2 — no live owner; spawn a fresh bridge.
+  // Phase 2 — no live owner (absent or stale); spawn a fresh bridge.
   let child: SpawnedChild;
   try {
     // SpawnFn is declared async — must await, otherwise `child` is a

--- a/packages/cli/tests/mailbox-bridge-bootstrap.test.ts
+++ b/packages/cli/tests/mailbox-bridge-bootstrap.test.ts
@@ -3,10 +3,7 @@ import { createServer, type Server } from 'node:http';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import {
-  acquireOrJoin,
-  MAILBOX_BRIDGE_LOCK_FILENAME,
-} from '@wrongstack/core/coordination';
+import { acquireOrJoin, MAILBOX_BRIDGE_LOCK_FILENAME } from '@wrongstack/core/coordination';
 import {
   tryAcquireMailboxBridge,
   type ProbeFn,
@@ -88,11 +85,7 @@ function _failingProbe(): ProbeFn {
   return async () => false;
 }
 
-function makeSpawnFnWritingLock(
-  host: string,
-  port: number,
-  token: string,
-): SpawnFn {
+function makeSpawnFnWritingLock(host: string, port: number, token: string): SpawnFn {
   return async (_args, cwd) => {
     // Use the test process's own PID so `isProcessAlive` accepts the
     // lock as live — `readLiveLock` checks both PID and /healthz, and
@@ -141,11 +134,7 @@ describe('tryAcquireMailboxBridge', () => {
         path.join(projectDir, MAILBOX_BRIDGE_LOCK_FILENAME),
         JSON.stringify(ownerLock, null, 2),
       );
-      await fs.writeFile(
-        path.join(projectDir, '.mailbox.token'),
-        ownerLock.token,
-        { mode: 0o600 },
-      );
+      await fs.writeFile(path.join(projectDir, '.mailbox.token'), ownerLock.token, { mode: 0o600 });
 
       const handle = await tryAcquireMailboxBridge({
         projectDir,
@@ -170,11 +159,7 @@ describe('tryAcquireMailboxBridge', () => {
       const handle = await tryAcquireMailboxBridge({
         projectDir,
         probeFn: liveProbe(),
-        spawnFn: makeSpawnFnWritingLock(
-          '127.0.0.1',
-          owner.port,
-          'b'.repeat(64),
-        ),
+        spawnFn: makeSpawnFnWritingLock('127.0.0.1', owner.port, 'b'.repeat(64)),
       });
 
       expect(handle.source).toBe('spawned');
@@ -233,6 +218,60 @@ describe('tryAcquireMailboxBridge', () => {
     }
   });
 
+  it('spawns a fresh bridge when the lock PID is DEAD (stale lock), not source=unhealthy', async () => {
+    // Regression test for the stale-lock wedge: a bridge crashed or the
+    // machine rebooted, leaving a lock file whose recorded PID is gone.
+    // Previously `tryAcquireMailboxBridge` short-circuited such a lock to
+    // source='unhealthy' and NEVER spawned — wedging every boot forever.
+    // Now a dead PID is treated like an absent lock: we spawn a fresh
+    // bridge (which internally unlinks the stale lock via acquireOrJoin).
+    const owner = await startHealthzServer();
+    try {
+      // A PID that is reliably dead on every platform: way above any
+      // realistic live PID. tasklist won't find it; process.kill(0)
+      // throws ESRCH. So `isProcessAlive` returns false → stale lock
+      // with pidAlive=false.
+      const deadPid = 999_999;
+      const staleLock = {
+        pid: deadPid,
+        host: '127.0.0.1',
+        port: 1, // dead port — irrelevant, PID check fails first
+        url: 'http://127.0.0.1:1',
+        token: 'd'.repeat(64),
+        generation: 3,
+        spawnedAt: '2020-01-01T00:00:00.000Z',
+      };
+      await fs.writeFile(
+        path.join(projectDir, MAILBOX_BRIDGE_LOCK_FILENAME),
+        JSON.stringify(staleLock, null, 2),
+      );
+
+      let spawnCalled = false;
+      const handle = await tryAcquireMailboxBridge({
+        projectDir,
+        timeoutMs: 2000,
+        spawnFn: (...args) => {
+          spawnCalled = true;
+          // The real subcommand would run acquireOrJoin (unlinking the
+          // stale lock) and bind a port; our stub writes a fresh live
+          // lock pointing at the running healthz server, using the
+          // test process PID so it reads back as live.
+          return makeSpawnFnWritingLock('127.0.0.1', owner.port, 'e'.repeat(64))(...args);
+        },
+      });
+
+      // The stale lock must trigger a spawn — NOT a short-circuit to
+      // 'unhealthy'.
+      expect(spawnCalled).toBe(true);
+      expect(handle.source).toBe('spawned');
+      expect(handle.url).toBe(`http://127.0.0.1:${owner.port}`);
+      expect(handle.token).toBe('e'.repeat(64));
+      expect(handle.childPid).not.toBeNull();
+    } finally {
+      await owner.close();
+    }
+  });
+
   it('returns source=failed when spawn throws', async () => {
     const handle = await tryAcquireMailboxBridge({
       projectDir,
@@ -250,7 +289,12 @@ describe('tryAcquireMailboxBridge', () => {
     // SpawnFn that does NOT write the lock file (simulating a bridge
     // that crashes before listen succeeds).
     const noopSpawn: SpawnFn = async () => {
-      return { pid: 12345, unref: () => { /* noop */ } };
+      return {
+        pid: 12345,
+        unref: () => {
+          /* noop */
+        },
+      };
     };
     const handle = await tryAcquireMailboxBridge({
       projectDir,
@@ -263,9 +307,7 @@ describe('tryAcquireMailboxBridge', () => {
   });
 
   it('cross-project: project A and B are isolated', async () => {
-    const projectB = await fs.mkdtemp(
-      path.join(os.tmpdir(), 'mailbox-bootstrap-other-'),
-    );
+    const projectB = await fs.mkdtemp(path.join(os.tmpdir(), 'mailbox-bootstrap-other-'));
     try {
       const owner = await startHealthzServer();
       // Project B needs its OWN bridge on a different port — use the
@@ -292,11 +334,7 @@ describe('tryAcquireMailboxBridge', () => {
         const handleB = await tryAcquireMailboxBridge({
           projectDir: projectB,
           probeFn: liveProbe(),
-          spawnFn: makeSpawnFnWritingLock(
-            '127.0.0.1',
-            ownerB.port,
-            'e'.repeat(64),
-          ),
+          spawnFn: makeSpawnFnWritingLock('127.0.0.1', ownerB.port, 'e'.repeat(64)),
         });
         expect(handleB.source).toBe('spawned');
         expect(handleB.token).toBe('e'.repeat(64));

--- a/packages/core/src/coordination/single-instance-mailbox.ts
+++ b/packages/core/src/coordination/single-instance-mailbox.ts
@@ -104,9 +104,7 @@ export interface AcquireOptions {
  * the caller owns the HTTP server instance; the lock module owns
  * the on-disk contract.
  */
-export async function acquireOrJoin(
-  opts: AcquireOptions,
-): Promise<AcquireResult> {
+export async function acquireOrJoin(opts: AcquireOptions): Promise<AcquireResult> {
   const lockPath = path.join(opts.projectDir, MAILBOX_BRIDGE_LOCK_FILENAME);
   const tokenPath = path.join(opts.projectDir, MAILBOX_BRIDGE_TOKEN_FILENAME);
 
@@ -137,9 +135,7 @@ export async function acquireOrJoin(
     /* v8 ignore next -- best-effort: a vanished stale lock is fine */
     await fsp.unlink(lockPath).catch(() => undefined);
   }
-  const generation = inspected.kind === 'stale'
-    ? inspected.lock.generation + 1
-    : 1;
+  const generation = inspected.kind === 'stale' ? inspected.lock.generation + 1 : 1;
   const token = randomBytes(32).toString('hex');
 
   // Pre-write a tentative lock with the requested port (or 0 if
@@ -151,9 +147,7 @@ export async function acquireOrJoin(
     pid: process.pid,
     host: opts.host,
     port: opts.requestedPort ?? 0,
-    url: opts.requestedPort !== null
-      ? `http://${opts.host}:${opts.requestedPort}`
-      : '', // finalized in finalize() once we know the OS-assigned port
+    url: opts.requestedPort !== null ? `http://${opts.host}:${opts.requestedPort}` : '', // finalized in finalize() once we know the OS-assigned port
     token,
     generation,
     spawnedAt: new Date().toISOString(),
@@ -219,7 +213,18 @@ export async function release(projectDir: string, generation: number): Promise<v
 
 type LockInspection =
   | { kind: 'live'; lock: MailboxBridgeLock }
-  | { kind: 'stale'; lock: MailboxBridgeLock }
+  /**
+   * The lock is present and parseable but not usable. `pidAlive`
+   * distinguishes the two reasons:
+   *  - `pidAlive: false` — the recorded PID is dead. The lock is
+   *    a leftover from a crashed/killed bridge; a fresh spawn is the
+   *    right recovery (`acquireOrJoin` unlinks + reacquires).
+   *  - `pidAlive: true`  — the PID is alive but /healthz didn't
+   *    respond. The bridge may be booting, wedged, or a PID got
+   *    reused. Callers may still surface the recorded URL/token so
+   *    a real request can confirm/deny liveness.
+   */
+  | { kind: 'stale'; lock: MailboxBridgeLock; pidAlive: boolean }
   | { kind: 'absent' };
 
 /**
@@ -259,9 +264,10 @@ async function readLockForInspection(lockPath: string): Promise<LockInspection> 
     return { kind: 'absent' };
   }
   if (!isProcessAlive(parsed.pid)) {
-    // Stale PID — keep the data so callers (acquireOrJoin) can bump
-    // generation off it; the caller decides whether to unlink.
-    return { kind: 'stale', lock: parsed };
+    // Dead PID — keep the data so callers (acquireOrJoin) can bump
+    // generation off it; the caller decides whether to unlink. The
+    // owning bridge is gone, so recovery is a fresh spawn.
+    return { kind: 'stale', lock: parsed, pidAlive: false };
   }
   // Sanity-check the URL too — if the lock is well-formed but the
   // recorded port doesn't have anything bound, the PID might be
@@ -270,7 +276,7 @@ async function readLockForInspection(lockPath: string): Promise<LockInspection> 
   if (!(await probeHealthz(parsed.url))) {
     // PID alive but /healthz unreachable. Keep the data so the
     // caller can surface the URL/token to the user; do NOT unlink.
-    return { kind: 'stale', lock: parsed };
+    return { kind: 'stale', lock: parsed, pidAlive: true };
   }
   return { kind: 'live', lock: parsed };
 }
@@ -293,7 +299,17 @@ async function readLockForInspection(lockPath: string): Promise<LockInspection> 
  */
 export type LiveLockResult =
   | { kind: 'live'; lock: MailboxBridgeLock }
-  | { kind: 'probe-failed'; lock: MailboxBridgeLock }
+  /**
+   * The lock exists but isn't usable. `pidAlive` tells the caller
+   * which recovery to pick:
+   *  - `pidAlive: false` — the owning process is dead (stale lock).
+   *    Callers should treat this like `absent` and spawn a fresh
+   *    bridge rather than surfacing a dead URL.
+   *  - `pidAlive: true`  — the process is alive but /healthz didn't
+   *    respond (booting/wedged/PID-reuse). Callers may return the
+   *    recorded URL/token and let a real request confirm liveness.
+   */
+  | { kind: 'probe-failed'; lock: MailboxBridgeLock; pidAlive: boolean }
   | { kind: 'absent' };
 
 export async function readLiveLock(projectDir: string): Promise<LiveLockResult> {
@@ -303,7 +319,7 @@ export async function readLiveLock(projectDir: string): Promise<LiveLockResult> 
     return { kind: 'live', lock: result.lock };
   }
   if (result.kind === 'stale') {
-    return { kind: 'probe-failed', lock: result.lock };
+    return { kind: 'probe-failed', lock: result.lock, pidAlive: result.pidAlive };
   }
   return { kind: 'absent' };
 }
@@ -342,11 +358,10 @@ function isProcessAlive(pid: number): boolean {
   if (pid === process.pid) return true;
   if (os.platform() === 'win32') {
     try {
-      const out = execFileSync(
-        'tasklist',
-        ['/FI', `PID eq ${pid}`, '/NH', '/FO', 'CSV'],
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-      );
+      const out = execFileSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH', '/FO', 'CSV'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
       // tasklist prints the header even with /NH; if the pid exists,
       // it includes a row with the pid somewhere.
       return /\b"?,?\d+,?"?/.test(out) || out.includes(String(pid));

--- a/packages/core/tests/coordination/single-instance-mailbox.test.ts
+++ b/packages/core/tests/coordination/single-instance-mailbox.test.ts
@@ -241,20 +241,28 @@ describe('release', () => {
     await writeLock(tmp, { pid: process.pid, generation: 1 });
     await fs.writeFile(path.join(tmp, MAILBOX_BRIDGE_TOKEN_FILENAME), 'tok');
     await release(tmp, 1);
-    await expect(fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8')).rejects.toThrow();
-    await expect(fs.readFile(path.join(tmp, MAILBOX_BRIDGE_TOKEN_FILENAME), 'utf-8')).rejects.toThrow();
+    await expect(
+      fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8'),
+    ).rejects.toThrow();
+    await expect(
+      fs.readFile(path.join(tmp, MAILBOX_BRIDGE_TOKEN_FILENAME), 'utf-8'),
+    ).rejects.toThrow();
   });
 
   it('keeps the files when the generation does not match (not ours)', async () => {
     await writeLock(tmp, { pid: process.pid, generation: 2 });
     await release(tmp, 1);
-    await expect(fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8')).resolves.toBeTruthy();
+    await expect(
+      fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8'),
+    ).resolves.toBeTruthy();
   });
 
   it('keeps the files when the pid does not match (not ours)', async () => {
     await writeLock(tmp, { pid: 999999, generation: 1 });
     await release(tmp, 1);
-    await expect(fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8')).resolves.toBeTruthy();
+    await expect(
+      fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8'),
+    ).resolves.toBeTruthy();
   });
 
   it('still removes the lock when the token file is already gone (best-effort)', async () => {
@@ -262,7 +270,9 @@ describe('release', () => {
     // best-effort .catch must swallow so the lock cleanup completes.
     await writeLock(tmp, { pid: process.pid, generation: 1 });
     await release(tmp, 1);
-    await expect(fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8')).rejects.toThrow();
+    await expect(
+      fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8'),
+    ).rejects.toThrow();
   });
 
   it('is a no-op when no lock file exists', async () => {
@@ -277,13 +287,16 @@ describe('readLiveLock', () => {
     expect(res.kind).toBe('live');
   });
 
-  it('returns probe-failed when the owner pid is alive but /healthz is unreachable', async () => {
+  it('returns probe-failed with pidAlive=true when the owner pid is alive but /healthz is unreachable', async () => {
     await writeLock(tmp, { pid: process.pid, port: 7000, url: 'http://127.0.0.1:7000' });
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementationOnce(
       async () => ({ ok: false }) as Response,
     );
     const res = await readLiveLock(tmp);
     expect(res.kind).toBe('probe-failed');
+    // Live PID, dead /healthz → pidAlive stays true so callers don't
+    // race a second spawn against a still-running owner.
+    if (res.kind === 'probe-failed') expect(res.pidAlive).toBe(true);
   });
 
   it('returns probe-failed when the healthz fetch itself throws', async () => {
@@ -304,7 +317,9 @@ describe('readLiveLock', () => {
     await fs.writeFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), '{ not json');
     const res = await readLiveLock(tmp);
     expect(res.kind).toBe('absent');
-    await expect(fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8')).rejects.toThrow();
+    await expect(
+      fs.readFile(path.join(tmp, MAILBOX_BRIDGE_LOCK_FILENAME), 'utf-8'),
+    ).rejects.toThrow();
   });
 
   it('treats a lock with an invalid (zero) pid as stale', async () => {
@@ -326,11 +341,13 @@ describe('isProcessAlive (win32 tasklist branch)', () => {
     expect(res.kind).toBe('live');
   });
 
-  it('reports a pid absent from tasklist as stale', async () => {
+  it('reports a pid absent from tasklist as stale (pidAlive=false)', async () => {
     await writeLock(tmp, { pid: 8888, port: 8000, url: 'http://127.0.0.1:8000' });
     const res = await readLiveLock(tmp);
-    // dead pid → stale → readLiveLock surfaces probe-failed
+    // dead pid → stale → readLiveLock surfaces probe-failed with
+    // pidAlive=false so bootstrap callers know to spawn a fresh bridge.
     expect(res.kind).toBe('probe-failed');
+    if (res.kind === 'probe-failed') expect(res.pidAlive).toBe(false);
   });
 
   it('reports stale when tasklist itself throws', async () => {


### PR DESCRIPTION
## Problem

On CLI boot the log shows a permanent warning:

> `mailbox bridge present but /healthz unreachable on cli boot`

whenever a `.mailbox-bridge.lock` points at a **dead** process (a bridge that crashed or a machine that rebooted without releasing the lock).

## Root cause

`readLiveLock` mapped *any* unusable-but-present lock to `probe-failed`, and `tryAcquireMailboxBridge` short-circuited **all** `probe-failed` results to `source:'unhealthy'` and returned — it never reached the spawn phase. Since `readLiveLock` is side-effect-free (never unlinks) and no spawn ran (spawn is the only path that calls `acquireOrJoin`, which cleans stale locks), the stale lock was never cleaned and no new bridge ever came up. The warning wedged every boot forever.

The `probe-failed` state conflated two very different situations:
- **live PID + no /healthz** (bridge booting / wedged / PID reuse) -> correct to return `unhealthy` and not race a second spawn
- **dead PID** (stale lock) -> should behave like `absent` and spawn a fresh bridge

## Fix

- Add a `pidAlive: boolean` discriminator to the `stale` (`LockInspection`) and `probe-failed` (`LiveLockResult`) variants in `single-instance-mailbox.ts`.
  - dead PID -> `pidAlive: false`
  - live PID, unreachable /healthz -> `pidAlive: true`
- `tryAcquireMailboxBridge` now only returns `source:'unhealthy'` when `pidAlive === true`. A dead PID falls through to Phase 2 and spawns a fresh bridge (`acquireOrJoin` unlinks the stale lock and reacquires).

## Not affected

- The WebUI `discover-mailbox-bridge.ts` already spawns on any non-`live` result.
- `mailbox-health.ts`'s own `probe-failed` enum is unrelated (different type).

## Tests

- New CLI regression test: dead-PID lock -> `spawnFn` **is** called, `source:'spawned'` (not `unhealthy`).
- `pidAlive` assertions on the `readLiveLock` unit tests (live-no-healthz -> true; dead -> false).
- 27/27 core coordination + 8/8 CLI bootstrap tests pass; core/cli/webui typecheck + Biome lint clean.