### PR TITLE
feat(tui): Claude-Code-style diff view for file mutations

### DIFF
--- a/packages/tui/src/components/confirm-prompt.tsx
+++ b/packages/tui/src/components/confirm-prompt.tsx
@@ -1,6 +1,9 @@
 import { Box, Text, useInput } from '../ink.js';
 import { writeOut } from '@wrongstack/core';
 import React from 'react';
+import { langFromPath } from '../highlight.js';
+import { theme } from '../theme.js';
+import { DiffBlock, parseUnifiedDiff } from './history/code-block.js';
 
 export type ConfirmDecision = 'yes' | 'no' | 'always' | 'deny';
 
@@ -66,7 +69,10 @@ function stringifyInput(input: unknown): string {
   if (!input || typeof input !== 'object') return '';
   const obj = input as Record<string, unknown>;
   return Object.entries(obj)
-    .filter(([k]) => k !== 'content' && k !== 'new_string')
+    // `content`/`new_string` are bulky payloads; `diff` is rendered as a
+    // proper DiffBlock below the summary — repeating its raw text here
+    // would just be noise.
+    .filter(([k]) => k !== 'content' && k !== 'new_string' && k !== 'diff')
     .map(([k, v]) => `${k}: ${truncate(JSON.stringify(v), 80)}`)
     .join('  ');
 }
@@ -80,6 +86,9 @@ function hasDiff(input: unknown): boolean {
     input && typeof input === 'object' && 'diff' in (input as Record<string, unknown>),
   );
 }
+
+/** Max diff lines shown inside the approval dialog before truncation. */
+const CONFIRM_DIFF_MAX_LINES = 20;
 
 function renderDiffLine(line: string): React.ReactElement {
   const prefix = line.startsWith('+')
@@ -97,11 +106,34 @@ function renderDiffLine(line: string): React.ReactElement {
   );
 }
 
-function renderDiff(diff: string): React.ReactElement {
+/**
+ * Pending-edit preview inside the approval dialog. Rendered with the same
+ * Claude-Code-style `DiffBlock` the committed tool entries use (single
+ * line-number gutter, dark add/del washes, syntax highlighting from the
+ * target file's extension), so the "what you approve" preview and the
+ * "what happened" entry look identical. Falls back to the flat per-line
+ * coloring when the string doesn't parse as a unified diff.
+ */
+function renderDiff(diff: string, path: string | undefined): React.ReactElement {
+  const preview = parseUnifiedDiff(diff, CONFIRM_DIFF_MAX_LINES);
+  if (preview.rows.length > 0) {
+    return (
+      <DiffBlock
+        rows={preview.rows}
+        hidden={preview.hidden}
+        added={preview.added}
+        removed={preview.removed}
+        hiddenAdded={preview.hiddenAdded}
+        hiddenRemoved={preview.hiddenRemoved}
+        useColor={theme.supportsBackground}
+        lang={langFromPath(path ?? '')}
+      />
+    );
+  }
   const lines = diff
     .split('\n')
     .filter((l) => l.length > 0)
-    .slice(0, 20);
+    .slice(0, CONFIRM_DIFF_MAX_LINES);
   return (
     <Box flexDirection="column" paddingX={2}>
       {lines.map((l) => renderDiffLine(l))}
@@ -147,8 +179,9 @@ export function ConfirmPrompt({
 
   const inputSummary = stringifyInput(input);
   const showDiff = hasDiff(input);
-  const inp = input as { diff?: unknown | undefined };
+  const inp = input as { diff?: unknown | undefined; path?: unknown | undefined };
   const diff = typeof inp?.diff === 'string' ? inp.diff : '';
+  const diffPath = typeof inp?.path === 'string' ? inp.path : undefined;
 
   // NOTE: no marginY here — the call site wraps this in a measured Box that
   // owns the vertical margin, so `measureElement` on the wrapper reports the
@@ -168,7 +201,7 @@ export function ConfirmPrompt({
       {inputSummary ? <Text dimColor>{inputSummary}</Text> : null}
       {showDiff && diff ? (
         <Box flexDirection="column" marginY={1}>
-          {renderDiff(diff)}
+          {renderDiff(diff, diffPath)}
         </Box>
       ) : null}
       <Text dimColor>─────────────────</Text>

--- a/packages/tui/src/components/history/code-block.tsx
+++ b/packages/tui/src/components/history/code-block.tsx
@@ -1,6 +1,12 @@
 import { Box, Text } from '../../ink.js';
 import type React from 'react';
-import { type HLState, type Lang, highlightLine } from '../../highlight.js';
+import {
+  type HLState,
+  type Lang,
+  type Token,
+  highlightLine,
+  langFromPath,
+} from '../../highlight.js';
 import { theme } from '../../theme.js';
 import { stringOf, truncMid, tryParseJson } from './utils.js';
 
@@ -214,11 +220,14 @@ export function DiffFileBlock({
   path,
   preview,
   useColor = true,
+  contentWidth,
 }: {
   path: string;
   preview: DiffPreview;
   /** Pass-through to {@link DiffBlock}. See that component for details. */
   useColor?: boolean | undefined;
+  /** Pass-through to {@link DiffBlock}. See that component for details. */
+  contentWidth?: number | undefined;
 }): React.ReactElement {
   return (
     <Box flexDirection="column" marginTop={1}>
@@ -233,9 +242,45 @@ export function DiffFileBlock({
         hiddenAdded={preview.hiddenAdded}
         hiddenRemoved={preview.hiddenRemoved}
         useColor={useColor}
+        lang={langFromPath(path)}
+        contentWidth={contentWidth}
       />
     </Box>
   );
+}
+
+/**
+ * Human-readable change-size line for a diff — `Added N lines, removed M
+ * lines` (Claude Code phrasing). Omits the zero side; returns `null` when
+ * nothing changed so callers can skip the line entirely.
+ */
+export function formatDiffStats(added: number, removed: number): string | null {
+  const parts: string[] = [];
+  if (added > 0) parts.push(`added ${added} line${added === 1 ? '' : 's'}`);
+  if (removed > 0) parts.push(`removed ${removed} line${removed === 1 ? '' : 's'}`);
+  if (parts.length === 0) return null;
+  const joined = parts.join(', ');
+  return joined.charAt(0).toUpperCase() + joined.slice(1);
+}
+
+/**
+ * Render highlight tokens as nested `<Text>` segments. Tokens without a
+ * color inherit the enclosing default foreground, so the same token list
+ * reads correctly both on the plain background (context lines) and on the
+ * dark add/del washes.
+ */
+function renderTokens(tokens: Token[]): React.ReactNode {
+  if (tokens.length === 0) return ' ';
+  return tokens.map((t, j) => (
+    <Text
+      key={j}
+      dimColor={Boolean(t.dim)}
+      bold={Boolean(t.bold)}
+      {...(t.color ? { color: t.color } : {})}
+    >
+      {t.text}
+    </Text>
+  ));
 }
 
 export function DiffBlock({
@@ -246,45 +291,62 @@ export function DiffBlock({
   hiddenAdded = 0,
   hiddenRemoved = 0,
   useColor = true,
+  lang = 'plain',
+  showStats = true,
+  contentWidth,
 }: {
   rows: DiffLineRow[];
   hidden: number;
   /**
    * Total lines added across the whole diff (not just the visible slice).
-   * Surfaced as a green `+N` in the always-visible summary footer so the
+   * Surfaced in the `⎿  Added N lines, removed M lines` stats line so the
    * reader knows the change size even when the body is truncated.
    */
   added?: number | undefined;
-  /**
-   * Total lines removed across the whole diff (not just the visible slice).
-   * Surfaced as a red `-N` in the always-visible summary footer.
-   */
+  /** Total lines removed across the whole diff (not just the visible slice). */
   removed?: number | undefined;
   hiddenAdded?: number | undefined;
   hiddenRemoved?: number | undefined;
   /**
-   * When true (default), added/removed lines get a pastel green/red
-   * background wash with black foreground text — the visual scannable
-   * "added/removed" cue. When false, only the `+`/`-` markers get
-   * colored (bright green/red, bold) so the diff stays readable on
-   * terminals that don't support truecolor backgrounds (TERM=xterm,
-   * `NO_COLOR=1`, etc.). Pass `false` from the entry-point when
-   * `theme.supportsBackground === false` (future hook — for now the
-   * default is fine for any modern terminal).
+   * When true (default), added/removed rows get a dark green/maroon
+   * background wash (Claude Code style) with normal-brightness,
+   * syntax-highlighted foreground text. When false, only the `+`/`-`
+   * markers get colored (bright green/red, bold) so the diff stays
+   * readable on terminals that don't support truecolor backgrounds
+   * (TERM=xterm, `NO_COLOR=1`, etc.). Pass `theme.supportsBackground`
+   * from the entry-point.
    */
   useColor?: boolean | undefined;
+  /**
+   * Syntax-highlight language for line bodies (derive from the touched
+   * file's extension via `langFromPath`). `plain` disables highlighting.
+   */
+  lang?: Lang | undefined;
+  /**
+   * Render the leading `⎿  Added N lines, removed M lines` stats line.
+   * Callers that print their own header/stats (e.g. the Update(path)
+   * entry header) pass `false` to avoid the duplicate.
+   */
+  showStats?: boolean | undefined;
+  /**
+   * Terminal width available to this block. When set, line bodies are
+   * truncated (with a trailing `…`) so a row never wraps — a wrapped row
+   * would continue under the gutter and break the diff's column alignment.
+   * When omitted, rows keep the parser's own 100-char cap.
+   */
+  contentWidth?: number | undefined;
 }): React.ReactElement {
+  // Single-column gutter (Claude Code style): each row shows ONE line
+  // number — the old line for deletions, the new line for additions and
+  // context.
+  const lineNoOf = (row: DiffLineRow): number | undefined =>
+    row.kind === 'del' ? row.oldLine : (row.newLine ?? row.oldLine);
   let gutterWidth = 1;
   for (const r of rows) {
-    for (const n of [r.oldLine, r.newLine]) {
-      if (typeof n === 'number') {
-        const w = String(n).length;
-        if (w > gutterWidth) gutterWidth = w;
-      }
-    }
+    const n = lineNoOf(r);
+    if (typeof n === 'number' && String(n).length > gutterWidth) gutterWidth = String(n).length;
   }
   const blank = ' '.repeat(gutterWidth);
-  const gutterPad = `${blank} ${blank}`;
 
   const markerFor = (kind: DiffLineKind) => {
     if (kind === 'add') return '+';
@@ -299,137 +361,106 @@ export function DiffBlock({
     return row.text || ' ';
   };
 
+  const stats = showStats ? formatDiffStats(added, removed) : null;
+
+  // Row anatomy: box margin (2) + `   ` prefix (3) + line number + ` X `
+  // marker cell (3). Whatever remains is the body budget.
+  const bodyBudget =
+    typeof contentWidth === 'number'
+      ? Math.max(16, contentWidth - (2 + 3 + gutterWidth + 3))
+      : undefined;
+  const clampBody = (body: string): string =>
+    bodyBudget !== undefined && body.length > bodyBudget
+      ? `${body.slice(0, bodyBudget - 1)}…`
+      : body;
+
+  const hiddenStats: string[] = [];
+  if (hiddenAdded > 0) hiddenStats.push(`+${hiddenAdded}`);
+  if (hiddenRemoved > 0) hiddenStats.push(`-${hiddenRemoved}`);
+
   return (
-    <Box flexDirection="column" marginLeft={4} marginTop={0}>
+    <Box flexDirection="column" marginLeft={2} marginTop={0}>
+      {stats ? (
+        <Text>
+          <Text dimColor>{'⎿  '}</Text>
+          <Text>{stats}</Text>
+        </Text>
+      ) : null}
       {rows.map((row, i) => {
         const key = i;
         if (row.kind === 'hunk') {
+          // Claude Code hides hunk headers — the line numbers already carry
+          // position. A leading hunk renders nothing; between hunks a dim
+          // `⋯` marks the gap.
+          if (i === 0) return null;
           return (
-            <Text key={key} color="cyan" dimColor>
-              {`${gutterPad}  ${row.text}`}
+            <Text key={key} dimColor>
+              {`   ${blank} ⋯`}
             </Text>
           );
         }
         if (row.kind === 'meta') {
           return (
             <Text key={key} dimColor>
-              {`${gutterPad}  ${row.text}`}
+              {`   ${blank}   ${row.text}`}
             </Text>
           );
         }
-        const oldLn =
-          typeof row.oldLine === 'number' ? String(row.oldLine).padStart(gutterWidth, ' ') : blank;
-        const newLn =
-          typeof row.newLine === 'number' ? String(row.newLine).padStart(gutterWidth, ' ') : blank;
+        const n = lineNoOf(row);
+        const ln = typeof n === 'number' ? String(n).padStart(gutterWidth, ' ') : blank;
+        const body = clampBody(textForDisplay(row));
+        // Fresh highlight state per row: diff rows are disjoint slices of
+        // the file, so carrying block-comment state across add/del pairs
+        // would color the wrong lines.
+        const tokens = highlightLine(body, lang).tokens;
         if (row.kind === 'ctx') {
           return (
-            <Text key={key} dimColor>
-              {`${oldLn} ${newLn}   ${textForDisplay(row)}`}
+            <Text key={key}>
+              <Text dimColor>{`   ${ln}   `}</Text>
+              {renderTokens(tokens)}
             </Text>
           );
         }
         const marker = markerFor(row.kind);
-        const text = textForDisplay(row);
-        const gutter = `${oldLn} ${newLn}`;
-        // When the host terminal supports truecolor (the default path):
-        // wrap the line in a <Box> with the pastel wash background and
-        // use black foreground so the text reads cleanly on the soft
-        // tint. When truecolor backgrounds aren't available (e.g. some
-        // TTYs strip background escapes), fall back to bright foreground
-        // markers only — the line still reads as added/removed, just
-        // without the wash. The bold marker is always rendered for
-        // accessibility regardless of `useColor`.
+        const markerColor = row.kind === 'add' ? theme.success : theme.error;
+        // Truecolor path: the whole row (number + marker + body) sits on a
+        // dark green/maroon wash; the body keeps its syntax colors, which
+        // stay readable on the dark tint. Fallback path: no wash, the bold
+        // colored marker alone distinguishes add vs del.
         if (useColor) {
           const bg = row.kind === 'add' ? theme.diffAddBg : theme.diffDelBg;
-          const lineColor = row.kind === 'add' ? theme.success : theme.error;
           return (
             <Box key={key} backgroundColor={bg} minWidth={1} flexShrink={0}>
               <Text>
-                <Text dimColor>{gutter}</Text>
-                <Text> </Text>
-                <Text color={lineColor} bold>
+                <Text dimColor>{`   ${ln} `}</Text>
+                <Text color={markerColor} bold>
                   {marker}
                 </Text>
-                <Text color="black">{text}</Text>
+                <Text> </Text>
+                {renderTokens(tokens)}
               </Text>
             </Box>
           );
         }
-        // No-bg fallback: rely on the marker color (bright ANSI green/red
-        // after the Ink shim routes them through `softColor`) plus bold
-        // to distinguish add vs del. The line text stays in the default
-        // terminal foreground so it never vanishes against an unknown
-        // background.
-        const fgColor = row.kind === 'add' ? 'green' : 'red';
         return (
           <Text key={key}>
-            <Text dimColor>{gutter}</Text>
-            <Text> </Text>
-            <Text color={fgColor} bold>
+            <Text dimColor>{`   ${ln} `}</Text>
+            <Text color={markerColor} bold>
               {marker}
             </Text>
-            <Text>{text}</Text>
+            <Text> </Text>
+            {renderTokens(tokens)}
           </Text>
         );
       })}
-      {summaryFooter({
-        added,
-        removed,
-        hidden,
-        hiddenAdded,
-        hiddenRemoved,
-        gutterPad,
-      })}
-    </Box>
-  );
-}
-
-/**
- * Always-visible summary footer for a `DiffBlock`. Shows the *total*
- * additions/deletions (`+N added · -M deleted`) as a green/red colored
- * chip so the change size is readable at a glance even when the body
- * fits on screen. When the body was truncated, appends a dim italic
- * `… N more lines (+A -B hidden)` note carrying the hidden breakdown.
- *
- * Returns `null` only when there is genuinely nothing to summarize —
- * no totals, no hidden lines — so an unchanged/empty diff renders no
- * footer (preserving the "no footer when nothing changed" contract).
- */
-function summaryFooter(opts: {
-  added: number;
-  removed: number;
-  hidden: number;
-  hiddenAdded: number;
-  hiddenRemoved: number;
-  gutterPad: string;
-}): React.ReactElement | null {
-  const { added, removed, hidden, hiddenAdded, hiddenRemoved, gutterPad } = opts;
-  // Nothing to report at all → render nothing.
-  if (added <= 0 && removed <= 0 && hidden <= 0) return null;
-
-  const hiddenStats: string[] = [];
-  if (hiddenAdded > 0) hiddenStats.push(`+${hiddenAdded}`);
-  if (hiddenRemoved > 0) hiddenStats.push(`-${hiddenRemoved}`);
-  const truncNote =
-    hidden > 0
-      ? `  ·  … ${hidden} more line${hidden === 1 ? '' : 's'}${
-          hiddenStats.length > 0 ? ` (${hiddenStats.join(' ')} hidden)` : ''
-        }`
-      : '';
-
-  return (
-    <Text>
-      <Text dimColor>{`${gutterPad}  `}</Text>
-      <Text color={theme.success} bold>{`+${added}`}</Text>
-      <Text dimColor>{` added  `}</Text>
-      <Text color={theme.error} bold>{`-${removed}`}</Text>
-      <Text dimColor>{` deleted`}</Text>
-      {truncNote ? (
+      {hidden > 0 ? (
         <Text dimColor italic>
-          {truncNote}
+          {`   ${blank}  … ${hidden} more line${hidden === 1 ? '' : 's'}${
+            hiddenStats.length > 0 ? ` (${hiddenStats.join(' ')} hidden)` : ''
+          }`}
         </Text>
       ) : null}
-    </Text>
+    </Box>
   );
 }
 

--- a/packages/tui/src/components/history/entry.tsx
+++ b/packages/tui/src/components/history/entry.tsx
@@ -3,11 +3,13 @@ import React, { useEffect, useMemo } from 'react';
 import { theme } from '../../theme.js';
 import { getToolVisual } from '../../tool-glyph.js';
 import { Banner } from './banner.js';
+import { langFromPath } from '../../highlight.js';
 import {
   DiffBlock,
   DiffFileBlock,
   extractDiffPreview,
   extractMultiFileDiffs,
+  formatDiffStats,
   formatMultiDiffSummary,
   summarizeMultiFileDiffs,
 } from './code-block.js';
@@ -22,7 +24,10 @@ import {
   formatToolArgs,
   formatToolOutput,
   formatToolVisualOutput,
+  shortenPath,
+  stringOf,
   ToolOutputLines,
+  tryParseJson,
 } from './utils.js';
 
 // ── Internal helpers ──
@@ -204,6 +209,7 @@ export const Entry = React.memo(function Entry({
         diff,
         multiDiffs,
         sizeChip,
+        mutation,
       } = useMemo(() => {
         const argSummary = formatToolArgs(entry.name, entry.input);
         const outLines = formatToolOutput(
@@ -233,7 +239,47 @@ export const Entry = React.memo(function Entry({
           }
           return parts.join(' · ');
         })();
-        return { argSummary, outLines, visualLines, diff, multiDiffs, sizeChip };
+        // Claude-Code-style header info for file-mutating tools whose diff
+        // is renderable: `● Update(path)` / `● Write(path)` + a
+        // `⎿  Added N lines, removed M lines` stats line. Only successful
+        // calls with a recovered diff take this shape — failures and
+        // diff-less results keep the generic glyph header below.
+        const mutation = (() => {
+          const name = entry.name;
+          if (name !== 'edit' && name !== 'write' && name !== 'patch' && name !== 'replace') {
+            return undefined;
+          }
+          if (!entry.ok || (!diff && !multiDiffs)) return undefined;
+          const inputObj =
+            entry.input && typeof entry.input === 'object'
+              ? (entry.input as Record<string, unknown>)
+              : undefined;
+          const outJson = tryParseJson((entry.output ?? '').trim());
+          const outObj =
+            outJson && typeof outJson === 'object' ? (outJson as Record<string, unknown>) : undefined;
+          // `created` lives in the JSON output shape; the serialized-text
+          // shape carries it as a `created=true` field on the header line.
+          const created =
+            name === 'write' &&
+            (outObj?.['created'] === true ||
+              /^[^\n]*\bcreated=true\b/.test(entry.output ?? ''));
+          const verb = created ? 'Write' : 'Update';
+          const path = stringOf(inputObj?.['path']) ?? stringOf(outObj?.['path']);
+          const target = multiDiffs
+            ? multiDiffs.length === 1
+              ? multiDiffs[0]!.path
+              : `${multiDiffs.length} files`
+            : (path ?? 'file');
+          const agg = multiDiffs ? summarizeMultiFileDiffs(multiDiffs) : undefined;
+          return {
+            verb,
+            target,
+            added: agg ? agg.added : (diff?.added ?? 0),
+            removed: agg ? agg.removed : (diff?.removed ?? 0),
+            lang: langFromPath(multiDiffs ? '' : (path ?? '')),
+          };
+        })();
+        return { argSummary, outLines, visualLines, diff, multiDiffs, sizeChip, mutation };
       }, [
         entry.name,
         entry.output,
@@ -243,6 +289,74 @@ export const Entry = React.memo(function Entry({
         entry.outputLines,
         entry.outputTokens,
       ]);
+      if (mutation) {
+        // Claude-Code-style file-mutation entry:
+        //   ● Update(D:\path\to\file.tsx)  ·  12ms
+        //     ⎿  Added 2 lines, removed 2 lines
+        //     122        <div className="…">
+        //     125 -      <Loader2 … /> Loading kits…      (dark red wash)
+        //     125 +      <Loader2 … /> {t('…')}           (dark green wash)
+        // In `simple` result-render mode only the header + stats line show;
+        // the diff body stays hidden.
+        const statsText = formatDiffStats(mutation.added, mutation.removed) ?? 'No line changes';
+        // Keep the header on one line: budget the path to the terminal
+        // width minus the bullet, verb, parens and the trailing duration
+        // chip — a too-long absolute path elides from the left
+        // (`…\SidePanel\DesignStudioPanel.tsx`) instead of wrapping the
+        // bullet onto its own row.
+        const targetBudget = Math.max(24, termWidth - mutation.verb.length - 16);
+        return (
+          <Box flexDirection="column">
+            <Text>
+              <Text color={theme.success}>{'●'}</Text>
+              <Text> </Text>
+              <Text bold color="white">
+                {`${mutation.verb}(${shortenPath(mutation.target, targetBudget)})`}
+              </Text>
+              <Text dimColor>{`  ·  ${fmtDuration(entry.durationMs)}`}</Text>
+            </Text>
+            <Text>
+              <Text dimColor>{'  ⎿  '}</Text>
+              <Text>{statsText}</Text>
+            </Text>
+            {entry.resultRenderMode !== 'simple' && multiDiffs ? (
+              <Box flexDirection="column">
+                {(() => {
+                  const summaryLine = formatMultiDiffSummary(
+                    summarizeMultiFileDiffs(multiDiffs),
+                    multiDiffSummaryThreshold ?? -1,
+                  );
+                  return summaryLine ? (
+                    <Text dimColor italic>{`  ${summaryLine}`}</Text>
+                  ) : null;
+                })()}
+                {multiDiffs.map((item) => (
+                  <DiffFileBlock
+                    key={item.path}
+                    path={item.path}
+                    preview={item.preview}
+                    useColor={theme.supportsBackground}
+                    contentWidth={termWidth}
+                  />
+                ))}
+              </Box>
+            ) : entry.resultRenderMode !== 'simple' && diff ? (
+              <DiffBlock
+                rows={diff.rows}
+                hidden={diff.hidden}
+                added={diff.added}
+                removed={diff.removed}
+                hiddenAdded={diff.hiddenAdded}
+                hiddenRemoved={diff.hiddenRemoved}
+                useColor={theme.supportsBackground}
+                lang={mutation.lang}
+                showStats={false}
+                contentWidth={termWidth}
+              />
+            ) : null}
+          </Box>
+        );
+      }
       return (
         <Box flexDirection="column">
           <Text>
@@ -296,7 +410,7 @@ export const Entry = React.memo(function Entry({
                 ) : null;
               })()}
               {multiDiffs.map((item) => (
-                <DiffFileBlock key={item.path} path={item.path} preview={item.preview} useColor={theme.supportsBackground} />
+                <DiffFileBlock key={item.path} path={item.path} preview={item.preview} useColor={theme.supportsBackground} contentWidth={termWidth} />
               ))}
             </Box>
           ) : entry.resultRenderMode !== 'simple' && diff ? (
@@ -308,6 +422,7 @@ export const Entry = React.memo(function Entry({
               hiddenAdded={diff.hiddenAdded}
               hiddenRemoved={diff.hiddenRemoved}
               useColor={theme.supportsBackground}
+              contentWidth={termWidth}
             />
           ) : null}
         </Box>

--- a/packages/tui/src/components/history/index.tsx
+++ b/packages/tui/src/components/history/index.tsx
@@ -24,6 +24,7 @@ export {
   extractDiffPreview,
   extractMultiFileDiffs,
   extractReplaceDiffs,
+  formatDiffStats,
   formatMultiDiffSummary,
   parseUnifiedDiff,
   summarizeMultiFileDiffs,

--- a/packages/tui/src/highlight.ts
+++ b/packages/tui/src/highlight.ts
@@ -507,3 +507,14 @@ export function detectLang(fenceInfo: string): Lang {
   const tag = fenceInfo.trim().toLowerCase().split(/\s+/)[0] ?? '';
   return LANG_ALIASES[tag] ?? 'plain';
 }
+
+/**
+ * Infer a supported Lang from a file path's extension (`foo/bar.tsx` → `ts`).
+ * Used by diff rendering to syntax-highlight changed/context lines of the
+ * touched file. Unknown or missing extensions fall back to `plain`.
+ */
+export function langFromPath(path: string): Lang {
+  const m = /\.([A-Za-z0-9]+)$/.exec(path.trim());
+  const ext = m?.[1]?.toLowerCase() ?? '';
+  return LANG_ALIASES[ext] ?? 'plain';
+}

--- a/packages/tui/src/theme.ts
+++ b/packages/tui/src/theme.ts
@@ -119,7 +119,13 @@ export interface Theme {
     worktree: string;
     phase: string;
   };
-  /** Diff add/delete background blocks (content highlight). */
+  /**
+   * Diff add/delete row washes. Dark, low-luminance tints (deep green /
+   * deep maroon) so the row reads as added/removed while the foreground
+   * text — including syntax-highlight pastels — keeps full contrast on
+   * top. Mirrors the Claude Code diff look rather than a light pastel
+   * wash with dark text.
+   */
   diffAddBg: string;
   diffDelBg: string;
 }
@@ -145,9 +151,12 @@ export const theme: Theme = Object.freeze({
     worktree: pastel.green,
     phase: pastel.cyan,
   },
-  // Diff blocks render dark text on a pastel wash (see DiffBlock).
-  diffAddBg: pastel.green,
-  diffDelBg: pastel.red,
+  // Diff rows render light (pastel) text on a dark wash (see DiffBlock):
+  // deep green for additions, deep maroon for deletions — the Claude Code
+  // diff palette. Values are deliberately NOT from the `pastel` map: they
+  // must stay dark enough for white/syntax-colored foregrounds to read.
+  diffAddBg: '#1e4620',
+  diffDelBg: '#5a1e1e',
   // Whether the host terminal can render truecolor backgrounds. Diff blocks
   // downgrade to marker-only rendering when this is false (e.g. `TERM=xterm`,
   // `NO_COLOR=1`, captured/piped output).

--- a/packages/tui/tests/confirm-prompt.test.ts
+++ b/packages/tui/tests/confirm-prompt.test.ts
@@ -17,7 +17,7 @@ function stringifyInput(input: unknown): string {
   if (!input || typeof input !== 'object') return '';
   const obj = input as Record<string, unknown>;
   return Object.entries(obj)
-    .filter(([k]) => k !== 'content' && k !== 'new_string')
+    .filter(([k]) => k !== 'content' && k !== 'new_string' && k !== 'diff')
     .map(([k, v]) => `${k}: ${truncate(JSON.stringify(v), 80)}`)
     .join('  ');
 }
@@ -66,10 +66,11 @@ describe('ConfirmPrompt helpers', () => {
       expect(result).toContain('/tmp/a.ts');
     });
 
-    it('filters out content and new_string keys', () => {
-      const result = stringifyInput({ content: 'big', new_string: 'stuff', path: 'a.ts' });
+    it('filters out content, new_string, and diff keys', () => {
+      const result = stringifyInput({ content: 'big', new_string: 'stuff', diff: '--- a', path: 'a.ts' });
       expect(result).not.toContain('content');
       expect(result).not.toContain('new_string');
+      expect(result).not.toContain('diff');
       expect(result).toContain('path');
     });
 

--- a/packages/tui/tests/diff-block-render.test.ts
+++ b/packages/tui/tests/diff-block-render.test.ts
@@ -1,11 +1,20 @@
 import { render } from 'ink-testing-library';
 import { createElement as e } from 'react';
 import { describe, expect, it } from 'vitest';
-import { DiffBlock, type DiffLineRow } from '../src/components/history/code-block.js';
+import { DiffBlock, type DiffLineRow, formatDiffStats } from '../src/components/history/code-block.js';
 
 function renderDiffBlock(
   rows: DiffLineRow[],
-  opts: { useColor?: boolean; added?: number; removed?: number; hidden?: number; hiddenAdded?: number; hiddenRemoved?: number } = {},
+  opts: {
+    useColor?: boolean;
+    added?: number;
+    removed?: number;
+    hidden?: number;
+    hiddenAdded?: number;
+    hiddenRemoved?: number;
+    lang?: 'ts' | 'plain';
+    showStats?: boolean;
+  } = {},
 ): string {
   const { lastFrame, unmount } = render(
     e(DiffBlock, {
@@ -16,12 +25,30 @@ function renderDiffBlock(
       hiddenAdded: opts.hiddenAdded ?? 0,
       hiddenRemoved: opts.hiddenRemoved ?? 0,
       useColor: opts.useColor ?? false,
+      lang: opts.lang ?? 'plain',
+      showStats: opts.showStats ?? true,
     }),
   );
   const frame = lastFrame() ?? '';
   unmount();
   return frame;
 }
+
+describe('formatDiffStats', () => {
+  it('renders both sides in Claude Code phrasing', () => {
+    expect(formatDiffStats(2, 2)).toBe('Added 2 lines, removed 2 lines');
+    expect(formatDiffStats(1, 3)).toBe('Added 1 line, removed 3 lines');
+  });
+
+  it('omits the zero side and capitalizes the first word', () => {
+    expect(formatDiffStats(7, 0)).toBe('Added 7 lines');
+    expect(formatDiffStats(0, 1)).toBe('Removed 1 line');
+  });
+
+  it('returns null when nothing changed', () => {
+    expect(formatDiffStats(0, 0)).toBeNull();
+  });
+});
 
 describe('<DiffBlock /> rendering', () => {
   const rows: DiffLineRow[] = [
@@ -39,41 +66,59 @@ describe('<DiffBlock /> rendering', () => {
     expect(frame).toContain('old line');
   });
 
-  it('shows the hunk header', () => {
+  it('hides the leading hunk header (line numbers carry position)', () => {
     const frame = renderDiffBlock(rows);
-    expect(frame).toContain('@@ -1 +1 @@');
+    expect(frame).not.toContain('@@');
   });
 
-  it('uses distinct markers — `+` for added, `-` for removed, blank for context', () => {
-    const frame = renderDiffBlock(rows);
-    // Each line carries its kind marker at the gutter position; the
-    // assertion below is intentionally loose because the + appears in
-    // the diff text too (in "+new line"); we just verify all three
-    // kinds show up in the rendered frame.
-    expect(frame).toMatch(/[+]/);
-    expect(frame).toMatch(/[-]/);
-    expect(frame).toContain('unchanged');
+  it('renders a dim ⋯ separator between hunks (not before the first)', () => {
+    const twoHunks: DiffLineRow[] = [
+      { kind: 'hunk', text: '@@ -1 +1 @@' },
+      { kind: 'del', text: '-old line', oldLine: 1 },
+      { kind: 'hunk', text: '@@ -10 +10 @@' },
+      { kind: 'add', text: '+new line', newLine: 10 },
+    ];
+    const frame = renderDiffBlock(twoHunks);
+    expect(frame).not.toContain('@@');
+    expect(frame.split('⋯').length - 1).toBe(1);
   });
 
-  it('renders no footer when there are zero totals and no hidden lines', () => {
-    // added=removed=hidden=0 → summaryFooter returns null, so nothing
-    // extra appears below the body.
+  it('renders a single line-number column — old line for del, new line for add', () => {
+    const frame = renderDiffBlock([
+      { kind: 'del', text: '-old line', oldLine: 125 },
+      { kind: 'add', text: '+new line', newLine: 125 },
+      { kind: 'ctx', text: ' unchanged', oldLine: 126, newLine: 126 },
+    ]);
+    expect(frame).toMatch(/125 - old line/);
+    expect(frame).toMatch(/125 \+ new line/);
+    expect(frame).toMatch(/126 {3}unchanged/);
+    // No dual gutter: "125 125" must not appear.
+    expect(frame).not.toMatch(/125\s+125/);
+  });
+
+  it('renders no stats line when there are zero totals and no hidden lines', () => {
     const frame = renderDiffBlock(rows, {});
     expect(frame).not.toContain('more line');
-    expect(frame).not.toContain('added');
-    expect(frame).not.toContain('deleted');
+    expect(frame).not.toContain('Added');
+    expect(frame).not.toContain('removed');
   });
 
-  it('renders an always-visible summary footer with total +N/-N (no truncation)', () => {
+  it('renders an always-visible stats line with Added/removed totals (no truncation)', () => {
     // Even when the whole diff fits on screen (hidden=0), the totals
     // must surface so the change size is readable at a glance.
     const frame = renderDiffBlock(rows, { added: 7, removed: 3 });
-    expect(frame).toContain('+7');
-    expect(frame).toContain('added');
-    expect(frame).toContain('-3');
-    expect(frame).toContain('deleted');
+    expect(frame).toContain('⎿');
+    expect(frame).toContain('Added 7 lines, removed 3 lines');
     // No truncation note when nothing is hidden.
     expect(frame).not.toContain('more line');
+  });
+
+  it('suppresses the stats line when showStats=false (caller prints its own)', () => {
+    const frame = renderDiffBlock(rows, { added: 7, removed: 3, showStats: false });
+    expect(frame).not.toContain('Added 7 lines');
+    expect(frame).not.toContain('⎿');
+    // Body still renders.
+    expect(frame).toContain('new line');
   });
 
   it('renders hidden-line footer when there are more rows than shown', () => {
@@ -89,7 +134,7 @@ describe('<DiffBlock /> rendering', () => {
     // Caller (parseUnifiedDiff) is responsible for slicing the rows
     // AND for reporting `hidden` + `hiddenAdded`/`hiddenRemoved` and the
     // overall `added`/`removed` totals separately. Pass them in here so
-    // both the summary chip and the truncation note have data to print.
+    // both the stats line and the truncation note have data to print.
     const { lastFrame, unmount } = render(
       e(DiffBlock, {
         rows: many,
@@ -105,8 +150,8 @@ describe('<DiffBlock /> rendering', () => {
     unmount();
     expect(frame).toContain('…');
     expect(frame).toContain('more line');
-    // Total additions surfaced by the summary chip.
-    expect(frame).toContain('+16');
+    // Total additions surfaced by the stats line.
+    expect(frame).toContain('Added 16 lines');
     // Hidden breakdown (+4 / -1) carried by the truncation note.
     expect(frame).toMatch(/\+4\b/);
     expect(frame).toMatch(/-1\b/);
@@ -115,10 +160,7 @@ describe('<DiffBlock /> rendering', () => {
   it('renders the + marker with bold styling (no-color fallback)', () => {
     // In `useColor=false` mode the diff still distinguishes added vs
     // removed via the bold marker — the marker character + bold flag
-    // are always emitted, only the wash is optional. We assert that the
-    // frame carries both markers and they show up in their respective
-    // line positions (i.e. we did NOT collapse add/del into the same
-    // glyph or drop the bold flag).
+    // are always emitted, only the wash is optional.
     const frame = renderDiffBlock([
       { kind: 'del', text: '-old', oldLine: 1 },
       { kind: 'add', text: '+new', newLine: 1 },
@@ -152,5 +194,19 @@ describe('<DiffBlock /> rendering', () => {
     // strips ANSI escapes from lastFrame, so both should be plain text).
     const normalize = (s: string) => s.replace(/\s+/g, ' ').trim();
     expect(normalize(withoutColor)).toBe(normalize(withColor));
+  });
+
+  it('syntax highlighting is length-preserving — body text unchanged under lang=ts', () => {
+    const plain = renderDiffBlock(
+      [{ kind: 'add', text: '+const x = "hi"; // note', newLine: 1 }],
+      { lang: 'plain' },
+    );
+    const highlighted = renderDiffBlock(
+      [{ kind: 'add', text: '+const x = "hi"; // note', newLine: 1 }],
+      { lang: 'ts' },
+    );
+    const normalize = (s: string) => s.replace(/\s+/g, ' ').trim();
+    expect(normalize(highlighted)).toBe(normalize(plain));
+    expect(highlighted).toContain('const x = "hi"; // note');
   });
 });

--- a/packages/tui/tests/supports-background.test.ts
+++ b/packages/tui/tests/supports-background.test.ts
@@ -155,8 +155,6 @@ describe('theme.supportsBackground integration', () => {
       // The marker-only branch still emits the +/- glyphs.
       expect(frame).toContain('+');
       expect(frame).toContain('-');
-      // The hunk header is unaffected by the gate.
-      expect(frame).toContain('@@ -1 +1 @@');
       // The diff body text is still present (no regression in fallback).
       expect(frame).toContain('new line');
       expect(frame).toContain('old line');

--- a/packages/tui/tests/tool-entry-render.test.ts
+++ b/packages/tui/tests/tool-entry-render.test.ts
@@ -37,7 +37,7 @@ describe('<Entry /> tool rendering', () => {
     expect(frame).toContain('const Widget = makeWidget();');
   });
 
-  it('renders new-file write diffs in committed tool entries', () => {
+  it('renders new-file write diffs with a Write(path) header', () => {
     const frame = renderEntry({
       id: 2,
       kind: 'tool',
@@ -52,11 +52,10 @@ describe('<Entry /> tool rendering', () => {
       }),
     });
 
-    expect(frame).toContain('write');
-    expect(frame).toContain('src/new.ts');
-    // `created: true` is now rendered as "new file" in the meta line —
-    // the visual summary sits above the diff body.
-    expect(frame).toContain('new file');
+    // `created: true` → Claude-Code-style header: ● Write(path)
+    expect(frame).toContain('Write(src/new.ts)');
+    expect(frame).toContain('⎿');
+    expect(frame).toContain('Added 2 lines');
     expect(frame).toContain('alpha');
     expect(frame).toContain('beta');
   });
@@ -86,7 +85,7 @@ describe('<Entry /> tool rendering', () => {
     expect(frame).toContain('denied');
   });
 
-  it('renders edit meta line (path + replacement count) above the diff body', () => {
+  it('renders edit entries with an Update(path) header + stats line above the diff body', () => {
     const frame = renderEntry({
       id: 4,
       kind: 'tool',
@@ -108,14 +107,13 @@ describe('<Entry /> tool rendering', () => {
       }),
     });
 
-    // Meta line: tool name + path
-    expect(frame).toContain('edit');
-    expect(frame).toContain('src/foo.ts');
-    // Replacement count meta
-    expect(frame).toContain('1 replacement');
-    // Diff body still rendered below
-    expect(frame).toContain('+b');
-    expect(frame).toContain('-a');
+    // Header: ● Update(path)
+    expect(frame).toContain('Update(src/foo.ts)');
+    // Stats line: ⎿  Added 1 line, removed 1 line
+    expect(frame).toContain('Added 1 line, removed 1 line');
+    // Diff body below (single line-number gutter + marker + text).
+    expect(frame).toMatch(/1 \+ b/);
+    expect(frame).toMatch(/1 - a/);
   });
 
   it('renders write meta line (path + bytes)', () => {
@@ -157,13 +155,12 @@ describe('<Entry /> tool rendering', () => {
       }),
     });
 
-    // Meta line: still present (path + replacement count).
-    expect(frame).toContain('edit');
-    expect(frame).toContain('src/foo.ts');
-    expect(frame).toContain('1 replacement');
-    // Diff BODY is hidden — the raw `-a`/`+b` markers from the diff
-    // must not appear in the simple render.
-    expect(frame).not.toContain('-a');
-    expect(frame).not.toContain('+b');
+    // Header + stats line: still present.
+    expect(frame).toContain('Update(src/foo.ts)');
+    expect(frame).toContain('Added 1 line, removed 1 line');
+    // Diff BODY is hidden — the changed-line rows must not appear in the
+    // simple render.
+    expect(frame).not.toMatch(/1 - a/);
+    expect(frame).not.toMatch(/1 \+ b/);
   });
 });


### PR DESCRIPTION
## Summary

Restyles the TUI diff rendering for file-mutating tools to match the Claude Code look:

- **Entry header** — successful `edit`/`write`/`patch`/`replace` calls with a recoverable diff now render `● Update(path)` / `● Write(path)` (Write only for `created=true`) plus a `⎿  Added N lines, removed M lines` stats line, instead of the generic glyph header. Long absolute paths elide from the left to fit the terminal; `simple` result-render mode keeps header + stats and hides the body.
- **DiffBlock** — single line-number gutter (old line for deletions, new line for additions/context), `-`/`+` marker cell, hunk headers hidden (dim `⋯` between hunks), syntax highlighting from the touched file's extension via new `langFromPath()`, and optional `contentWidth` clamping so rows never wrap under the gutter. New `showStats` toggle lets the entry header own the stats line.
- **Theme** — `diffAddBg`/`diffDelBg` switch from pastel washes + black text to dark washes (`#1e4620` / `#5a1e1e`) with normal-brightness syntax-colored foreground.
- **ConfirmPrompt** — the approval dialog's pending-diff preview reuses the same DiffBlock (flat per-line coloring kept as fallback for unparseable strings); the raw `diff` text is dropped from the input summary line.
- `NO_COLOR` / non-truecolor terminals keep the marker-only fallback (no background SGR), asserted by the existing regression test.

## Test plan

- `pnpm vitest run packages/tui` — 987/987 passing; `diff-block-render`, `tool-entry-render`, `supports-background`, `confirm-prompt` tests updated to the new contract, plus new cases for `formatDiffStats`, single-gutter layout, hunk separators, `showStats=false`, and highlight length-preservation.
- `pnpm --filter @wrongstack/tui build` — ESM + DTS clean; pre-commit gate ran the full workspace typecheck (17/17).