### PR TITLE
feat(hq-mailbox): live feed UI skeleton (phase 1-3)

### DIFF
--- a/packages/webui-hq/src/views/mailbox-filters.ts
+++ b/packages/webui-hq/src/views/mailbox-filters.ts
@@ -1,0 +1,92 @@
+/**
+ * Live feed filter state + reducer (skeleton).
+ *
+ * Phase 1 skeleton: declares the `MailboxLiveFilterState` shape and
+ * the action types. Phase 3+ will wire this into a React reducer
+ * (or `useState` + helpers) and feed it to
+ * {@link buildLiveFeedFromHq}.
+ *
+ * Keeping the state shape here — separate from the React component —
+ * means we can unit-test the reducer logic without jsdom, mirroring
+ * the pattern set by `mailbox-grouping.test.ts`.
+ */
+import type { HqMailboxMessageType, HqMailboxPriority } from '@wrongstack/core';
+
+export interface MailboxLiveFilterState {
+  /** Selected message types. Empty = all types. */
+  readonly types: ReadonlySet<HqMailboxMessageType>;
+  /** Selected priority levels. Empty = all priorities. */
+  readonly priorities: ReadonlySet<HqMailboxPriority>;
+  /** Selected project ids. Empty = all projects. */
+  readonly projectIds: ReadonlySet<string>;
+  /** When false, completed messages are hidden. */
+  includeCompleted: boolean;
+  /** Free-text search (subject/from/to/bodyPreview). */
+  query: string;
+}
+
+export const EMPTY_LIVE_FILTER_STATE: MailboxLiveFilterState = Object.freeze({
+  types: new Set<HqMailboxMessageType>(),
+  priorities: new Set<HqMailboxPriority>(),
+  projectIds: new Set<string>(),
+  includeCompleted: true,
+  query: '',
+});
+
+/**
+ * Action union for the live-feed filter reducer. Each action is a
+ * minimal descriptor — the reducer copies the relevant Set rather
+ * than mutating in place so React's reference-equality check fires
+ * correctly on a state change.
+ */
+export type MailboxLiveFilterAction =
+  | { type: 'toggle-type'; value: HqMailboxMessageType }
+  | { type: 'toggle-priority'; value: HqMailboxPriority }
+  | { type: 'toggle-project'; value: string }
+  | { type: 'set-query'; value: string }
+  | { type: 'set-include-completed'; value: boolean }
+  | { type: 'clear-all' };
+
+/**
+ * Pure reducer. Skeleton — body is intentionally minimal so the
+ * Phase 1 commit stays a refactor-free, drop-in module. The full
+ * transition table (with immutable Set updates) lands in Phase 3
+ * when the UI is wired up.
+ */
+export function mailboxLiveFilterReducer(
+  state: MailboxLiveFilterState,
+  action: MailboxLiveFilterAction,
+): MailboxLiveFilterState {
+  switch (action.type) {
+    case 'toggle-type': {
+      const next = new Set(state.types);
+      if (next.has(action.value)) next.delete(action.value);
+      else next.add(action.value);
+      return { ...state, types: next };
+    }
+    case 'toggle-priority': {
+      const next = new Set(state.priorities);
+      if (next.has(action.value)) next.delete(action.value);
+      else next.add(action.value);
+      return { ...state, priorities: next };
+    }
+    case 'toggle-project': {
+      const next = new Set(state.projectIds);
+      if (next.has(action.value)) next.delete(action.value);
+      else next.add(action.value);
+      return { ...state, projectIds: next };
+    }
+    case 'set-query':
+      return { ...state, query: action.value };
+    case 'set-include-completed':
+      return { ...state, includeCompleted: action.value };
+    case 'clear-all':
+      return EMPTY_LIVE_FILTER_STATE;
+    default: {
+      // Exhaustiveness — adding a new action without updating the
+      // reducer is a compile-time error.
+      const _exhaustive: never = action;
+      return state;
+    }
+  }
+}

--- a/packages/webui-hq/src/views/mailbox-live-view.tsx
+++ b/packages/webui-hq/src/views/mailbox-live-view.tsx
@@ -1,0 +1,94 @@
+/**
+ * Live mailbox feed view (skeleton).
+ *
+ * Phase 3 skeleton: declares the `LiveMailboxView` React component
+ * signature, wires it to the existing pure helpers
+ * (`groupMailboxEvents` + `buildLiveFeedFromHq`), and renders a
+ * minimal placeholder list. Phase 4+ will add the filter bar UI,
+ * the virtualised scroll, and the new-event highlight.
+ *
+ * Keeping the view in its own file (vs. inside `mailbox.tsx`) means
+ * the view-mode toggle in `mailbox.tsx` is a one-line import swap
+ * when both views are wired up in Phase 5.
+ */
+
+import type { HqEventEnvelope, HqSnapshot } from '@wrongstack/core';
+import type React from 'react';
+import { useMemo, useReducer } from 'react';
+import { useHqStore } from '../store.js';
+import { EMPTY_LIVE_FILTER_STATE, mailboxLiveFilterReducer } from './mailbox-filters.js';
+import { buildLiveFeedFromHq } from './mailbox-live.js';
+import { MessageRow } from './mailbox-row.js';
+
+export interface LiveMailboxViewProps {
+  /** Optional injected snapshot for unit tests. */
+  snapshot?: Pick<HqSnapshot, 'mailboxes'> | null | undefined;
+  /** Optional injected event stream for unit tests. */
+  events?: readonly HqEventEnvelope[] | undefined;
+}
+
+export function LiveMailboxView({
+  snapshot: snapshotOverride,
+  events: eventsOverride,
+}: LiveMailboxViewProps = {}): React.ReactElement {
+  // When called from the unified `mailbox.tsx` view, prefer the live
+  // HQ store. When called from a unit test, the caller passes the
+  // snapshot + events explicitly so we don't need a provider.
+  const store = useHqStore();
+  const snapshot = snapshotOverride !== undefined ? snapshotOverride : store.snapshot;
+  const events = eventsOverride !== undefined ? eventsOverride : store.events;
+
+  const [filters, dispatch] = useReducer(mailboxLiveFilterReducer, EMPTY_LIVE_FILTER_STATE);
+
+  const feed = useMemo(
+    () =>
+      buildLiveFeedFromHq(snapshot ?? null, events, {
+        types: Array.from(filters.types),
+        priorities: Array.from(filters.priorities),
+        projectIds: Array.from(filters.projectIds),
+        includeCompleted: filters.includeCompleted,
+        query: filters.query || undefined,
+        limit: 500,
+      }),
+    [snapshot, events, filters],
+  );
+
+  // Skeleton render: just the row list. Phase 4 adds the filter bar
+  // and the virtualised scroll. The "showing N of M" hint is
+  // already wired because `feed.truncated` is the live signal.
+  return (
+    <div>
+      <div className="hq-card-title">
+        Live mailbox feed · {feed.returned} of {feed.totalMatched} message
+        {feed.totalMatched === 1 ? '' : 's'}
+        {feed.truncated ? ' · refined to fit' : ''}
+      </div>
+      {feed.entries.length === 0 ? (
+        <div className="hq-empty">No mailbox activity matches the current filters.</div>
+      ) : (
+        <div className="hq-msg-list">
+          {feed.entries.map((e) => (
+            <MessageRow key={e.key} flat={e.flat} />
+          ))}
+        </div>
+      )}
+      {/* Filter controls land in Phase 4. The reducer wiring is
+          already here so the next phase only has to add the JSX.
+          The button below is a skeleton so the dispatch reference is
+          live (and so users can see the toggle is wired). Phase 4 will
+          replace it with the real filter bar. */}
+      <div className="hq-card-title" style={{ display: 'flex', gap: 8 }}>
+        <button
+          type="button"
+          className="hq-btn secondary"
+          onClick={() => dispatch({ type: 'clear-all' })}
+        >
+          Clear filters (skeleton)
+        </button>
+      </div>
+      <noscript>
+        Filter controls require JavaScript. The skeleton above shows the full unfiltered timeline.
+      </noscript>
+    </div>
+  );
+}

--- a/packages/webui-hq/src/views/mailbox-row.tsx
+++ b/packages/webui-hq/src/views/mailbox-row.tsx
@@ -1,0 +1,50 @@
+/**
+ * Shared message row component (skeleton).
+ *
+ * Phase 2 skeleton: a placeholder that accepts the same `flat`
+ * prop the current `MessageRow` in `mailbox.tsx` takes, so the
+ * view-mode toggle in Phase 5 can swap the two views without
+ * changing the row markup. The full row render (icon + subject +
+ * from→to + body preview + meta line) lands in Phase 4 — for now
+ * the component just renders the subject so the build is green
+ * and the integration site is obvious.
+ *
+ * Keeping the row as its own file means the grouped view and the
+ * live view share the exact same message markup, so a tweak to
+ * how (e.g.) a "high priority" indicator is shown applies to both
+ * at once.
+ */
+import type React from 'react';
+import { useState } from 'react';
+import type { FlatMessage } from './mailbox-grouping.js';
+import { formatMailboxTime, shortMailboxId } from './mailbox-time.js';
+import { MAILBOX_TYPE_LABEL } from './mailbox-types.js';
+
+export interface MessageRowProps {
+  flat: FlatMessage;
+  /** Open the body on first render (default: collapsed). */
+  defaultExpanded?: boolean | undefined;
+}
+
+export function MessageRow({ flat, defaultExpanded }: MessageRowProps): React.ReactElement {
+  const [open, setOpen] = useState(Boolean(defaultExpanded));
+  const m = flat.message;
+  const typeMeta = MAILBOX_TYPE_LABEL[m.type] ?? { icon: '✉️', tone: 'info' };
+
+  // Skeleton render — the real row (subject + from→to + body + meta) is
+  // added in Phase 4. For now we render a minimal placeholder so the
+  // build is green and Phase 5 (view-mode toggle) has something to
+  // call.
+  return (
+    <div className="hq-msg" onClick={() => setOpen((v) => !v)}>
+      <span className="hq-msg-icon" title={m.type}>
+        {typeMeta.icon}
+      </span>
+      <span className="hq-pill">{m.type}</span>
+      <span className="hq-msg-subject">{m.subject || '(no subject)'}</span>
+      <span className="hq-mono hq-msg-time">{formatMailboxTime(m.timestamp)}</span>
+      <span className="hq-mono hq-msg-id">{shortMailboxId(m.messageId)}</span>
+      {open ? <div className="hq-msg-body">{m.bodyPreview ?? '(no body)'}</div> : null}
+    </div>
+  );
+}

--- a/packages/webui-hq/src/views/mailbox-time.ts
+++ b/packages/webui-hq/src/views/mailbox-time.ts
@@ -1,0 +1,52 @@
+/**
+ * Time / id formatting helpers shared by both mailbox views.
+ *
+ * The formatting rules here are deliberately simple — the TUI uses
+ * a different locale than the WebUI does, and a UI change here
+ * affects every message row in both views, so we keep the contract
+ * small and explicit.
+ */
+
+const MS_PER_SECOND = 1000;
+
+/**
+ * Render an ISO 8601 timestamp as a localised string. Falls back to
+ * the raw string on parse failure (which keeps the UI usable even
+ * when a client sends a malformed timestamp).
+ */
+export function formatMailboxTime(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts;
+  return d.toLocaleString();
+}
+
+/**
+ * Return a compact, human-readable version of the elapsed time since
+ * `ts`, suitable for "5m ago" / "2h ago" placeholders. Returns the
+ * full timestamp string if the input is unparseable.
+ *
+ * Buckets (seconds → minutes → hours → days → weeks → months → years)
+ * trade absolute precision for readability on a small status-bar chip.
+ */
+export function formatRelativeTime(ts: string, now: number = Date.now()): string {
+  const t = new Date(ts).getTime();
+  if (Number.isNaN(t)) return ts;
+  const diff = Math.max(0, now - t) / MS_PER_SECOND;
+  if (diff < 60) return `${Math.round(diff)}s ago`;
+  if (diff < 60 * 60) return `${Math.round(diff / 60)}m ago`;
+  if (diff < 60 * 60 * 24) return `${Math.round(diff / 3600)}h ago`;
+  if (diff < 60 * 60 * 24 * 7) return `${Math.round(diff / 86400)}d ago`;
+  if (diff < 60 * 60 * 24 * 30) return `${Math.round(diff / 604800)}w ago`;
+  if (diff < 60 * 60 * 24 * 365) return `${Math.round(diff / 2592000)}mo ago`;
+  return `${Math.round(diff / 31536000)}y ago`;
+}
+
+/**
+ * Truncate a long id/UUID to a 14-char "xxxxxxxx…xxxx" form for
+ * display. Identifiers shorter than or equal to 14 chars are returned
+ * verbatim — the ellipsis would only add noise.
+ */
+export function shortMailboxId(s: string): string {
+  if (s.length <= 14) return s;
+  return `${s.slice(0, 8)}…${s.slice(-4)}`;
+}

--- a/packages/webui-hq/src/views/mailbox-types.ts
+++ b/packages/webui-hq/src/views/mailbox-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared mailbox type/label/icon mapping.
+ *
+ * Extracted from `mailbox.tsx` so both the grouped view and the live
+ * feed can render the same metadata. Keeping the map in one place
+ * means a new message type added to `@wrongstack/core` only needs to
+ * be added here (and tests will catch the missing entry).
+ *
+ * This is a leaf module — no React, no state. It depends only on the
+ * core types so it can be unit-tested with vitest.
+ */
+import type { HqMailboxMessageType } from '@wrongstack/core';
+
+export interface MailboxTypeMeta {
+  icon: string;
+  /** CSS class suffix used in the `.hq-pill` family (see app.css). */
+  tone: 'info' | 'warn' | 'running' | 'idle' | 'error';
+}
+
+export const MAILBOX_TYPE_LABEL: Record<HqMailboxMessageType, MailboxTypeMeta> = {
+  note: { icon: '📝', tone: 'info' },
+  ask: { icon: '❓', tone: 'warn' },
+  assign: { icon: '📌', tone: 'warn' },
+  steer: { icon: '🛞', tone: 'warn' },
+  btw: { icon: '💬', tone: 'info' },
+  broadcast: { icon: '📣', tone: 'info' },
+  status: { icon: '📊', tone: 'idle' },
+  result: { icon: '✅', tone: 'running' },
+  review: { icon: '🔍', tone: 'info' },
+  control: { icon: '⚙️', tone: 'error' },
+};
+
+export const ALL_MAILBOX_TYPES: readonly HqMailboxMessageType[] = Object.keys(
+  MAILBOX_TYPE_LABEL,
+) as readonly HqMailboxMessageType[];


### PR DESCRIPTION
feat(hq-mailbox): live feed UI skeleton (phase 1-3)

Skeleton layer for the upcoming "Live" mode in `MailboxView`. Wires
the existing pure helper `buildLiveFeedFromHq` (merged in PR #187)
to a new React component, with the filter state, time/id helpers,
and shared message row factored out so the grouped view can also
use them.

This is deliberately a thin skeleton — no filter bar UI, no
virtualised scroll, no view-mode toggle in `mailbox.tsx` yet. Those
land in Phase 4-7. The point of this commit is to give the next
phase a single landing site for the new code so the diff in the
follow-up PRs stays reviewable.

Files
- `src/views/mailbox-types.ts` (new) — `MAILBOX_TYPE_LABEL` +
  `ALL_MAILBOX_TYPES`. Extracted from the inline `TYPE_LABEL` map in
  `mailbox.tsx` so both views share it.
- `src/views/mailbox-time.ts` (new) — `formatMailboxTime`,
  `formatRelativeTime`, `shortMailboxId`. Extracted from
  `mailbox.tsx` and adds a relative-time formatter that the live
  view will use for "5m ago" chips.
- `src/views/mailbox-filters.ts` (new) — `MailboxLiveFilterState`,
  `MailboxLiveFilterAction`, `mailboxLiveFilterReducer`,
  `EMPTY_LIVE_FILTER_STATE`. Pure reducer, no React. Phase 4 will
  wire the action types into a filter bar UI.
- `src/views/mailbox-row.tsx` (new) — `MessageRow` extracted from
  `mailbox.tsx`. Same `FlatMessage` prop the existing row takes;
  the placeholder body shows the body preview on click so the
  shape is obvious. The full row markup (with the body, meta line,
  and reply-to / read-count / task status pills) is refactored in
  Phase 4.
- `src/views/mailbox-live-view.tsx` (new) — `LiveMailboxView`
  React component. Wires `useHqStore` to
  `buildLiveFeedFromHq(snapshot, events, filters)` with the filter
  reducer and a placeholder "Clear filters" button so the dispatch
  reference is live. Renders the list of `MessageRow` and the
  "N of M" hint. No filter bar UI yet — Phase 4.

Why skeleton first
- Single small commit keeps the diff reviewable. Each subsequent
  phase lands in its own commit, so bisecting later is easy.
- The shared modules (`mailbox-types.ts`, `mailbox-time.ts`,
  `mailbox-row.tsx`) double as the refactor target for the
  follow-up that moves the existing grouped view to share them.
- The reducer skeleton compiles, the type-checker is green, and
  the build still produces the same `dist/`. The Phase 1-3 commit
  is the safe "shape is right" landing.

Next steps (not in this commit; tracked separately)
- Phase 4: filter bar UI (type chips, priority chips, project
  selector, search input, completed toggle, "clear all"). Real
  filter dispatch from the filter chips into the reducer.
- Phase 5: virtualised scroll (`useVirtualList` + `VirtualList`).
- Phase 6: `MailboxView` split into `GroupedMailboxView` +
  `LiveMailboxView` with a view-mode toggle pill.
- Phase 7: refactor the existing `MessageRow` to share the
  extracted component + add the action buttons (mark-read, ack,
  delete) from the parallel `feat/hq-mailbox-message-actions`
  branch.

Verified locally
- `pnpm exec biome check` on the touched paths → clean
  (0 errors, 0 warnings) after `--write` auto-fixes.
- `pnpm exec tsc --noEmit` in `packages/webui-hq` → clean.