### PR TITLE
ci: build workspace before typecheck to resolve cross-package declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Build all workspace packages in dependency (topological) order before
+      # typechecking. Each package resolves its `@wrongstack/*` imports from a
+      # dependency's *emitted* dist/*.d.ts, so without this step downstream
+      # packages (e.g. @wrongstack/acp -> @wrongstack/core) fail with
+      # TS2307 "Cannot find module '@wrongstack/core' or its corresponding
+      # type declarations". `pnpm build` runs scripts/build.mjs, which topo-sorts.
+      - name: Build
+        run: pnpm build
+
       - name: Typecheck
         run: pnpm typecheck
 


### PR DESCRIPTION
## Summary

CI has been red on `main` for every recent commit (`cf44d488`, `84d7360b`, `60f9ec9e`) — but the failure is an ordering bug in the workflow, not the diffs.

The `Typecheck` step runs `pnpm typecheck` (`tsc --noEmit` across all workspace packages) **immediately after install, with no build step**. Packages resolve their `@wrongstack/*` imports from each dependency's *emitted* `dist/*.d.ts`, so with no dist present, downstream packages fail with:

```
error TS2307: Cannot find module '@wrongstack/core' or its corresponding type declarations.
```

`@wrongstack/acp` (`src/agent/server-agent-turn.ts`, `src/agent/stdio-transport.ts`) is the first to trip it.

## Fix

Add a **Build** step before **Typecheck**:

```yaml
- name: Build
  run: pnpm build

- name: Typecheck
  run: pnpm typecheck
```

`pnpm build` runs `scripts/build.mjs`, which builds packages in **topological (dependency) order** — so `@wrongstack/core` (and every other dep) emits its `dist/*.d.ts` before any dependent is typechecked.

## Verification

Reproduced and validated in an isolated git worktree off `origin/main`:

- `pnpm install --frozen-lockfile` → ok
- `pnpm build` → "Build complete." (topological, all `dist/*.d.ts` emitted, acp included)
- `pnpm typecheck` → passes clean across all 17 projects; the prior `TS2307` on acp is gone.

## Scope

Single-file change (`.github/workflows/ci.yml`). No source or dependency changes.
