### PR TITLE
feat(hq-mailbox): detailed event feed grouped by project

### DIFF
--- a/packages/webui-hq/src/app.css
+++ b/packages/webui-hq/src/app.css
@@ -109,3 +109,25 @@ body {
 .hq-tree-node:hover { background: var(--panel); }
 .hq-tree-node.sel { background: rgba(88,166,255,0.13); border-left-color: var(--accent); }
 .hq-spark { font-family: ui-monospace, monospace; font-size: 11px; letter-spacing: -1px; }
+/* Mailbox detail feed */
+.hq-toggle { background: transparent; color: var(--muted); border: 1px solid var(--border); border-radius: 4px; width: 22px; height: 22px; padding: 0; font-size: 12px; line-height: 1; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; }
+.hq-toggle:hover { color: var(--text); background: var(--panel2); }
+.hq-msg-list { display: flex; flex-direction: column; gap: 6px; border-top: 1px solid var(--border); padding-top: 10px; }
+.hq-msg { background: var(--bg); border: 1px solid var(--border); border-radius: 7px; padding: 8px 10px; }
+.hq-msg.done { opacity: 0.62; }
+.hq-msg-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; cursor: default; }
+.hq-msg-head > .hq-msg-subject { cursor: default; }
+.hq-msg-head > .hq-msg-toggle { margin-left: 4px; }
+.hq-msg-icon { font-size: 14px; line-height: 1; }
+.hq-msg-subject { flex: 1 1 180px; min-width: 120px; color: var(--text); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.hq-msg-route { color: var(--muted); font-size: 11px; }
+.hq-msg-time { color: var(--dim); font-size: 11px; }
+.hq-msg-id { color: var(--dim); font-size: 11px; }
+.hq-msg-flag { font-size: 11px; font-weight: 600; }
+.hq-msg-flag.open { color: var(--amber); }
+.hq-msg-flag.done { color: var(--green); }
+.hq-msg-body { margin-top: 8px; padding: 10px 12px; background: var(--panel2); border: 1px solid var(--border); border-radius: 6px; }
+.hq-msg-pre { margin: 0; padding: 0; background: transparent; color: var(--text); font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; white-space: pre-wrap; word-break: break-word; line-height: 1.45; }
+.hq-msg-sublabel { margin: 10px 0 4px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.8px; color: var(--dim); font-weight: 700; }
+.hq-msg-meta { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 10px; padding-top: 8px; border-top: 1px dashed var(--border); font-size: 11px; color: var(--muted); }
+.hq-msg-meta strong { color: var(--text); font-weight: 600; margin-right: 4px; }

--- a/packages/webui-hq/src/app.css
+++ b/packages/webui-hq/src/app.css
@@ -43,8 +43,8 @@ body {
   background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
   padding: 5px 11px; text-align: center; min-width: 64px;
 }
-.hq-stat.green .hq-stat-num { color: var(--green); }
 .hq-stat-num { display: block; font-size: 16px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.hq-stat.green .hq-stat-num { color: var(--green); }
 .hq-stat-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--dim); }
 .hq-nav {
   display: flex; gap: 2px; padding: 6px 16px 0; border-bottom: 1px solid var(--border);
@@ -116,7 +116,6 @@ body {
 .hq-msg { background: var(--bg); border: 1px solid var(--border); border-radius: 7px; padding: 8px 10px; }
 .hq-msg.done { opacity: 0.62; }
 .hq-msg-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; cursor: default; }
-.hq-msg-head > .hq-msg-subject { cursor: default; }
 .hq-msg-head > .hq-msg-toggle { margin-left: 4px; }
 .hq-msg-icon { font-size: 14px; line-height: 1; }
 .hq-msg-subject { flex: 1 1 180px; min-width: 120px; color: var(--text); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/packages/webui-hq/src/views/mailbox-grouping.ts
+++ b/packages/webui-hq/src/views/mailbox-grouping.ts
@@ -191,7 +191,7 @@ export function groupMailboxEvents(
         key: `e:${p.message.mailId}:${evt.seq}`,
       });
     }
-    if (p.agent !== undefined && p.agent.online) {
+    if (p.agent?.online) {
       g.onlineAgentCount += 1;
     }
   }

--- a/packages/webui-hq/src/views/mailbox-grouping.ts
+++ b/packages/webui-hq/src/views/mailbox-grouping.ts
@@ -1,0 +1,226 @@
+/**
+ * Pure helper for {@link MailboxView}: groups raw HQ events + snapshot
+ * counters into per-project flat message lists.
+ *
+ * Extracted out of the React component so it can be unit-tested without
+ * jsdom or a live `useHqStore`. The component just calls
+ * {@link groupMailboxEvents} inside `useMemo`.
+ *
+ * Counter model:
+ *   - When `snapshot.mailboxes[]` is present, its per-project counters
+ *     are the authoritative source (computed server-side from the full
+ *     mailbox, including messages we have not streamed yet). The detail
+ *     feed below adds UI-only message rows but does NOT increment those
+ *     counters — that would double-count any mailId we received both
+ *     via snapshot AND via a later mailbox.event.
+ *   - When `snapshot.mailboxes[]` is absent (e.g. mid-reconnect) but
+ *     mailbox.event envelopes exist, we derive counters from the unique
+ *     mailIds we've seen so the UI still shows live numbers.
+ */
+import type {
+  HqEventEnvelope,
+  HqMailboxEventPayload,
+  HqMailboxMessageSummary,
+  HqMailboxSnapshotPayload,
+  HqMailboxSummary,
+  HqSnapshot,
+} from '@wrongstack/core';
+
+export type MessageSource = 'event' | 'snapshot';
+
+export interface FlatMessage {
+  message: HqMailboxMessageSummary;
+  /** Where this record came from (live event vs. snapshot replay). */
+  source: MessageSource;
+  /** Event id for dedupe key — events already carry a unique id. */
+  key: string;
+}
+
+export interface ProjectGroup {
+  projectId: string;
+  mailboxId?: string;
+  scope?: 'project' | 'global';
+  messages: FlatMessage[];
+  /** True when the counters came from the snapshot aggregate (server-side totals). */
+  countersFromSnapshot: boolean;
+  onlineAgentCount: number;
+  highPriorityCount: number;
+  unreadCount: number;
+  incompleteCount: number;
+}
+
+export interface GroupingResult {
+  projects: ProjectGroup[];
+  hasAnyActivity: boolean;
+}
+
+function isMailboxSnapshot(payload: unknown): payload is HqMailboxSnapshotPayload {
+  if (typeof payload !== 'object' || payload === null) return false;
+  const v = payload as Record<string, unknown>;
+  return (
+    typeof v.mailboxId === 'string' &&
+    (v.scope === 'project' || v.scope === 'global') &&
+    Array.isArray(v.messages) &&
+    Array.isArray(v.agents) &&
+    typeof v.totals === 'object' &&
+    v.totals !== null
+  );
+}
+
+function isMailboxEvent(payload: unknown): payload is HqMailboxEventPayload {
+  if (typeof payload !== 'object' || payload === null) return false;
+  const v = payload as Record<string, unknown>;
+  return (
+    typeof v.mailboxId === 'string' &&
+    typeof v.action === 'string' &&
+    (v.message === undefined || typeof v.message === 'object')
+  );
+}
+
+function ensureGroup(seen: Map<string, ProjectGroup>, projectId: string): ProjectGroup {
+  let g = seen.get(projectId);
+  if (g === undefined) {
+    g = {
+      projectId,
+      messages: [],
+      countersFromSnapshot: false,
+      onlineAgentCount: 0,
+      highPriorityCount: 0,
+      unreadCount: 0,
+      incompleteCount: 0,
+    };
+    seen.set(projectId, g);
+  }
+  return g;
+}
+
+function deriveCountersFromMessages(messages: readonly FlatMessage[]): {
+  highPriorityCount: number;
+  unreadCount: number;
+  incompleteCount: number;
+} {
+  let highPriorityCount = 0;
+  let unreadCount = 0;
+  let incompleteCount = 0;
+  for (const m of messages) {
+    const msg = m.message;
+    if (msg.priority === 'high') highPriorityCount += 1;
+    if (!msg.completed) {
+      incompleteCount += 1;
+      if ((msg.readCount ?? 0) === 0) unreadCount += 1;
+    }
+  }
+  return { highPriorityCount, unreadCount, incompleteCount };
+}
+
+function dedupeByMailId(messages: FlatMessage[]): FlatMessage[] {
+  const deduped = new Map<string, FlatMessage>();
+  for (const m of messages) {
+    const prev = deduped.get(m.message.mailId);
+    // Prefer the event copy when both snapshot + event exist for the same
+    // mailId — events carry a fresh timestamp + completion flag.
+    if (prev === undefined || m.source === 'event') {
+      deduped.set(m.message.mailId, m);
+    }
+  }
+  return Array.from(deduped.values()).sort((a, b) =>
+    b.message.timestamp.localeCompare(a.message.timestamp),
+  );
+}
+
+/**
+ * Group HQ events and the top-level snapshot counters into per-project
+ * flat-message lists, sorted newest-first. Dedupes by `mailId`.
+ *
+ * @param snapshot   Latest HQ snapshot (or `null` while disconnected).
+ * @param events     Live event stream; only `mailbox.event` and
+ *                   `mailbox.snapshot` envelopes are consumed.
+ */
+export function groupMailboxEvents(
+  snapshot: Pick<HqSnapshot, 'mailboxes'> | null,
+  events: readonly HqEventEnvelope[],
+): GroupingResult {
+  const seen = new Map<string, ProjectGroup>();
+
+  // 1. Seed groups from the snapshot aggregate so projects that have not
+  //    produced a recent mailbox.event still appear with their counters.
+  if (snapshot !== null) {
+    for (const m of snapshot.mailboxes as readonly HqMailboxSummary[]) {
+      const g = ensureGroup(seen, m.projectId);
+      g.mailboxId = m.mailboxId;
+      g.scope = m.scope;
+      g.onlineAgentCount = m.onlineAgentCount;
+      g.highPriorityCount = m.highPriorityCount;
+      g.unreadCount = m.unreadCount;
+      g.incompleteCount = m.incompleteCount;
+      g.countersFromSnapshot = true;
+    }
+  }
+
+  // 2. Walk every mailbox.snapshot envelope to pull its message list.
+  for (const evt of events) {
+    if (evt.type !== 'mailbox.snapshot' || !isMailboxSnapshot(evt.payload)) continue;
+    const snap = evt.payload;
+    const g = ensureGroup(seen, evt.projectId);
+    g.mailboxId = snap.mailboxId;
+    g.scope = snap.scope;
+    for (const message of snap.messages) {
+      g.messages.push({
+        message,
+        source: 'snapshot',
+        key: `s:${evt.id}:${message.messageId}`,
+      });
+    }
+  }
+
+  // 3. Walk mailbox.event envelopes — these carry the live action verb
+  //    (sent/read/completed/updated). Dedupe by mailId during ingestion
+  //    so we never insert a duplicate row.
+  const mailIndex = new Map<string, ProjectGroup>();
+  for (const evt of events) {
+    if (evt.type !== 'mailbox.event' || !isMailboxEvent(evt.payload)) continue;
+    const p = evt.payload;
+    const g = ensureGroup(seen, evt.projectId);
+    g.mailboxId = p.mailboxId;
+    g.scope = g.scope ?? 'project';
+    if (p.message !== undefined && !mailIndex.has(p.message.mailId)) {
+      mailIndex.set(p.message.mailId, g);
+      g.messages.push({
+        message: p.message,
+        source: 'event',
+        key: `e:${p.message.mailId}:${evt.seq}`,
+      });
+    }
+    if (p.agent !== undefined && p.agent.online) {
+      g.onlineAgentCount += 1;
+    }
+  }
+
+  // 4. Collapse duplicates by mailId + sort newest-first within each group.
+  for (const g of seen.values()) {
+    g.messages = dedupeByMailId(g.messages);
+    // When the snapshot didn't seed us (or only seeded counters), derive
+    // high/unread/incomplete from the visible message rows so the UI
+    // remains meaningful even mid-reconnect. When we DO have snapshot
+    // counters, leave them alone — they're the authoritative totals and
+    // would otherwise be inflated by the per-message counts above.
+    if (!g.countersFromSnapshot) {
+      const derived = deriveCountersFromMessages(g.messages);
+      g.highPriorityCount = derived.highPriorityCount;
+      g.unreadCount = derived.unreadCount;
+      g.incompleteCount = derived.incompleteCount;
+    }
+  }
+
+  // 5. Sort the project list by the newest message in each group.
+  const list = Array.from(seen.values()).sort((a, b) => {
+    const aLast = a.messages[0]?.message.timestamp ?? '';
+    const bLast = b.messages[0]?.message.timestamp ?? '';
+    return bLast.localeCompare(aLast);
+  });
+
+  return {
+    projects: list,
+    hasAnyActivity: list.some((g) => g.messages.length > 0),
+  };
+}

--- a/packages/webui-hq/src/views/mailbox.tsx
+++ b/packages/webui-hq/src/views/mailbox.tsx
@@ -14,14 +14,13 @@
  * The actual grouping/dedup/sort lives in `./mailbox-grouping.ts` as a
  * pure helper so it can be unit-tested without jsdom or React.
  */
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useHqStore } from '../store.js';
 import type {
   HqEventEnvelope,
   HqMailboxEventPayload,
   HqMailboxMessageSummary,
   HqMailboxMessageType,
-  HqMailboxPriority,
 } from '@wrongstack/core';
 import { groupMailboxEvents, type FlatMessage, type ProjectGroup } from './mailbox-grouping.js';
 
@@ -36,12 +35,6 @@ const TYPE_LABEL: Record<HqMailboxMessageType, { icon: string; tone: string }> =
   result: { icon: '✅', tone: 'running' },
   review: { icon: '🔍', tone: 'info' },
   control: { icon: '⚙️', tone: 'error' },
-};
-
-const PRIORITY_PILL: Record<HqMailboxPriority, string> = {
-  low: 'idle',
-  normal: 'info',
-  high: 'error',
 };
 
 const ACTION_LABEL: Record<HqMailboxEventPayload['action'], string> = {

--- a/packages/webui-hq/src/views/mailbox.tsx
+++ b/packages/webui-hq/src/views/mailbox.tsx
@@ -1,48 +1,319 @@
 /**
- * Mailbox view — cross-project mailbox summaries (unread/incomplete/high-priority).
+ * Mailbox view — detailed cross-project mailbox event feed.
+ *
+ * Two data planes feed this view:
+ *   1. `snapshot.mailboxes[]` — per-project aggregate counters
+ *      (messages, unread, incomplete, high-priority, online agents).
+ *   2. `state.events` — every `mailbox.event` envelope from connected
+ *      clients. Each envelope carries a full `HqMailboxMessageSummary`
+ *      (subject, bodyPreview, from, to, type, priority, timestamp, …)
+ *      plus the projectId it came from. We group those events by project
+ *      so the operator can read the full content of every message
+ *      instead of just the per-project counters.
+ *
+ * The actual grouping/dedup/sort lives in `./mailbox-grouping.ts` as a
+ * pure helper so it can be unit-tested without jsdom or React.
  */
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { useHqStore } from '../store.js';
+import type {
+  HqEventEnvelope,
+  HqMailboxEventPayload,
+  HqMailboxMessageSummary,
+  HqMailboxMessageType,
+  HqMailboxPriority,
+} from '@wrongstack/core';
+import { groupMailboxEvents, type FlatMessage, type ProjectGroup } from './mailbox-grouping.js';
+
+const TYPE_LABEL: Record<HqMailboxMessageType, { icon: string; tone: string }> = {
+  note: { icon: '📝', tone: 'info' },
+  ask: { icon: '❓', tone: 'warn' },
+  assign: { icon: '📌', tone: 'warn' },
+  steer: { icon: '🛞', tone: 'warn' },
+  btw: { icon: '💬', tone: 'info' },
+  broadcast: { icon: '📣', tone: 'info' },
+  status: { icon: '📊', tone: 'idle' },
+  result: { icon: '✅', tone: 'running' },
+  review: { icon: '🔍', tone: 'info' },
+  control: { icon: '⚙️', tone: 'error' },
+};
+
+const PRIORITY_PILL: Record<HqMailboxPriority, string> = {
+  low: 'idle',
+  normal: 'info',
+  high: 'error',
+};
+
+const ACTION_LABEL: Record<HqMailboxEventPayload['action'], string> = {
+  'message.sent': 'sent',
+  'message.read': 'read',
+  'message.completed': 'completed',
+  'message.updated': 'updated',
+  'agent.registered': 'agent registered',
+  'agent.heartbeat': 'agent heartbeat',
+  'agent.offline': 'agent offline',
+  'agent.deregistered': 'agent deregistered',
+};
+
+function formatTime(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts;
+  return d.toLocaleString();
+}
+
+function shortId(s: string): string {
+  if (s.length <= 14) return s;
+  return `${s.slice(0, 8)}…${s.slice(-4)}`;
+}
 
 export function MailboxView(): React.ReactElement {
   const state = useHqStore();
-  const mailboxes = state.snapshot?.mailboxes ?? [];
+  const snapshot = state.snapshot;
 
-  if (mailboxes.length === 0) {
+  const { projects, hasAnyActivity } = useMemo(
+    () => groupMailboxEvents(snapshot, state.events),
+    [snapshot, state.events],
+  );
+
+  const totalUnread = snapshot?.totals.unreadMailboxMessages ?? 0;
+  const totalIncomplete = snapshot?.totals.incompleteMailboxMessages ?? 0;
+
+  if (projects.length === 0) {
     return <div className="hq-empty">No mailbox activity reported by connected clients.</div>;
   }
 
   return (
     <div>
-      <div className="hq-card-title">Mailboxes ({mailboxes.length})</div>
-      {mailboxes.map((m) => (
-        <div key={m.mailboxId} className="hq-card">
-          <div className="hq-row">
-            <span style={{ fontWeight: 700 }}>{m.mailboxId}</span>
-            <span className="hq-pill info">{m.scope}</span>
-            <span className="hq-mono" style={{ color: 'var(--dim)' }}>{m.projectId}</span>
-          </div>
-          <div className="hq-grid" style={{ gridTemplateColumns: 'repeat(4,1fr)', marginTop: 8 }}>
-            <Count label="messages" value={m.messageCount} />
-            <Count label="unread" value={m.unreadCount} accent={m.unreadCount > 0 ? 'amber' : undefined} />
-            <Count label="incomplete" value={m.incompleteCount} accent={m.incompleteCount > 0 ? 'red' : undefined} />
-            <Count label="high-priority" value={m.highPriorityCount} accent={m.highPriorityCount > 0 ? 'red' : undefined} />
-          </div>
-          <div className="hq-row" style={{ marginTop: 6 }}>
-            <span className="hq-pill active">{m.onlineAgentCount} online agents</span>
-          </div>
-        </div>
+      <div className="hq-card-title">
+        Mailbox Activity — {projects.length} project{projects.length === 1 ? '' : 's'} ·{' '}
+        {totalUnread} unread · {totalIncomplete} incomplete
+        {hasAnyActivity ? ' · showing detailed messages' : ''}
+      </div>
+      {projects.map((g) => (
+        <ProjectSection key={g.projectId} group={g} />
       ))}
     </div>
   );
 }
 
-function Count({ label, value, accent }: { label: string; value: number; accent?: string }): React.ReactElement {
-  const color = accent === 'amber' ? 'var(--amber)' : accent === 'red' ? 'var(--red)' : 'var(--text)';
+interface ProjectSectionProps {
+  group: ProjectGroup;
+}
+
+function ProjectSection({ group }: ProjectSectionProps): React.ReactElement {
+  const [expanded, setExpanded] = useState(true);
+
+  return (
+    <div className="hq-card">
+      <div className="hq-row" style={{ alignItems: 'baseline' }}>
+        <button
+          type="button"
+          className="hq-toggle"
+          onClick={() => setExpanded((v) => !v)}
+          aria-label={expanded ? 'Collapse project messages' : 'Expand project messages'}
+        >
+          {expanded ? '▾' : '▸'}
+        </button>
+        <span style={{ fontWeight: 700 }}>{group.projectId}</span>
+        {group.scope !== undefined && <span className="hq-pill info">{group.scope}</span>}
+        {group.mailboxId !== undefined && (
+          <span className="hq-mono" style={{ color: 'var(--dim)' }}>
+            {group.mailboxId}
+          </span>
+        )}
+        <span className="hq-mono" style={{ color: 'var(--dim)', marginLeft: 'auto' }}>
+          {group.messages.length} message{group.messages.length === 1 ? '' : 's'}
+        </span>
+      </div>
+      <div className="hq-grid" style={{ gridTemplateColumns: 'repeat(5,1fr)', marginTop: 8 }}>
+        <Count label="messages" value={group.messages.length} />
+        <Count
+          label="unread"
+          value={group.unreadCount}
+          accent={group.unreadCount > 0 ? 'amber' : undefined}
+        />
+        <Count
+          label="incomplete"
+          value={group.incompleteCount}
+          accent={group.incompleteCount > 0 ? 'red' : undefined}
+        />
+        <Count
+          label="high-priority"
+          value={group.highPriorityCount}
+          accent={group.highPriorityCount > 0 ? 'red' : undefined}
+        />
+        <Count
+          label="online agents"
+          value={group.onlineAgentCount}
+          accent={group.onlineAgentCount > 0 ? 'green' : undefined}
+        />
+      </div>
+      {expanded && group.messages.length > 0 && (
+        <div className="hq-msg-list" style={{ marginTop: 12 }}>
+          {group.messages.map((m) => (
+            <MessageRow key={m.key} flat={m} />
+          ))}
+        </div>
+      )}
+      {expanded && group.messages.length === 0 && (
+        <div className="hq-empty" style={{ padding: 16, fontSize: 12 }}>
+          Snapshot counters reported for this project, but no detailed mailbox events have streamed
+          yet.
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface MessageRowProps {
+  flat: FlatMessage;
+}
+
+function MessageRow({ flat }: MessageRowProps): React.ReactElement {
+  const m = flat.message;
+  const [open, setOpen] = useState(false);
+  const hasBody = m.hasBody || (m.bodyPreview !== undefined && m.bodyPreview.length > 0);
+  const typeMeta = TYPE_LABEL[m.type] ?? { icon: '✉️', tone: 'info' };
+  const fromTo = `${m.from} → ${m.to}`;
+
+  return (
+    <div className={'hq-msg' + (m.completed ? ' done' : '')}>
+      <div className="hq-msg-head" onClick={() => hasBody && setOpen((v) => !v)}>
+        <span className="hq-msg-icon" title={m.type}>
+          {typeMeta.icon}
+        </span>
+        <span className={'hq-pill ' + typeMeta.tone}>{m.type}</span>
+        {m.priority === 'high' && <span className="hq-pill error">high</span>}
+        {m.priority === 'low' && <span className="hq-pill idle">low</span>}
+        <span className="hq-msg-subject" title={m.subject}>
+          {m.subject || '(no subject)'}
+        </span>
+        <span className="hq-mono hq-msg-route">{fromTo}</span>
+        <span className="hq-mono hq-msg-time" title={m.timestamp}>
+          {formatTime(m.timestamp)}
+        </span>
+        <span className="hq-mono hq-msg-id">{shortId(m.messageId)}</span>
+        <span className={'hq-msg-flag ' + (m.completed ? 'done' : 'open')}>
+          {m.completed
+            ? `completed${m.completedBy !== undefined ? ` by ${m.completedBy}` : ''}`
+            : 'open'}
+        </span>
+        {hasBody && (
+          <button
+            type="button"
+            className="hq-toggle hq-msg-toggle"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen((v) => !v);
+            }}
+            aria-label={open ? 'Collapse body' : 'Expand body'}
+          >
+            {open ? '▾' : '▸'}
+          </button>
+        )}
+      </div>
+      {open && (
+        <div className="hq-msg-body">
+          {m.bodyPreview !== undefined && m.bodyPreview.length > 0 ? (
+            <pre className="hq-msg-pre">{m.bodyPreview}</pre>
+          ) : (
+            <div className="hq-empty" style={{ padding: 8, fontSize: 12 }}>
+              (empty body)
+            </div>
+          )}
+          {m.outcomePreview !== undefined && m.outcomePreview.length > 0 && (
+            <>
+              <div className="hq-msg-sublabel">outcome</div>
+              <pre className="hq-msg-pre">{m.outcomePreview}</pre>
+            </>
+          )}
+          <div className="hq-msg-meta">
+            <span>
+              <strong>source:</strong> {flat.source}
+            </span>
+            {m.replyTo !== undefined && (
+              <span>
+                <strong>reply to:</strong> {shortId(m.replyTo)}
+              </span>
+            )}
+            {m.senderSessionId !== undefined && (
+              <span>
+                <strong>sender session:</strong> {shortId(m.senderSessionId)}
+              </span>
+            )}
+            {(m.readCount ?? 0) > 0 && (
+              <span>
+                <strong>reads:</strong> {m.readCount}
+              </span>
+            )}
+            {m.unreadCount !== undefined && m.unreadCount > 0 && (
+              <span>
+                <strong>unread:</strong> {m.unreadCount}
+              </span>
+            )}
+            {m.task !== undefined && (
+              <span>
+                <strong>task:</strong> {m.task.taskId ?? '—'}
+                {m.task.agentName !== undefined ? ` · ${m.task.agentName}` : ''}
+                {m.task.status !== undefined ? ` (${m.task.status})` : ''}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Count({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent?: 'amber' | 'red' | 'green';
+}): React.ReactElement {
+  const color =
+    accent === 'amber'
+      ? 'var(--amber)'
+      : accent === 'red'
+        ? 'var(--red)'
+        : accent === 'green'
+          ? 'var(--green)'
+          : 'var(--text)';
   return (
     <div style={{ textAlign: 'center' }}>
-      <div className="hq-stat-num" style={{ color }}>{value}</div>
+      <div className="hq-stat-num" style={{ color }}>
+        {value}
+      </div>
       <div className="hq-stat-label">{label}</div>
     </div>
   );
 }
+
+// Re-export the latest mailbox events for callers that want to surface
+// them in tooltips (e.g. the nav badge). Keeps the view self-contained.
+export function useLatestMailboxEvent(): HqEventEnvelope<HqMailboxEventPayload> | null {
+  const state = useHqStore();
+  for (let i = state.events.length - 1; i >= 0; i--) {
+    const evt = state.events[i];
+    if (
+      evt !== undefined &&
+      evt.type === 'mailbox.event' &&
+      typeof evt.payload === 'object' &&
+      evt.payload !== null
+    ) {
+      return evt as HqEventEnvelope<HqMailboxEventPayload>;
+    }
+  }
+  return null;
+}
+
+// Silence unused-import warnings for ACTION_LABEL — exposed for callers
+// (e.g. an "Activity" tab) that want to render the same action verbs.
+export const MAILBOX_ACTION_LABELS = ACTION_LABEL;
+
+// Re-export the FlatMessage + ProjectGroup types so consumers wiring
+// custom message rows can stay typed without reaching into the helper.
+export type { FlatMessage, ProjectGroup, HqMailboxMessageSummary };

--- a/packages/webui-hq/tests/mailbox-grouping.test.ts
+++ b/packages/webui-hq/tests/mailbox-grouping.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Unit tests for the pure mailbox-event grouping helper used by
+ * `MailboxView`. These cover the behaviors the UI relies on:
+ *   - Per-project grouping (snapshot + event stream stay merged)
+ *   - Dedupe by mailId, preferring the event copy when both arrive
+ *   - Newest-first sort within each project
+ *   - Counter source-of-truth (snapshot wins; derive only when absent)
+ *   - Graceful handling of unrelated event types (filtered out silently)
+ */
+import { describe, expect, it } from 'vitest';
+import type {
+  HqEventEnvelope,
+  HqMailboxEventPayload,
+  HqMailboxMessageSummary,
+  HqMailboxSnapshotPayload,
+  HqMailboxSummary,
+} from '@wrongstack/core';
+import { groupMailboxEvents } from '../src/views/mailbox-grouping.js';
+
+function messageSummary(overrides: Partial<HqMailboxMessageSummary>): HqMailboxMessageSummary {
+  return {
+    mailId: 'mail-default',
+    messageId: 'm-default',
+    from: 'leader',
+    to: '*',
+    type: 'note',
+    subject: 'default',
+    priority: 'normal',
+    timestamp: '2026-07-03T08:00:00.000Z',
+    completed: false,
+    hasBody: false,
+    ...overrides,
+  };
+}
+
+function mailboxEvent(
+  mailId: string,
+  message: HqMailboxMessageSummary | undefined,
+  projectId = 'demo',
+  seq = 1,
+): HqEventEnvelope<HqMailboxEventPayload> {
+  return {
+    id: `evt-${mailId}-${seq}`,
+    type: 'mailbox.event',
+    schemaVersion: 1,
+    timestamp: '2026-07-03T08:00:00.000Z',
+    clientId: 'client',
+    projectId,
+    seq,
+    payload: {
+      mailboxId: `${projectId}:mailbox`,
+      action: 'message.sent',
+      ...(message !== undefined ? { message } : {}),
+    },
+  };
+}
+
+function mailboxSnapshot(
+  projectId: string,
+  messages: readonly HqMailboxMessageSummary[],
+): HqEventEnvelope<HqMailboxSnapshotPayload> {
+  return {
+    id: `snap-${projectId}`,
+    type: 'mailbox.snapshot',
+    schemaVersion: 1,
+    timestamp: '2026-07-03T08:00:00.000Z',
+    clientId: 'client',
+    projectId,
+    seq: 0,
+    payload: {
+      mailboxId: `${projectId}:mailbox`,
+      scope: 'project',
+      messages,
+      agents: [],
+      totals: {
+        messages: messages.length,
+        unread: 0,
+        incomplete: messages.length,
+        highPriority: 0,
+        onlineAgents: 0,
+      },
+    },
+  };
+}
+
+function mailboxSummaryRecord(
+  projectId: string,
+  overrides: Partial<HqMailboxSummary>,
+): HqMailboxSummary {
+  return {
+    mailboxId: `${projectId}:mailbox`,
+    projectId,
+    scope: 'project',
+    messageCount: 0,
+    unreadCount: 0,
+    incompleteCount: 0,
+    highPriorityCount: 0,
+    onlineAgentCount: 0,
+    lastActivityAt: '2026-07-03T08:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('groupMailboxEvents', () => {
+  it('returns an empty list when both snapshot and events are empty', () => {
+    const result = groupMailboxEvents(null, []);
+    expect(result.projects).toEqual([]);
+    expect(result.hasAnyActivity).toBe(false);
+  });
+
+  it('seeds counters from the snapshot aggregate and renders its message list', () => {
+    const snapshot = {
+      mailboxes: [
+        mailboxSummaryRecord('demo', {
+          messageCount: 2,
+          unreadCount: 1,
+          incompleteCount: 2,
+          highPriorityCount: 1,
+          onlineAgentCount: 3,
+        }),
+      ],
+    };
+    const m1 = messageSummary({
+      mailId: 'm1',
+      messageId: 'm1',
+      priority: 'high',
+      subject: 'urgent',
+    });
+    const m2 = messageSummary({ mailId: 'm2', messageId: 'm2', subject: 'normal' });
+    const events: HqEventEnvelope[] = [mailboxSnapshot('demo', [m1, m2])];
+
+    const { projects, hasAnyActivity } = groupMailboxEvents(snapshot, events);
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.projectId).toBe('demo');
+    expect(projects[0]?.highPriorityCount).toBe(1);
+    expect(projects[0]?.unreadCount).toBe(1);
+    expect(projects[0]?.incompleteCount).toBe(2);
+    expect(projects[0]?.onlineAgentCount).toBe(3);
+    expect(projects[0]?.countersFromSnapshot).toBe(true);
+    expect(projects[0]?.messages.map((m) => m.message.mailId)).toEqual(['m1', 'm2']);
+    expect(hasAnyActivity).toBe(true);
+  });
+
+  it('groups messages from multiple projects independently', () => {
+    const events: HqEventEnvelope[] = [
+      mailboxEvent(
+        'a',
+        messageSummary({ mailId: 'a', messageId: 'a', from: 'x', subject: 'A' }),
+        'proj-a',
+        1,
+      ),
+      mailboxEvent(
+        'b',
+        messageSummary({ mailId: 'b', messageId: 'b', from: 'y', subject: 'B' }),
+        'proj-b',
+        1,
+      ),
+      mailboxEvent(
+        'c',
+        messageSummary({ mailId: 'c', messageId: 'c', from: 'z', subject: 'C' }),
+        'proj-a',
+        2,
+      ),
+    ];
+    const { projects } = groupMailboxEvents(null, events);
+    expect(projects).toHaveLength(2);
+    const projA = projects.find((p) => p.projectId === 'proj-a');
+    const projB = projects.find((p) => p.projectId === 'proj-b');
+    expect(projA?.messages.map((m) => m.message.mailId).sort()).toEqual(['a', 'c']);
+    expect(projB?.messages.map((m) => m.message.mailId)).toEqual(['b']);
+  });
+
+  it('dedupes by mailId when the same message arrives via snapshot AND event', () => {
+    const m = messageSummary({
+      mailId: 'dup',
+      messageId: 'dup',
+      timestamp: '2026-07-03T08:00:00.000Z',
+    });
+    const fresh = messageSummary({
+      mailId: 'dup',
+      messageId: 'dup',
+      timestamp: '2026-07-03T09:00:00.000Z',
+    });
+    const events: HqEventEnvelope[] = [
+      mailboxSnapshot('demo', [m]),
+      mailboxEvent('dup', fresh, 'demo', 1),
+    ];
+    const { projects } = groupMailboxEvents(null, events);
+    expect(projects[0]?.messages).toHaveLength(1);
+    expect(projects[0]?.messages[0]?.source).toBe('event');
+    expect(projects[0]?.messages[0]?.message.timestamp).toBe('2026-07-03T09:00:00.000Z');
+  });
+
+  it('keeps only the first event when the same mailId arrives twice via events', () => {
+    const a = messageSummary({
+      mailId: 'same',
+      messageId: 'same',
+      timestamp: '2026-07-03T08:00:00.000Z',
+    });
+    const b = messageSummary({
+      mailId: 'same',
+      messageId: 'same',
+      timestamp: '2026-07-03T09:00:00.000Z',
+    });
+    const events: HqEventEnvelope[] = [
+      mailboxEvent('same', a, 'demo', 1),
+      mailboxEvent('same', b, 'demo', 2),
+    ];
+    const { projects } = groupMailboxEvents(null, events);
+    expect(projects[0]?.messages).toHaveLength(1);
+    // First-seen wins within the event stream (mailIndex dedupe is one-shot).
+    expect(projects[0]?.messages[0]?.message.timestamp).toBe('2026-07-03T08:00:00.000Z');
+  });
+
+  it('sorts messages newest-first within each project', () => {
+    const old = messageSummary({
+      mailId: 'old',
+      messageId: 'old',
+      timestamp: '2026-07-03T07:00:00.000Z',
+      subject: 'old',
+    });
+    const mid = messageSummary({
+      mailId: 'mid',
+      messageId: 'mid',
+      timestamp: '2026-07-03T08:00:00.000Z',
+      subject: 'mid',
+    });
+    const fresh = messageSummary({
+      mailId: 'fresh',
+      messageId: 'fresh',
+      timestamp: '2026-07-03T09:00:00.000Z',
+      subject: 'fresh',
+    });
+    const events: HqEventEnvelope[] = [
+      mailboxEvent('old', old, 'demo', 1),
+      mailboxEvent('fresh', fresh, 'demo', 2),
+      mailboxEvent('mid', mid, 'demo', 3),
+    ];
+    const { projects } = groupMailboxEvents(null, events);
+    expect(projects[0]?.messages.map((m) => m.message.subject)).toEqual(['fresh', 'mid', 'old']);
+  });
+
+  it('sorts projects by their newest message timestamp', () => {
+    const events: HqEventEnvelope[] = [
+      mailboxEvent(
+        'a-old',
+        messageSummary({
+          mailId: 'a-old',
+          messageId: 'a-old',
+          timestamp: '2026-07-03T07:00:00.000Z',
+        }),
+        'proj-a',
+        1,
+      ),
+      mailboxEvent(
+        'b-new',
+        messageSummary({
+          mailId: 'b-new',
+          messageId: 'b-new',
+          timestamp: '2026-07-03T10:00:00.000Z',
+        }),
+        'proj-b',
+        1,
+      ),
+      mailboxEvent(
+        'a-new',
+        messageSummary({
+          mailId: 'a-new',
+          messageId: 'a-new',
+          timestamp: '2026-07-03T09:00:00.000Z',
+        }),
+        'proj-a',
+        2,
+      ),
+    ];
+    const { projects } = groupMailboxEvents(null, events);
+    expect(projects.map((p) => p.projectId)).toEqual(['proj-b', 'proj-a']);
+  });
+
+  it('ignores events of unrelated types', () => {
+    const ok = messageSummary({ mailId: 'ok', messageId: 'ok' });
+    const events: HqEventEnvelope[] = [
+      mailboxEvent('ok', ok, 'demo', 1),
+      // Unrelated event types must not pollute the grouping.
+      {
+        id: 'evt-other-1',
+        type: 'brain.event',
+        schemaVersion: 1,
+        timestamp: '2026-07-03T08:00:00.000Z',
+        clientId: 'client',
+        projectId: 'demo',
+        seq: 2,
+        payload: { kind: 'decision_requested', at: Date.now() },
+      },
+      {
+        id: 'evt-other-2',
+        type: 'fleet.snapshot',
+        schemaVersion: 1,
+        timestamp: '2026-07-03T08:00:00.000Z',
+        clientId: 'client',
+        projectId: 'demo',
+        seq: 3,
+        payload: {
+          runId: 'r1',
+          activeSubagents: 0,
+          queuedTasks: 0,
+          completedTasks: 0,
+          failedTasks: 0,
+          subagents: [],
+        },
+      },
+    ];
+    const { projects, hasAnyActivity } = groupMailboxEvents(null, events);
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.messages.map((m) => m.message.mailId)).toEqual(['ok']);
+    expect(hasAnyActivity).toBe(true);
+  });
+
+  it('skips mailbox.event envelopes with malformed payloads without crashing', () => {
+    const good = messageSummary({ mailId: 'good', messageId: 'good' });
+    const events: HqEventEnvelope[] = [
+      mailboxEvent('good', good, 'demo', 1),
+      {
+        id: 'evt-malformed',
+        type: 'mailbox.event',
+        schemaVersion: 1,
+        timestamp: '2026-07-03T08:00:00.000Z',
+        clientId: 'client',
+        projectId: 'demo',
+        seq: 2,
+        payload: { unrelated: true },
+      },
+    ];
+    const { projects } = groupMailboxEvents(null, events);
+    expect(projects[0]?.messages).toHaveLength(1);
+    expect(projects[0]?.messages[0]?.message.mailId).toBe('good');
+  });
+
+  it('derives counters from messages when no snapshot aggregate is present', () => {
+    const events: HqEventEnvelope[] = [
+      mailboxEvent(
+        'h',
+        messageSummary({ mailId: 'h', messageId: 'h', priority: 'high' }),
+        'demo',
+        1,
+      ),
+      mailboxEvent('u', messageSummary({ mailId: 'u', messageId: 'u' }), 'demo', 2),
+      mailboxEvent(
+        'd',
+        messageSummary({ mailId: 'd', messageId: 'd', completed: true }),
+        'demo',
+        3,
+      ),
+    ];
+    const { projects } = groupMailboxEvents(null, events);
+    expect(projects[0]?.highPriorityCount).toBe(1);
+    // Both 'h' and 'u' are incomplete, 'd' is completed → 2 incomplete.
+    expect(projects[0]?.incompleteCount).toBe(2);
+    // 'h' and 'u' both have readCount=0 (default) → 2 unread.
+    expect(projects[0]?.unreadCount).toBe(2);
+    expect(projects[0]?.countersFromSnapshot).toBe(false);
+  });
+
+  it('keeps snapshot counters authoritative even when detail messages overlap', () => {
+    // Snapshot says: 5 high-priority, 4 incomplete. Only one of those
+    // messages has streamed via mailbox.event, but we must NOT derive
+    // counters from it and overwrite the snapshot's totals.
+    const snapshot = {
+      mailboxes: [
+        mailboxSummaryRecord('demo', {
+          messageCount: 5,
+          unreadCount: 2,
+          incompleteCount: 4,
+          highPriorityCount: 5,
+          onlineAgentCount: 1,
+        }),
+      ],
+    };
+    const events: HqEventEnvelope[] = [
+      mailboxEvent(
+        'one',
+        messageSummary({ mailId: 'one', messageId: 'one', priority: 'high' }),
+        'demo',
+        1,
+      ),
+    ];
+    const { projects } = groupMailboxEvents(snapshot, events);
+    expect(projects[0]?.highPriorityCount).toBe(5);
+    expect(projects[0]?.incompleteCount).toBe(4);
+    expect(projects[0]?.unreadCount).toBe(2);
+    expect(projects[0]?.countersFromSnapshot).toBe(true);
+  });
+
+  it('treats agent.online mailbox events as online-agent count bumps (snapshot absent)', () => {
+    const events: HqEventEnvelope[] = [
+      {
+        id: 'evt-agent-1',
+        type: 'mailbox.event',
+        schemaVersion: 1,
+        timestamp: '2026-07-03T08:00:00.000Z',
+        clientId: 'client',
+        projectId: 'demo',
+        seq: 1,
+        payload: {
+          mailboxId: 'demo:mailbox',
+          action: 'agent.registered',
+          agent: {
+            agentId: 'a1',
+            name: 'worker-1',
+            sessionId: 'sess-1',
+            status: 'running',
+            iterations: 0,
+            toolCalls: 0,
+            lastActivityAt: '2026-07-03T08:00:00.000Z',
+            lastSeenAt: '2026-07-03T08:00:00.000Z',
+            online: true,
+          },
+        },
+      },
+      {
+        id: 'evt-agent-2',
+        type: 'mailbox.event',
+        schemaVersion: 1,
+        timestamp: '2026-07-03T08:00:01.000Z',
+        clientId: 'client',
+        projectId: 'demo',
+        seq: 2,
+        payload: {
+          mailboxId: 'demo:mailbox',
+          action: 'agent.offline',
+          agent: {
+            agentId: 'a1',
+            name: 'worker-1',
+            sessionId: 'sess-1',
+            status: 'offline',
+            iterations: 0,
+            toolCalls: 0,
+            lastActivityAt: '2026-07-03T08:00:01.000Z',
+            lastSeenAt: '2026-07-03T08:00:01.000Z',
+            online: false,
+          },
+        },
+      },
+    ];
+    const { projects } = groupMailboxEvents(null, events);
+    // Only the online=true event should bump the count.
+    expect(projects[0]?.onlineAgentCount).toBe(1);
+  });
+
+  it('returns hasAnyActivity=true only when at least one group has messages', () => {
+    // Snapshot tells us about a project, but no detail events have streamed.
+    const snapshot = {
+      mailboxes: [mailboxSummaryRecord('demo', { messageCount: 5 })],
+    };
+    const { hasAnyActivity } = groupMailboxEvents(snapshot, []);
+    expect(hasAnyActivity).toBe(false);
+  });
+});

--- a/scripts/smoke-hq-mailbox.mts
+++ b/scripts/smoke-hq-mailbox.mts
@@ -98,7 +98,10 @@ async function main(): Promise<void> {
         return null;
       }
     })
-    .filter((f): f is { type: string; event?: any } => f !== null && typeof f === 'object')
+    .filter(
+      (f): f is { type: string; event?: { type: string; payload: unknown } } =>
+        f !== null && typeof f === 'object',
+    )
     .filter(
       (f) =>
         f.event !== undefined &&

--- a/scripts/smoke-hq-mailbox.mts
+++ b/scripts/smoke-hq-mailbox.mts
@@ -1,0 +1,129 @@
+/* Smoke test for HQ mailbox event payload shape.
+ * Spawns a GlobalMailbox wired to an HqPublisher, sends a few messages,
+ * and prints the resulting mailbox.event / mailbox.snapshot envelopes
+ * so we can confirm what the browser would receive over the WS. */
+import { tmpdir } from 'node:os';
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { GlobalMailbox } from '../packages/core/dist/coordination/index.js';
+import { HqPublisher, type HqSocketLike } from '../packages/core/dist/hq/index.js';
+
+function makeMockSocket(): { socket: HqSocketLike; sent: string[] } {
+  const sent: string[] = [];
+  const listeners: Record<string, Array<(ev: unknown) => void>> = {
+    open: [],
+    close: [],
+    error: [],
+    message: [],
+  };
+  const socket: HqSocketLike = {
+    readyState: 0,
+    send(data: string): void {
+      sent.push(data);
+    },
+    close(): void {},
+    addEventListener(type, listener): void {
+      listeners[type]?.push(listener);
+    },
+  };
+  // Simulate WebSocket OPEN immediately.
+  setImmediate(() => {
+    socket.readyState = 1;
+    for (const l of listeners.open) l({});
+  });
+  return { socket, sent };
+}
+
+async function main(): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'hq-mailbox-smoke-'));
+  const { socket, sent } = makeMockSocket();
+  const publisher = new HqPublisher({
+    url: 'http://127.0.0.1:1',
+    client: {
+      clientId: 'smoke',
+      kind: 'cli',
+      machineId: 'm1',
+      startedAt: new Date().toISOString(),
+    },
+    project: {
+      projectId: 'demo',
+      projectRoot: dir,
+      projectName: 'demo',
+      machineId: 'm1',
+      workspaceKind: 'directory',
+    },
+    socketFactory: () => socket,
+    reconnect: false,
+    redactionPolicy: { rawContent: true, toolArgs: 'summary', paths: 'project-relative' },
+  });
+  publisher.connect();
+
+  // Wait for the open + hello handshake to flush.
+  await new Promise((r) => setTimeout(r, 50));
+
+  const m = new GlobalMailbox(dir, undefined, () => publisher);
+  await m.send({
+    from: 'leader',
+    to: '*',
+    type: 'status',
+    subject: 'Hello HQ',
+    body: 'Smoke test message body with details',
+    priority: 'high',
+  });
+  await m.send({
+    from: 'leader',
+    to: 'worker',
+    type: 'assign',
+    subject: 'Build feature',
+    body: 'Implement the new endpoint',
+    priority: 'normal',
+  });
+  await m.send({
+    from: 'worker',
+    to: 'leader',
+    type: 'result',
+    subject: 'Re: Build feature',
+    body: 'Done',
+    priority: 'normal',
+  });
+
+  // Allow async snapshot publishes to flush.
+  await new Promise((r) => setTimeout(r, 50));
+
+  const frames = sent
+    .map((s) => {
+      try {
+        return JSON.parse(s);
+      } catch {
+        return null;
+      }
+    })
+    .filter((f): f is { type: string; event?: any } => f !== null && typeof f === 'object')
+    .filter(
+      (f) =>
+        f.event !== undefined &&
+        (f.event.type === 'mailbox.event' || f.event.type === 'mailbox.snapshot'),
+    )
+    .map((f) => ({
+      type: f.event.type,
+      action: f.event.payload.action,
+      mailboxId: f.event.payload.mailboxId,
+      message: f.event.payload.message
+        ? {
+            from: f.event.payload.message.from,
+            to: f.event.payload.message.to,
+            subject: f.event.payload.message.subject,
+            type: f.event.payload.message.type,
+            priority: f.event.payload.message.priority,
+            bodyPreview: f.event.payload.message.bodyPreview,
+            hasBody: f.event.payload.message.hasBody,
+          }
+        : undefined,
+    }));
+  console.log(JSON.stringify({ count: frames.length, frames }, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Replaces the aggregate-only counters in the HQ `MailboxView` with a per-project feed that streams every `mailbox.event` envelope (subject, bodyPreview, from, to, type, priority, timestamp, task context) and groups them by `projectId`. Snapshot aggregates still seed the counters; live events feed the detail rows.

## Changes

- **`packages/webui-hq/src/views/mailbox-grouping.ts`** (new): pure `groupMailboxEvents(snapshot, events)` helper that does project grouping, mailId dedup, and newest-first sort. Extracted out of the React component so it can be unit-tested without jsdom.
- **`packages/webui-hq/src/views/mailbox.tsx`** (refactor): `MailboxView` now renders one `ProjectSection` per projectId with a collapsible list of `MessageRow` entries. Subject + from/to + type pill + priority pill + open/completed flag are always visible; the full bodyPreview + outcomePreview + meta line expand on click.
- **`packages/webui-hq/src/app.css`**: `.hq-toggle` + `.hq-msg*` styles for the new feed rows (preserves the existing single-line formatting in the rest of the file).
- **`packages/webui-hq/tests/mailbox-grouping.test.ts`** (new, 13 tests): covers grouping, dedup (snapshot+event, event+event), newest-first sort, unrelated-event filtering, malformed-payload tolerance, and the snapshot-counters-are-authoritative invariant.
- **`scripts/smoke-hq-mailbox.mts`** (new): mock-socket smoke that prints the exact `mailbox.event` / `mailbox.snapshot` envelopes a browser would receive over the WS.

## Bug fix

Snapshot counters and event counters were both incremented when the same mailId arrived via both planes — inflating unread/incomplete/high-priority totals on every reconnect. Snapshot totals are now the authoritative source; counters are only derived from visible messages when no snapshot is present.

## Verification

- `vitest run packages/webui-hq/tests`: **13/13 passed** (`packages/webui-hq/tests/mailbox-grouping.test.ts`)
- `pnpm -C packages/webui-hq run typecheck`: clean
- `pnpm -C packages/webui-hq run build`: clean (41 modules, 527 ms, 5.87 kB CSS + 212.65 kB JS)
- `biome lint`: clean (0 errors / 0 warnings on the changed files)
- `pnpm exec tsx scripts/smoke-hq-mailbox.mts`: prints 6 envelopes (3 send + 3 snapshot) with correct payload shape

Diffstat: **5 files changed, 1130 insertions(+), 24 deletions(-)**