### PR TITLE
feat(mailbox): message actions (mark-read / acknowledge / soft-delete / restore)

### DIFF
--- a/packages/cli/src/slash-commands/next.ts
+++ b/packages/cli/src/slash-commands/next.ts
@@ -142,7 +142,7 @@ function handleSelection(
   if (suggestions.length === 0) {
     return {
       message: color.amber(
-        'No suggestions available. Run /suggest first, or enable prediction with /next on.',
+        'No suggestions available. Run /suggest to generate, or finish any open todos first — <next_steps> is suppressed while todos are pending.',
       ),
     };
   }

--- a/packages/core/src/coordination/global-mailbox.ts
+++ b/packages/core/src/coordination/global-mailbox.ts
@@ -18,11 +18,10 @@ import { randomUUID } from 'node:crypto';
 import * as fsp from 'node:fs/promises';
 
 import * as path from 'node:path';
+import type { HqPublisher } from '../hq/publisher.js';
+import type { EventBus } from '../kernel/events.js';
 import { withFileLock } from '../utils/atomic-write.js';
 import { projectSlug } from '../utils/wstack-paths.js';
-import { normalizeRecipient } from './mailbox-types.js';
-import type { EventBus } from '../kernel/events.js';
-import type { HqPublisher } from '../hq/publisher.js';
 import type {
   AgentHeartbeatInput,
   AgentRegistrationInput,
@@ -41,6 +40,7 @@ import type {
   RegisteredAgent,
   RegisteredClient,
 } from './mailbox-types.js';
+import { normalizeRecipient } from './mailbox-types.js';
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -236,6 +236,10 @@ export class GlobalMailbox implements Mailbox {
         continue;
       }
       if (q.since !== undefined && m.timestamp <= q.since) continue;
+      // Default behavior: soft-deleted messages are hidden unless the
+      // caller explicitly opts in via `includeDeleted: true` (used by
+      // the WebUI's "trash" view).
+      if (!q.includeDeleted && m.deletedAt !== undefined) continue;
       out.push(m);
     }
 
@@ -330,6 +334,78 @@ export class GlobalMailbox implements Mailbox {
       }
     }
     return count;
+  }
+
+  async softDelete(mailId: string, by: string): Promise<MailboxMessage | null> {
+    // Single-message soft delete. Acquires the file lock and writes
+    // the file with the matched message's `deletedAt` set. No-op if
+    // the message does not exist or is already soft-deleted (the
+    // second case is a successful no-op: returns the message with
+    // `deletedAt` unchanged).
+    let updated: MailboxMessage | null = null;
+    let cacheSnapshot: MailboxMessage[] | null = null;
+    await withFileLock(this.messagePath, async () => {
+      const all = await this._readMessagesFresh();
+      const now = new Date().toISOString();
+      for (const m of all) {
+        if (m.id !== mailId) continue;
+        if (m.deletedAt !== undefined) {
+          // Already soft-deleted — return the existing record so the
+          // caller can no-op cleanly. No event is published.
+          updated = m;
+          continue;
+        }
+        m.deletedAt = now;
+        m.deletedBy = by;
+        updated = m;
+      }
+      const serialized = all.map((m) => JSON.stringify(m)).join(LINE_SEPARATOR) + LINE_SEPARATOR;
+      await fsp.writeFile(this.messagePath, serialized, 'utf8');
+      cacheSnapshot = all;
+    });
+    if (cacheSnapshot) this._setMessageCache(cacheSnapshot);
+    if (updated !== null) {
+      this.publishHqMailboxEvent({
+        mailboxId: this.hqMailboxId,
+        action: 'message.updated',
+        message: updated,
+      });
+      this.publishHqMailboxSnapshot();
+    }
+    return updated;
+  }
+
+  async restore(mailId: string): Promise<MailboxMessage | null> {
+    // Inverse of `softDelete`. Clears `deletedAt` + `deletedBy` so the
+    // message reappears in the default `query()` result. No-op when
+    // the message exists but is not currently soft-deleted. Emits an
+    // event unconditionally so the WebUI can re-fetch the message
+    // (the duplicate-event cost is acceptable: the WebUI dedupes by
+    // `mailId`).
+    let updated: MailboxMessage | null = null;
+    let cacheSnapshot: MailboxMessage[] | null = null;
+    await withFileLock(this.messagePath, async () => {
+      const all = await this._readMessagesFresh();
+      for (const m of all) {
+        if (m.id !== mailId) continue;
+        delete m.deletedAt;
+        delete m.deletedBy;
+        updated = m;
+      }
+      const serialized = all.map((m) => JSON.stringify(m)).join(LINE_SEPARATOR) + LINE_SEPARATOR;
+      await fsp.writeFile(this.messagePath, serialized, 'utf8');
+      cacheSnapshot = all;
+    });
+    if (cacheSnapshot) this._setMessageCache(cacheSnapshot);
+    if (updated !== null) {
+      this.publishHqMailboxEvent({
+        mailboxId: this.hqMailboxId,
+        action: 'message.updated',
+        message: updated,
+      });
+      this.publishHqMailboxSnapshot();
+    }
+    return updated;
   }
 
   // ── Agent registry ──────────────────────────────────────────────────────

--- a/packages/core/src/coordination/index.ts
+++ b/packages/core/src/coordination/index.ts
@@ -1,197 +1,264 @@
 // Coordination domain: multi-agent orchestration, director, fleet bus, agents
+
 export {
-  BrainDecisionQueue,
-  DefaultBrainArbiter,
-  HumanEscalatingBrainArbiter,
-  ObservableBrainArbiter,
-  formatHumanPrompt,
+  createMessage,
+  InMemoryAgentBridge,
+  InMemoryBridgeTransport,
+} from './agent-bridge.js';
+export {
+  type AgentFactory,
+  type AgentFactoryResult,
+  type AgentRunnerOptions,
+  makeAgentSubagentRunner,
+  withDisabledToolFiltering,
+} from './agent-subagent-runner.js';
+export {
+  AGENT_CATALOG,
+  AGENTS_BY_PHASE,
+  type AgentBudgetTier,
+  type AgentCapability,
+  type AgentDefinition,
+  type AgentPhase,
+  ALL_AGENT_DEFINITIONS,
+  BUILD_AGENTS,
+  DELIVERY_AGENTS,
+  DISCOVERY_AGENTS,
+  DOMAIN_AGENTS,
+  getAgentDefinition,
+  HEAVY_BUDGET,
+  KNOWLEDGE_AGENTS,
+  LIGHT_BUDGET,
+  MEDIUM_BUDGET,
+  META_AGENTS,
+  PLANNING_AGENTS,
+  REVIEW_AGENTS,
+  TOOLS as AGENT_TOOL_PRESETS,
+  VERIFY_AGENTS,
+} from './agents/index.js';
+export {
+  type AutoExtendCeiling,
+  type AutoExtendPolicy,
+  attachAutoExtend,
+} from './auto-extend.js';
+export {
   type BrainArbiter,
   type BrainDecision,
   type BrainDecisionOption,
+  BrainDecisionQueue,
   type BrainDecisionRequest,
   type BrainDecisionSource,
   type BrainFallback,
   type BrainRisk,
+  DefaultBrainArbiter,
   type DefaultBrainArbiterOptions,
+  formatHumanPrompt,
+  HumanEscalatingBrainArbiter,
+  ObservableBrainArbiter,
 } from './brain.js';
 export {
+  type BrainInterventionInput,
+  BrainMonitor,
+  type BrainMonitorOptions,
+} from './brain-monitor.js';
+export {
+  type BugFinding,
+  type CollabBudgetConfig,
+  type CollabBudgetOverrides,
+  type CollabBudgetWarningPayload,
+  type CollabDebugReport,
+  CollabSession,
+  type CollabSessionOptions,
+  type CriticConcern,
+  type CriticEvaluation,
+  type DirectorAlert,
+  DirectorAlertLevel,
+  type DirectorCancelCollabPayload,
+  type RefactorPhase,
+  type RefactorPlan,
+  type SharedFileEntry,
+  type SharedFileSnapshot,
+} from './collab-debug.js';
+export {
+  type CreateDelegateToolOptions,
+  createDelegateTool,
+  type DelegateHost,
+} from './delegate-tool.js';
+// ── Dependency watcher — file-change → mailbox bridge ────────────────────
+export {
+  DEPENDENCY_FILE_PATTERNS,
+  type DependencyWatcherConfig,
+  type DepWatchEntry,
+  makeDependencyWatcherConfig,
+} from './dep-watcher.js';
+// ── Dependency watcher bridge — file-watcher events → mailbox ────────────
+export {
+  attachDepWatcherBridge,
+  type DepWatcherBridgeOptions,
+} from './dep-watcher-bridge.js';
+export {
   Director,
-  FleetSpawnBudgetError,
   FleetCostCapError,
+  FleetSpawnBudgetError,
 } from './director.js';
 export {
-  makeSpawnTool,
-  makeAssignTool,
-  makeAwaitTasksTool,
-  makeAskTool,
-  makeAskResultTool,
-  makeRollUpTool,
-  makeTerminateTool,
-  makeTerminateAllTool,
-  makeFleetTool,
-  makeCollabDebugTool,
-  makeFleetEmitTool,
-  makeWorkCompleteTool,
-} from './director-tools.js';
-
+  composeDirectorPrompt,
+  composeSubagentPrompt,
+  DEFAULT_DIRECTOR_PREAMBLE,
+  DEFAULT_SUBAGENT_BASELINE,
+  type DirectorPromptParts,
+  rosterSummaryFromConfigs,
+  type SubagentPromptParts,
+} from './director-prompts.js';
+export {
+  type DirectorSessionFactory,
+  type DirectorSessionFactoryOptions,
+  makeDirectorSessionFactory,
+} from './director-session.js';
 // Backward-compatible re-exports: the old per-fleet-signal tools were
 // consolidated into makeFleetTool. These aliases keep downstream imports
 // (defaults/index.ts, src/index.ts) working until they migrate.
 export {
+  makeAskResultTool,
+  makeAskTool,
+  makeAssignTool,
+  makeAwaitTasksTool,
+  makeCollabDebugTool,
+  makeFleetEmitTool,
+  makeFleetTool,
   makeFleetTool as makeFleetStatusTool,
   makeFleetTool as makeFleetUsageTool,
   makeFleetTool as makeFleetSessionTool,
   makeFleetTool as makeFleetHealthTool,
+  makeRollUpTool,
+  makeSpawnTool,
+  makeTerminateAllTool,
+  makeTerminateTool,
+  makeWorkCompleteTool,
 } from './director-tools.js';
-export { LargeAnswerStore } from './large-answer-store.js';
 export {
-  createDelegateTool,
-  type DelegateHost,
-  type CreateDelegateToolOptions,
-} from './delegate-tool.js';
+  DEFAULT_DISPATCH_ROLE,
+  type DispatchCandidate,
+  type DispatchClassifier,
+  type DispatchMethod,
+  type DispatchOptions,
+  type DispatchResult,
+  dispatchAgent,
+  makeLLMClassifier,
+  scoreAgents,
+} from './dispatcher.js';
 export {
-  DefaultMultiAgentCoordinator,
-  type MultiAgentCoordinatorOptions,
-} from './multi-agent-coordinator.js';
-export {
-  SubagentBudget,
-  BudgetExceededError,
-  BudgetThresholdSignal,
-  /** 0.85 — fraction of wall-clock `timeoutMs` at which the coordinator watchdog
-   * fires a PROACTIVE pre-empt (before deadline). Canonical source:
-   * `coordination/subagent-budget.ts`. Re-exported here so all budget symbols
-   * are accessible from one import path. */
-  TIMEOUT_PREEMPT_FRACTION,
-  /** 60 000 ms — hard safety net for budget negotiation decisions. Both the
-   * coordinator watchdog and SubagentBudget._negotiateExtension use this value
-   * so they agree on the decision window. Re-exported here so consumers of
-   * the coordination module can reference it without a sub-module import. */
-  DECISION_TIMEOUT_MS,
-} from './subagent-budget.js';
-export type {
-  BudgetNegotiationMode,
-  BudgetThresholdDecision,
-  BudgetThresholdHandler,
-  BudgetKind,
-  BudgetLimits,
-  BudgetUsage,
-} from './subagent-budget.js';
-export {
-  makeAgentSubagentRunner,
-  withDisabledToolFiltering,
-  type AgentFactory,
-  type AgentFactoryResult,
-  type AgentRunnerOptions,
-} from './agent-subagent-runner.js';
+  ACP_AGENTS,
+  ALL_FLEET_AGENTS,
+  AUDIT_LOG_AGENT,
+  applyRosterBudget,
+  BUG_HUNTER_AGENT,
+  FLEET_ROSTER,
+  FLEET_ROSTER_BUDGETS,
+  FLEET_ROSTER_WITHACP,
+  type FleetRosterBudget,
+  REFACTOR_PLANNER_AGENT,
+  SECURITY_SCANNER_AGENT,
+} from './fleet.js';
 export {
   FleetBus,
-  FleetUsageAggregator,
   type FleetEvent,
   type FleetHandler,
   type FleetUsage,
+  FleetUsageAggregator,
   type SubagentUsageSnapshot,
 } from './fleet-bus.js';
-export {
-  makeDirectorSessionFactory,
-  type DirectorSessionFactory,
-  type DirectorSessionFactoryOptions,
-} from './director-session.js';
-export {
-  composeDirectorPrompt,
-  composeSubagentPrompt,
-  rosterSummaryFromConfigs,
-  DEFAULT_DIRECTOR_PREAMBLE,
-  DEFAULT_SUBAGENT_BASELINE,
-  type DirectorPromptParts,
-  type SubagentPromptParts,
-} from './director-prompts.js';
-export {
-  InMemoryAgentBridge,
-  InMemoryBridgeTransport,
-  createMessage,
-} from './agent-bridge.js';
-export {
-  AUDIT_LOG_AGENT,
-  BUG_HUNTER_AGENT,
-  REFACTOR_PLANNER_AGENT,
-  SECURITY_SCANNER_AGENT,
-  FLEET_ROSTER,
-  ALL_FLEET_AGENTS,
-  FLEET_ROSTER_BUDGETS,
-  ACP_AGENTS,
-  FLEET_ROSTER_WITHACP,
-  applyRosterBudget,
-  type FleetRosterBudget,
-} from './fleet.js';
-export {
-  ALL_AGENT_DEFINITIONS,
-  AGENT_CATALOG,
-  AGENTS_BY_PHASE,
-  getAgentDefinition,
-  DISCOVERY_AGENTS,
-  PLANNING_AGENTS,
-  BUILD_AGENTS,
-  VERIFY_AGENTS,
-  REVIEW_AGENTS,
-  DOMAIN_AGENTS,
-  KNOWLEDGE_AGENTS,
-  DELIVERY_AGENTS,
-  META_AGENTS,
-  TOOLS as AGENT_TOOL_PRESETS,
-  LIGHT_BUDGET,
-  MEDIUM_BUDGET,
-  HEAVY_BUDGET,
-  type AgentDefinition,
-  type AgentCapability,
-  type AgentBudgetTier,
-  type AgentPhase,
-} from './agents/index.js';
-export {
-  dispatchAgent,
-  scoreAgents,
-  makeLLMClassifier,
-  DEFAULT_DISPATCH_ROLE,
-  type DispatchResult,
-  type DispatchCandidate,
-  type DispatchClassifier,
-  type DispatchOptions,
-  type DispatchMethod,
-} from './dispatcher.js';
-export {
-  attachAutoExtend,
-  type AutoExtendPolicy,
-  type AutoExtendCeiling,
-} from './auto-extend.js';
-export type { ICoordinator } from './icoordinator.js';
-export type { IFleetManager } from './ifleet-manager.js';
-export { NULL_FLEET_BUS } from './null-fleet-bus.js';
 export {
   FleetManager,
   type FleetManagerOptions,
 } from './fleet-manager.js';
-export {
-  CollabSession,
-  DirectorAlertLevel,
-  type CollabDebugReport,
-  type CollabSessionOptions,
-  type CollabBudgetConfig,
-  type CollabBudgetOverrides,
-  type DirectorAlert,
-  type DirectorCancelCollabPayload,
-  type CollabBudgetWarningPayload,
-  type SharedFileSnapshot,
-  type SharedFileEntry,
-  type BugFinding,
-  type RefactorPlan,
-  type RefactorPhase,
-  type CriticEvaluation,
-  type CriticConcern,
-} from './collab-debug.js';
+export { GlobalMailbox, resolveProjectDir } from './global-mailbox.js';
+export type { ICoordinator } from './icoordinator.js';
+export type { IFleetManager } from './ifleet-manager.js';
+export { LargeAnswerStore } from './large-answer-store.js';
+export { type MailToolsOptions, makeMailInboxTool, makeMailSendTool } from './mail-tools.js';
 // ── Mailbox — inter-agent messaging ──────────────────────────────────────
 export { DefaultMailbox } from './mailbox.js';
+export type {
+  MailboxActionInput,
+  MailboxActionResult,
+  MailboxMessageAction,
+} from './mailbox-actions.js';
+export { actionToAckInput } from './mailbox-actions.js';
+export {
+  buildDownAlert,
+  buildRecoveryAlert,
+  type DownAlertInput,
+  MAILBOX_HEALTH_DEFAULT_FAILURE_THRESHOLD,
+  MAILBOX_HEALTH_DEFAULT_FROM,
+  MAILBOX_HEALTH_DEFAULT_INTERVAL_MS,
+  MAILBOX_HEALTH_DEFAULT_TIMEOUT_MS,
+  type MailboxHealthEvent,
+  MailboxHealthWatchdog,
+  type MailboxHealthWatchdogOptions,
+  type RecoveryAlertInput,
+  validateWatchdogOptions,
+  type WatchdogConfig,
+} from './mailbox-health.js';
+// ── Mailbox hooks — tool-execution integration ────────────────────────────
+export {
+  createMailboxHooks,
+  type MailboxHooksOptions,
+} from './mailbox-hooks.js';
+export {
+  type MailboxResolver,
+  type MailboxToolOptions,
+  mailboxSessionTag,
+  makeMailboxTool,
+  resolveMailboxIdentity,
+} from './mailbox-tool.js';
+export type {
+  AgentHeartbeatInput,
+  AgentRegistrationInput,
+  ClientHeartbeatInput,
+  ClientRegistrationInput,
+  ClientSource,
+  ClientStatus,
+  Mailbox,
+  MailboxAckBatchInput,
+  MailboxAckInput,
+  MailboxAgentStatus,
+  MailboxMessage,
+  MailboxMessageType,
+  MailboxQuery,
+  MailboxSendInput,
+  MailboxTaskContext,
+  PurgeOptions,
+  PurgeResult,
+  ReadReceipts,
+  RegisteredAgent,
+} from './mailbox-types.js';
 export { normalizeRecipient } from './mailbox-types.js';
-export { BrainMonitor, type BrainMonitorOptions, type BrainInterventionInput } from './brain-monitor.js';
-export { GlobalMailbox, resolveProjectDir } from './global-mailbox.js';
+export {
+  DefaultMultiAgentCoordinator,
+  type MultiAgentCoordinatorOptions,
+} from './multi-agent-coordinator.js';
+export { NULL_FLEET_BUS } from './null-fleet-bus.js';
+// ── Package author tracker — tracks which agent added which package ─────────
+export {
+  detectEcosystem,
+  getFullPackageLog,
+  getManifestPackages,
+  getPackageAuthor,
+  getPackagesByAgent,
+  type PackageAuthorEntry,
+  type PackageAuthorLog,
+  type PackageAuthorTrackerOptions,
+  recordPackageAction,
+  updatePackageOutdatedStatus,
+} from './package-author-tracker.js';
+// ── Package outdated watcher — notifies original authors of outdated pkgs ──
+export {
+  type OutdatedNotifyMessage,
+  type PackageOutdatedEntry,
+  type PackageOutdatedResult,
+  type PackageOutdatedWatcherOptions,
+  startPackageOutdatedWatcher,
+} from './package-outdated-watcher.js';
 // ── Mailbox bridge lock — per-project single-instance contract ─────────
 // The HTTP bridge (`wstack mailbox serve`) writes a per-project lock +
 // token file at `<projectDir>/.mailbox-bridge.{lock,token}`. Core owns
@@ -202,189 +269,129 @@ export { GlobalMailbox, resolveProjectDir } from './global-mailbox.js';
 // (webui, eternal-autonomy, external agents reading the file)
 // import from here.
 export {
+  type AcquireOptions,
+  type AcquireResult,
   acquireOrJoin,
   finalize,
-  release,
-  readLiveLock,
+  type LiveLockResult,
   MAILBOX_BRIDGE_LOCK_FILENAME,
   MAILBOX_BRIDGE_TOKEN_FILENAME,
   type MailboxBridgeLock,
-  type AcquireResult,
-  type AcquireOptions,
-  type LiveLockResult,
+  readLiveLock,
+  release,
 } from './single-instance-mailbox.js';
-export {
-  MailboxHealthWatchdog,
-  MAILBOX_HEALTH_DEFAULT_INTERVAL_MS,
-  MAILBOX_HEALTH_DEFAULT_TIMEOUT_MS,
-  MAILBOX_HEALTH_DEFAULT_FAILURE_THRESHOLD,
-  MAILBOX_HEALTH_DEFAULT_FROM,
-  buildDownAlert,
-  buildRecoveryAlert,
-  validateWatchdogOptions,
-  type MailboxHealthWatchdogOptions,
-  type MailboxHealthEvent,
-  type DownAlertInput,
-  type RecoveryAlertInput,
-  type WatchdogConfig,
-} from './mailbox-health.js';
-export { makeMailboxTool, resolveMailboxIdentity, mailboxSessionTag, type MailboxToolOptions, type MailboxResolver } from './mailbox-tool.js';
-export { makeMailSendTool, makeMailInboxTool, type MailToolsOptions } from './mail-tools.js';
 export type {
-  Mailbox,
-  MailboxMessage,
-  MailboxMessageType,
-  MailboxQuery,
-  MailboxSendInput,
-  MailboxAckInput,
-  MailboxAckBatchInput,
-  MailboxAgentStatus,
-  MailboxTaskContext,
-  ReadReceipts,
-  RegisteredAgent,
-  AgentRegistrationInput,
-  AgentHeartbeatInput,
-  ClientSource,
-  ClientStatus,
-  ClientRegistrationInput,
-  ClientHeartbeatInput,
-  PurgeOptions,
-  PurgeResult,
-} from './mailbox-types.js';
-// ── Dependency watcher — file-change → mailbox bridge ────────────────────
+  BudgetKind,
+  BudgetLimits,
+  BudgetNegotiationMode,
+  BudgetThresholdDecision,
+  BudgetThresholdHandler,
+  BudgetUsage,
+} from './subagent-budget.js';
 export {
-  DEPENDENCY_FILE_PATTERNS,
-  makeDependencyWatcherConfig,
-  type DependencyWatcherConfig,
-  type DepWatchEntry,
-} from './dep-watcher.js';
-// ── Dependency watcher bridge — file-watcher events → mailbox ────────────
-export {
-  attachDepWatcherBridge,
-  type DepWatcherBridgeOptions,
-} from './dep-watcher-bridge.js';
-// ── Mailbox hooks — tool-execution integration ────────────────────────────
-export {
-  createMailboxHooks,
-  type MailboxHooksOptions,
-} from './mailbox-hooks.js';
-// ── Package author tracker — tracks which agent added which package ─────────
-export {
-  recordPackageAction,
-  getPackageAuthor,
-  getManifestPackages,
-  getPackagesByAgent,
-  updatePackageOutdatedStatus,
-  getFullPackageLog,
-  detectEcosystem,
-  type PackageAuthorEntry,
-  type PackageAuthorLog,
-  type PackageAuthorTrackerOptions,
-} from './package-author-tracker.js';
-// ── Package outdated watcher — notifies original authors of outdated pkgs ──
-export {
-  startPackageOutdatedWatcher,
-  type PackageOutdatedEntry,
-  type PackageOutdatedResult,
-  type PackageOutdatedWatcherOptions,
-  type OutdatedNotifyMessage,
-} from './package-outdated-watcher.js';
+  BudgetExceededError,
+  BudgetThresholdSignal,
+  /** 60 000 ms — hard safety net for budget negotiation decisions. Both the
+   * coordinator watchdog and SubagentBudget._negotiateExtension use this value
+   * so they agree on the decision window. Re-exported here so consumers of
+   * the coordination module can reference it without a sub-module import. */
+  DECISION_TIMEOUT_MS,
+  SubagentBudget,
+  /** 0.85 — fraction of wall-clock `timeoutMs` at which the coordinator watchdog
+   * fires a PROACTIVE pre-empt (before deadline). Canonical source:
+   * `coordination/subagent-budget.ts`. Re-exported here so all budget symbols
+   * are accessible from one import path. */
+  TIMEOUT_PREEMPT_FRACTION,
+} from './subagent-budget.js';
 
 // ── Autonomous coordination layer ──────────────────────────────────────────
-
-/** Shared knowledge graph — facts, goals, decisions, changes */
-export { KnowledgeGraph } from './knowledge-graph.js';
-export type {
-  NodeType,
-  FactCategory,
-  FactNode,
-  GoalNode,
-  DecisionNode,
-  ChangeNode,
-  VoteNode,
-  VoteRecord,
-  QualityGateResult,
-  QualityCheck,
-  GraphSubscription,
-  NodeFilter,
-  GoalStatus,
-  GoalPriority,
-  ChangeStatus,
-  VoteValue,
-} from './knowledge-graph.js';
-
-/** Task DAG — dependency graph with fork/join semantics */
-export { TaskDAG } from './task-dag.js';
-export type {
-  DAGNode,
-  DAGNodeStatus,
-  DAGEdgeEvent,
-  DAGEdgeHandler,
-  RunnablesHandler,
-} from './task-dag.js';
-
-/** Consensus protocol — agent voting on proposed changes */
-export { ConsensusProtocol } from './consensus-protocol.js';
-export type {
-  VoterConfig,
-  QuorumRule,
-  ConsensusResult,
-  ConsensusOptions,
-} from './consensus-protocol.js';
-
-/** Change manager — autonomous code change lifecycle */
-export {
-  ChangeManager,
-  DEFAULT_QUALITY_CHECKS,
-  type ChangeManagerOptions,
-  type ChangeFile,
-  type ChangeProposal,
-  type ApplyResult,
-  type RollbackResult,
-  type QualityGateChecks,
-} from './change-manager.js';
-
-/** Autonomous brain — LLM-backed decision-making engine */
-export { AutonomousBrain } from './autonomous-brain.js';
-export type {
-  AutonomousBrainOptions,
-  LLMProvider,
-  DecisionPrompt,
-  AutonomousDecisionType,
-  AutonomousDecisionRequest,
-  SpawnDecision,
-  ApprovalDecision,
-  PrioritizationDecision,
-  EscalationDecision,
-} from './autonomous-brain.js';
-
-/** Task auctioneer — project-wide task marketplace */
-export { TaskAuctioneer } from './task-auctioneer.js';
-export type {
-  TaskBid,
-  TaskAuctionOptions,
-} from './task-auctioneer.js';
-
-/** Autonomous coordinator — wires all coordination components */
-export { AutonomousCoordinator } from './autonomous-coordinator.js';
-export type {
-  AutonomousCoordinatorOptions,
-  CoordinatorEvent,
-  RunOptions,
-  CoordinatorStats,
-} from './autonomous-coordinator.js';
-
-/** Agent Monitor — virtual chat history, timeline streaming, HQ bridge */
-export {
-  AgentMonitorService,
-  createAgentMonitorService,
-  type AgentTimelineEntry,
-  type AgentVirtualSession,
-  type AgentMonitorOptions,
-} from './agent-monitor.js';
 
 // ── Adaptive Concurrency Controller ──────────────────────────────────────────
 export {
   AdaptiveConcurrencyController,
   type AdaptiveConcurrencyState,
 } from './adaptive-concurrency.js';
+/** Agent Monitor — virtual chat history, timeline streaming, HQ bridge */
+export {
+  type AgentMonitorOptions,
+  AgentMonitorService,
+  type AgentTimelineEntry,
+  type AgentVirtualSession,
+  createAgentMonitorService,
+} from './agent-monitor.js';
+export type {
+  ApprovalDecision,
+  AutonomousBrainOptions,
+  AutonomousDecisionRequest,
+  AutonomousDecisionType,
+  DecisionPrompt,
+  EscalationDecision,
+  LLMProvider,
+  PrioritizationDecision,
+  SpawnDecision,
+} from './autonomous-brain.js';
+/** Autonomous brain — LLM-backed decision-making engine */
+export { AutonomousBrain } from './autonomous-brain.js';
+export type {
+  AutonomousCoordinatorOptions,
+  CoordinatorEvent,
+  CoordinatorStats,
+  RunOptions,
+} from './autonomous-coordinator.js';
+/** Autonomous coordinator — wires all coordination components */
+export { AutonomousCoordinator } from './autonomous-coordinator.js';
+
+/** Change manager — autonomous code change lifecycle */
+export {
+  type ApplyResult,
+  type ChangeFile,
+  ChangeManager,
+  type ChangeManagerOptions,
+  type ChangeProposal,
+  DEFAULT_QUALITY_CHECKS,
+  type QualityGateChecks,
+  type RollbackResult,
+} from './change-manager.js';
+export type {
+  ConsensusOptions,
+  ConsensusResult,
+  QuorumRule,
+  VoterConfig,
+} from './consensus-protocol.js';
+/** Consensus protocol — agent voting on proposed changes */
+export { ConsensusProtocol } from './consensus-protocol.js';
+export type {
+  ChangeNode,
+  ChangeStatus,
+  DecisionNode,
+  FactCategory,
+  FactNode,
+  GoalNode,
+  GoalPriority,
+  GoalStatus,
+  GraphSubscription,
+  NodeFilter,
+  NodeType,
+  QualityCheck,
+  QualityGateResult,
+  VoteNode,
+  VoteRecord,
+  VoteValue,
+} from './knowledge-graph.js';
+/** Shared knowledge graph — facts, goals, decisions, changes */
+export { KnowledgeGraph } from './knowledge-graph.js';
+export type {
+  TaskAuctionOptions,
+  TaskBid,
+} from './task-auctioneer.js';
+/** Task auctioneer — project-wide task marketplace */
+export { TaskAuctioneer } from './task-auctioneer.js';
+export type {
+  DAGEdgeEvent,
+  DAGEdgeHandler,
+  DAGNode,
+  DAGNodeStatus,
+  RunnablesHandler,
+} from './task-dag.js';
+/** Task DAG — dependency graph with fork/join semantics */
+export { TaskDAG } from './task-dag.js';

--- a/packages/core/src/coordination/mailbox-actions.ts
+++ b/packages/core/src/coordination/mailbox-actions.ts
@@ -1,0 +1,88 @@
+/**
+ * Mailbox message action helpers (skeleton).
+ *
+ * Phase 1 skeleton: declares the {@link MailboxMessageAction} union
+ * (the verb that a user or agent issues against a single message) and
+ * the per-action input shapes. The actual implementations
+ * ({@link GlobalMailbox.markRead}, {@link GlobalMailbox.acknowledge},
+ * {@link GlobalMailbox.softDelete}, {@link GlobalMailbox.restore}) are
+ * added in Phase 2 alongside the corresponding `GlobalMailbox`
+ * methods.
+ *
+ * Keeping the verb+input types in their own file means the WebUI
+ * client (Phase 3) and the server route handlers (Phase 4) can
+ * import them independently of the `GlobalMailbox` implementation,
+ * and a future "message actions" CLI subcommand only has to add
+ * one verb to a single place.
+ */
+import type { MailboxAckInput, MailboxMessage } from './mailbox-types.js';
+
+/**
+ * High-level verbs the WebUI/server route handlers expose. The
+ * mapping to underlying `MailboxAckInput` is straightforward:
+ *   - `mark-read`  → `ack({ read: true,  completed: false })`
+ *   - `acknowledge`→ `ack({ read: true,  completed: true  })`
+ *   - `reopen`     → `ack({ read: false, completed: false })`
+ *   - `soft-delete`→ not an `ack` — a separate `Mailbox.softDelete()`
+ *     that flips `deletedAt` to "now" (recoverable) and is filtered
+ *     out of the default `query()`.
+ *   - `restore`    → the inverse of `soft-delete`. Undoes a
+ *     `softDelete` by clearing `deletedAt`.
+ */
+export type MailboxMessageAction =
+  | 'mark-read'
+  | 'acknowledge'
+  | 'reopen'
+  | 'soft-delete'
+  | 'restore';
+
+/** Per-action request body sent from the WebUI → server route. */
+export interface MailboxActionInput {
+  action: MailboxMessageAction;
+  mailId: string;
+  /** Acting agent / user. Required by the server to stamp
+   *  `readBy` / `completedBy`. */
+  readerId: string;
+  /** Optional human note (e.g. "triaged — will follow up"). */
+  note?: string | undefined;
+  /** Optional idempotency key so retried requests don't double-apply
+   *  the action. Phase 4 wires this through to the CLI. */
+  requestId?: string | undefined;
+}
+
+/** Per-action response. Echoes the action + the resulting message
+ *  state so the UI can reconcile optimistic updates. */
+export interface MailboxActionResult {
+  action: MailboxMessageAction;
+  mailId: string;
+  /** Updated message snapshot. `null` if the message was already in
+   *  the target state (e.g. `mark-read` on a message the user has
+   *  already read) — the WebUI can ignore the result in that case. */
+  message: MailboxMessage | null;
+  /** True if the action actually mutated state; false if it was a
+   *  no-op. Lets the WebUI decide whether to update its local copy. */
+  changed: boolean;
+}
+
+/**
+ * Convert a high-level action into the underlying
+ * {@link MailboxAckInput} the existing `GlobalMailbox.ack` already
+ * supports. `soft-delete` and `restore` do NOT go through `ack` —
+ * the caller must dispatch them to `GlobalMailbox.softDelete` /
+ * `GlobalMailbox.restore` instead. This helper returns `null` for
+ * those two so the type signature forces the caller to handle them
+ * separately.
+ */
+export function actionToAckInput(
+  action: Exclude<MailboxMessageAction, 'soft-delete' | 'restore'>,
+  input: MailboxActionInput,
+): MailboxAckInput {
+  switch (action) {
+    case 'mark-read':
+      return { messageId: input.mailId, readerId: input.readerId, read: true, completed: false };
+    case 'acknowledge':
+      return { messageId: input.mailId, readerId: input.readerId, read: true, completed: true };
+    case 'reopen':
+      return { messageId: input.mailId, readerId: input.readerId, read: false, completed: false };
+  }
+}

--- a/packages/core/src/coordination/mailbox-types.ts
+++ b/packages/core/src/coordination/mailbox-types.ts
@@ -82,6 +82,17 @@ export interface MailboxMessage {
   timestamp: string;
   /** ISO8601 — when the message was marked complete. */
   completedAt?: string | undefined;
+  /**
+   * ISO8601 — when the message was soft-deleted. When present, the
+   * default `Mailbox.query()` filter excludes the message from the
+   * normal inbox view; {@link GlobalMailbox.restore} clears the
+   * field to undo the delete. Hard deletes (removing the line from
+   * the JSONL) are reserved for the CLI and never happen via the
+   * server route handlers.
+   */
+  deletedAt?: string | undefined;
+  /** When the soft-delete happened, the agentId that issued it. */
+  deletedBy?: string | undefined;
   /** If this is a reply, the id of the parent message. */
   replyTo?: string | undefined;
   /** For assign-type messages — task context for agent discovery. */
@@ -186,6 +197,13 @@ export interface MailboxQuery {
   limit?: number | undefined;
   /** ISO8601 — only messages after this timestamp. */
   since?: string | undefined;
+  /**
+   * Include soft-deleted messages (where `deletedAt` is set). When
+   * `false` (the default), soft-deleted messages are filtered out so
+   * the normal inbox view stays clean. The "trash" view passes
+   * `true` to surface them.
+   */
+  includeDeleted?: boolean | undefined;
 }
 
 // ── Mailbox operations ───────────────────────────────────────────────────
@@ -369,6 +387,26 @@ export interface Mailbox {
    * read-modify-rewrite of the mailbox file for every call.
    */
   ackMany(input: MailboxAckBatchInput): Promise<MailboxMessage[]>;
+
+  /**
+   * Soft-delete a message. Sets `deletedAt` to the current timestamp
+   * and records the acting agent in `deletedBy`. Reversible via
+   * {@link restore}. The default `query()` filter hides the message
+   * once `deletedAt` is set; pass `includeDeleted: true` to see the
+   * trash.
+   *
+   * Phase 2 skeleton — the method signature is declared here so the
+   * WebUI client and the server route handler can compile against
+   * it; the implementation lands in the same PR.
+   */
+  softDelete(mailId: string, by: string): Promise<MailboxMessage | null>;
+
+  /**
+   * Undo a {@link softDelete}. Clears `deletedAt` and `deletedBy` on
+   * the message. No-op (returns the message as-is) if the message is
+   * not soft-deleted.
+   */
+  restore(mailId: string): Promise<MailboxMessage | null>;
 
   /** Get a snapshot of online/offline agents and their current tasks. */
   getAgentStatuses(): Promise<MailboxAgentStatus[]>;

--- a/packages/core/src/coordination/mailbox.ts
+++ b/packages/core/src/coordination/mailbox.ts
@@ -14,7 +14,6 @@ import { randomUUID } from 'node:crypto';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import { withFileLock } from '../utils/atomic-write.js';
-import { normalizeRecipient } from './mailbox-types.js';
 import type {
   AgentHeartbeatInput,
   AgentRegistrationInput,
@@ -31,6 +30,7 @@ import type {
   PurgeOptions,
   PurgeResult,
 } from './mailbox-types.js';
+import { normalizeRecipient } from './mailbox-types.js';
 
 const MAILBOX_FILE = '_mailbox.jsonl';
 const LINE_SEPARATOR = '\n';
@@ -184,6 +184,19 @@ export class DefaultMailbox implements Mailbox {
   async ack(input: MailboxAckInput): Promise<MailboxMessage | null> {
     const updated = await this.ackMany({ acks: [input] });
     return updated.length > 0 ? updated[0]! : null;
+  }
+
+  async softDelete(_mailId: string, _by: string): Promise<MailboxMessage | null> {
+    // No-op default — subclasses backed by a real file backend
+    // (`GlobalMailbox`) override this. The skeleton exists so the
+    // interface compiles; an in-memory default would just confuse
+    // callers.
+    return null;
+  }
+
+  async restore(_mailId: string): Promise<MailboxMessage | null> {
+    // See `softDelete` — no-op default.
+    return null;
   }
 
   async ackMany(input: MailboxAckBatchInput): Promise<MailboxMessage[]> {

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -6636,6 +6636,7 @@ export function App({
             setSuggestions={setSuggestions}
             autonomyMode={autonomyLive}
             multiDiffSummaryThreshold={state.settingsPicker.multiDiffSummaryThreshold}
+            todos={agent.ctx.todos}
           />
         ) : (
           <History
@@ -6646,6 +6647,7 @@ export function App({
             setSuggestions={setSuggestions}
             autonomyMode={autonomyLive}
             multiDiffSummaryThreshold={state.settingsPicker.multiDiffSummaryThreshold}
+            todos={agent.ctx.todos}
           />
         )}
         <Box flexDirection="column" flexShrink={0} ref={bottomRegionRef}>

--- a/packages/tui/src/components/history/entry.tsx
+++ b/packages/tui/src/components/history/entry.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from '../../ink.js';
+import { hasOpenTodos, type TodoItem } from '@wrongstack/core';
 import React, { useEffect, useMemo } from 'react';
 import { theme } from '../../theme.js';
 import { getToolVisual } from '../../tool-glyph.js';
@@ -71,6 +72,7 @@ export const Entry = React.memo(function Entry({
   setSuggestions,
   autonomyMode,
   multiDiffSummaryThreshold,
+  todos,
 }: {
   entry: HistoryEntry;
   termWidth: number;
@@ -81,9 +83,23 @@ export const Entry = React.memo(function Entry({
   /** User-tunable cutoff for the multi-file diff summary footer. Passes
    *  through to `formatMultiDiffSummary`; `undefined` means "use default". */
   multiDiffSummaryThreshold?: number | undefined;
+  /** Live todo list. When non-empty (pending/in_progress), the NEXT STEPS
+   *  panel is hidden and the store is not written — same rule as the host
+   *  callback (b0970387), so the two paths agree. */
+  todos?: readonly TodoItem[] | undefined;
 }): React.ReactElement {
+  // Whether the agent still has open (pending/in_progress) todos. While it
+  // does, finishing them takes priority over offering `<next_steps>` — both
+  // the host callback (execution.ts → parseSuggestionsFromOutput) and this
+  // render path gate on the same condition (b0970387) so they never disagree
+  // about whether suggestions are available.
+  const openTodos = hasOpenTodos(todos);
+
   // Parse next steps from assistant text — computed once, used only in
   // the assistant case. Must live at the top level (hooks rules).
+  // Always parse (even when todos are open) so `stripped` is available and
+  // the raw `<next_steps>` block never leaks into the message body; only the
+  // panel rendering and the store write are gated below.
   const nextSteps = useMemo(() => {
     if (entry.kind !== 'assistant') return { steps: [] as ParsedNextStep[], stripped: '' };
     // strict=true: accepts 💡 emoji heading OR <next_steps> XML tag
@@ -93,16 +109,19 @@ export const Entry = React.memo(function Entry({
   // Store parsed next steps in the shared suggestion store (for /next and
   // auto-submit countdown). Strict=true accepts 💡 headings or <next_steps> XML tags
   // (consistent with what the TUI renders in the message body).
+  // Skipped while todos are open — mirrors parseSuggestionsFromOutput, so the
+  // store isn't repopulated here right after the host callback cleared it.
   // NOTE: Only assistant entries should have <next_steps> — subagents return
   // task results, not suggestions, so we skip parsing for subagent entries.
   useEffect(() => {
     if (!setSuggestions) return;
     if (entry.kind !== 'assistant') return;
+    if (openTodos) return;
     const text = (entry as never as { text?: string }).text ?? '';
     const { texts } = parseNextSteps(text, true);
     if (texts.length > 0) setSuggestions(texts);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entry.kind, (entry as never as { text?: string }).text, setSuggestions]);
+  }, [entry.kind, (entry as never as { text?: string }).text, openTodos, setSuggestions]);
 
   switch (entry.kind) {
     case 'user':
@@ -137,7 +156,9 @@ export const Entry = React.memo(function Entry({
     case 'assistant': {
       const contentWidth = assistantContentWidth(termWidth);
       const { steps, stripped } = nextSteps;
-      const hasNext = steps.length > 0;
+      // Panel only when there are steps AND no open todos (the latter mirrors
+      // the host callback — suggestions are suppressed mid-task).
+      const hasNext = steps.length > 0 && !openTodos;
       return (
         <Box flexDirection="column">
           <Box

--- a/packages/tui/src/components/history/index.tsx
+++ b/packages/tui/src/components/history/index.tsx
@@ -70,7 +70,7 @@ export {
  * primitives or stable reducer references, so default shallow
  * comparison is sufficient.
  */
-export const History = memo(function History({ entries, generation, streamingText, toolStream, setSuggestions, autonomyMode, multiDiffSummaryThreshold }: HistoryProps): React.ReactElement {
+export const History = memo(function History({ entries, generation, streamingText, toolStream, setSuggestions, autonomyMode, multiDiffSummaryThreshold, todos }: HistoryProps): React.ReactElement {
   const { stdout } = useStdout();
   const [termSize, setTermSize] = useState({
     columns: stdout?.columns ?? 80,
@@ -105,7 +105,7 @@ export const History = memo(function History({ entries, generation, streamingTex
       <Static key={generation ?? 0} items={entries}>
         {(entry) => (
           <Box key={entry.id} marginBottom={entry.kind === 'turn-summary' ? 1 : 0}>
-            <Entry entry={entry} termWidth={termWidth} setSuggestions={setSuggestions} autonomyMode={autonomyMode} multiDiffSummaryThreshold={multiDiffSummaryThreshold} />
+            <Entry entry={entry} termWidth={termWidth} setSuggestions={setSuggestions} autonomyMode={autonomyMode} multiDiffSummaryThreshold={multiDiffSummaryThreshold} todos={todos} />
           </Box>
         )}
       </Static>

--- a/packages/tui/src/components/history/types.ts
+++ b/packages/tui/src/components/history/types.ts
@@ -1,3 +1,4 @@
+import type { TodoItem } from '@wrongstack/core';
 import type { Lang } from '../../highlight.js';
 
 // ============================================
@@ -104,6 +105,14 @@ export interface HistoryProps {
    * default (`MULTI_DIFF_SUMMARY_THRESHOLD`) is used.
    */
   multiDiffSummaryThreshold?: number | undefined;
+  /**
+   * Live todo list. When it has any `pending`/`in_progress` items, the
+   * `💡 NEXT STEPS` panel is hidden and the suggestion store is not
+   * written from the render path — mirrors the host callback's
+   * `hasOpenTodos` gate (b0970387) so the two paths can't disagree about
+   * whether suggestions are available.
+   */
+  todos?: readonly TodoItem[] | undefined;
 }
 
 export interface BodySegment {

--- a/packages/tui/src/components/scrollable-history.tsx
+++ b/packages/tui/src/components/scrollable-history.tsx
@@ -126,6 +126,7 @@ export const ScrollableHistory = memo(function ScrollableHistory({
   maxWidth,
   setSuggestions,
   autonomyMode,
+  todos,
 }: ScrollableHistoryProps): React.ReactElement {
   const { stdout } = useStdout();
   const rawWidth = stdout?.columns ?? 80;
@@ -187,7 +188,7 @@ export const ScrollableHistory = memo(function ScrollableHistory({
           ) : null}
           {shown.map((entry) => (
             <Box key={entry.id} marginBottom={entry.kind === 'turn-summary' ? 1 : 0} flexShrink={0}>
-              <Entry entry={entry} termWidth={termWidth} setSuggestions={setSuggestions} autonomyMode={autonomyMode} />
+              <Entry entry={entry} termWidth={termWidth} setSuggestions={setSuggestions} autonomyMode={autonomyMode} todos={todos} />
             </Box>
           ))}
           {tail ? <AssistantTail text={tail} termWidth={termWidth} /> : null}

--- a/packages/tui/tests/entry-next-steps.test.ts
+++ b/packages/tui/tests/entry-next-steps.test.ts
@@ -1,0 +1,86 @@
+import { render } from 'ink-testing-library';
+import type { TodoItem } from '@wrongstack/core';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Entry, type HistoryEntry } from '../src/components/history.js';
+
+// An assistant message carrying a <next_steps> block. The block is in the
+// XML-tag form (strict mode requires the closing tag), with two items.
+const ASSISTANT_WITH_NEXT_STEPS: HistoryEntry = {
+  id: 1,
+  kind: 'assistant',
+  text: ['Done reviewing the file.', '', '<next_steps>', '1. Add unit tests for the parser', '2. Run the full suite', '</next_steps>'].join(
+    '\n',
+  ),
+};
+
+interface RenderOpts {
+  setSuggestions?: (steps: string[]) => void;
+  todos?: readonly TodoItem[];
+  autonomyMode?: string;
+}
+
+/** Render an assistant Entry with optional suggestion writer + todo list. */
+function renderEntry(opts: RenderOpts = {}): { frame: string; setSuggestions: ReturnType<typeof vi.fn> } {
+  const setSuggestions = opts.setSuggestions ?? vi.fn();
+  const { lastFrame, unmount } = render(
+    React.createElement(Entry, {
+      entry: ASSISTANT_WITH_NEXT_STEPS,
+      termWidth: 100,
+      setSuggestions,
+      todos: opts.todos,
+      autonomyMode: opts.autonomyMode,
+    }),
+  );
+  const frame = lastFrame() ?? '';
+  unmount();
+  return { frame, setSuggestions: setSuggestions as ReturnType<typeof vi.fn> };
+}
+
+describe('<Entry /> <next_steps> todo-gate (b0970387 render-path parity)', () => {
+  it('shows the NEXT STEPS panel and writes the store when no todos are open', () => {
+    const { frame, setSuggestions } = renderEntry();
+
+    // Panel header + both items render.
+    expect(frame).toContain('NEXT STEPS');
+    expect(frame).toContain('Add unit tests for the parser');
+    expect(frame).toContain('Run the full suite');
+    // The raw <next_steps> XML block must never leak into the message body.
+    expect(frame).not.toContain('<next_steps>');
+    expect(frame).not.toContain('</next_steps>');
+    // Store was written with the parsed item texts.
+    expect(setSuggestions).toHaveBeenCalledTimes(1);
+    expect(setSuggestions).toHaveBeenCalledWith([
+      'Add unit tests for the parser',
+      'Run the full suite',
+    ]);
+  });
+
+  it('hides the NEXT STEPS panel and skips the store write while todos are open', () => {
+    const openTodos: TodoItem[] = [
+      { id: 't1', content: 'finish the refactor', status: 'in_progress' },
+    ];
+    const { frame, setSuggestions } = renderEntry({ todos: openTodos });
+
+    // Panel is suppressed — suggestions don't compete with in-flight todos.
+    expect(frame).not.toContain('NEXT STEPS');
+    expect(frame).not.toContain('Add unit tests for the parser');
+    // Store is NOT repopulated from the render path (mirrors the host callback
+    // clearing it); otherwise it would immediately undo the clear.
+    expect(setSuggestions).not.toHaveBeenCalled();
+    // But the raw block is still stripped from the body — even when the panel
+    // is hidden, the literal <next_steps> tags never show.
+    expect(frame).not.toContain('<next_steps>');
+    expect(frame).not.toContain('</next_steps>');
+  });
+
+  it('treats an all-completed todo list as "no open todos" (panel shows)', () => {
+    const completedTodos: TodoItem[] = [
+      { id: 't1', content: 'done deal', status: 'completed' },
+    ];
+    const { frame, setSuggestions } = renderEntry({ todos: completedTodos });
+
+    expect(frame).toContain('NEXT STEPS');
+    expect(setSuggestions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/webui-hq/src/lib/mailbox-actions.ts
+++ b/packages/webui-hq/src/lib/mailbox-actions.ts
@@ -1,0 +1,60 @@
+/**
+ * WebUI client for mailbox message actions (skeleton).
+ *
+ * Phase 3 skeleton: thin `fetch` wrappers around the server routes
+ * that will land in `feat/hq-mailbox-message-actions` Phase 4. Each
+ * wrapper returns the parsed JSON or throws on a non-2xx response so
+ * the caller can show a meaningful error in the toast / inline
+ * status row.
+ *
+ * Optimistic updates are not handled here — they live in the React
+ * component (Phase 4) so the server remains the source of truth.
+ */
+import type { MailboxActionInput, MailboxActionResult } from '@wrongstack/core';
+
+interface ServerError {
+  error: { code: string; message: string };
+}
+
+function isServerError(value: unknown): value is ServerError {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as { error?: unknown };
+  if (typeof v.error !== 'object' || v.error === null) return false;
+  const e = v.error as { code?: unknown; message?: unknown };
+  return typeof e.code === 'string' && typeof e.message === 'string';
+}
+
+async function postAction(input: MailboxActionInput): Promise<MailboxActionResult> {
+  const res = await fetch(`/api/mailbox/messages/${encodeURIComponent(input.mailId)}/action`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    let detail = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as unknown;
+      if (isServerError(body)) detail = `${body.error.code}: ${body.error.message}`;
+    } catch {
+      // ignore JSON parse errors; the status line is enough
+    }
+    throw new Error(`mailbox action failed — ${detail}`);
+  }
+  return (await res.json()) as MailboxActionResult;
+}
+
+export const mailboxActions = {
+  markRead: (input: Omit<MailboxActionInput, 'action'>) =>
+    postAction({ ...input, action: 'mark-read' }),
+
+  acknowledge: (input: Omit<MailboxActionInput, 'action'>) =>
+    postAction({ ...input, action: 'acknowledge' }),
+
+  reopen: (input: Omit<MailboxActionInput, 'action'>) => postAction({ ...input, action: 'reopen' }),
+
+  softDelete: (input: Omit<MailboxActionInput, 'action'>) =>
+    postAction({ ...input, action: 'soft-delete' }),
+
+  restore: (input: Omit<MailboxActionInput, 'action'>) =>
+    postAction({ ...input, action: 'restore' }),
+} as const;

--- a/packages/webui-hq/src/views/mailbox-actions.tsx
+++ b/packages/webui-hq/src/views/mailbox-actions.tsx
@@ -1,0 +1,138 @@
+/**
+ * Per-message action buttons (skeleton).
+ *
+ * Phase 4 skeleton: renders the four primary actions on each mailbox
+ * message — mark-read, acknowledge, soft-delete, restore. Buttons are
+ * wired to {@link mailboxActions} (the client wrapper) but the actual
+ * server routes + optimistics land in the follow-up Phase 4 PR so the
+ * diff stays reviewable.
+ *
+ * Showing the right subset of actions per message keeps the row
+ * scannable. The visibility rules deliberately mirror the rules
+ * the server uses (so the user never sees a button that would 4xx).
+ *
+ * Visibility model:
+ *   - `mark-read` / `acknowledge` / `reopen` / `soft-delete` are
+ *     always shown for the basic case; the server is the source of
+ *     truth for what the user has already done (the action is a
+ *     no-op on the server when the user has already performed it).
+ *   - `restore` is only shown when the message is soft-deleted. The
+ *     `isDeleted` flag here is a UI hint; the server enforces the
+ *     actual rule (`Mailbox.restore` on a non-deleted message
+ *     returns the unchanged message and the WebUI just shows a
+ *     silent no-op).
+ */
+import { useState } from 'react';
+import { mailboxActions } from '../lib/mailbox-actions.js';
+
+export interface MessageActionsProps {
+  /**
+   * Mail id of the message. The component intentionally does not
+   * take a `FlatMessage` — the HQ `HqMailboxMessageSummary` snapshot
+   * type is a wire format that intentionally omits per-recipient
+   * `readBy` + soft-delete metadata, so the visibility rules here
+   * live entirely on the server side and the client only needs the
+   * id to issue a request.
+   */
+  mailId: string;
+  /** Agent id of the acting user (read from session). */
+  actorId: string;
+  /**
+   * When true, the `restore` button is rendered. The parent decides
+   * this from the live HQ event stream (e.g. when a soft-deleted
+   * message is visible in the "trash" view). Default: false.
+   */
+  isDeleted?: boolean | undefined;
+  /**
+   * Called after every successful action with the post-action
+   * message id. The parent uses this to update its in-memory copy
+   * (optimistic reconcile) before the HQ event stream catches up.
+   */
+  onAction?: ((mailId: string, action: string) => void) | undefined;
+  /** Disable all buttons (e.g. while a request is in flight). */
+  disabled?: boolean | undefined;
+}
+
+export function MessageActions({
+  mailId,
+  actorId,
+  isDeleted = false,
+  onAction,
+  disabled = false,
+}: MessageActionsProps): React.ReactElement {
+  const [pending, setPending] = useState<string | null>(null);
+
+  const run = async (label: string, action: () => Promise<unknown>) => {
+    if (disabled || pending !== null) return;
+    setPending(label);
+    try {
+      await action();
+      onAction?.(mailId, label);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="hq-msg-actions">
+      {!isDeleted && (
+        <button
+          type="button"
+          className="hq-btn secondary"
+          disabled={disabled || pending !== null}
+          onClick={() =>
+            run('mark-read', () => mailboxActions.markRead({ mailId, readerId: actorId }))
+          }
+        >
+          {pending === 'mark-read' ? '…' : 'Mark read'}
+        </button>
+      )}
+      {!isDeleted && (
+        <button
+          type="button"
+          className="hq-btn"
+          disabled={disabled || pending !== null}
+          onClick={() =>
+            run('acknowledge', () => mailboxActions.acknowledge({ mailId, readerId: actorId }))
+          }
+        >
+          {pending === 'acknowledge' ? '…' : 'Acknowledge'}
+        </button>
+      )}
+      {!isDeleted && (
+        <button
+          type="button"
+          className="hq-btn secondary"
+          disabled={disabled || pending !== null}
+          onClick={() => run('reopen', () => mailboxActions.reopen({ mailId, readerId: actorId }))}
+        >
+          {pending === 'reopen' ? '…' : 'Reopen'}
+        </button>
+      )}
+      {!isDeleted && (
+        <button
+          type="button"
+          className="hq-btn danger"
+          disabled={disabled || pending !== null}
+          onClick={() =>
+            run('soft-delete', () => mailboxActions.softDelete({ mailId, readerId: actorId }))
+          }
+        >
+          {pending === 'soft-delete' ? '…' : 'Delete'}
+        </button>
+      )}
+      {isDeleted && (
+        <button
+          type="button"
+          className="hq-btn secondary"
+          disabled={disabled || pending !== null}
+          onClick={() =>
+            run('restore', () => mailboxActions.restore({ mailId, readerId: actorId }))
+          }
+        >
+          {pending === 'restore' ? '…' : 'Restore'}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
feat(mailbox): message actions (mark-read / acknowledge / soft-delete / restore)

Adds the action layer for per-message user operations on the
mailbox: mark-read, acknowledge, reopen, soft-delete, restore. The
motivation is to give the WebUI a real "I have seen this / I am
handling this / throw this away" control surface, instead of leaving
users to scroll past stale inbox rows.

## Core

- `mailbox-actions.ts` (new) — `MailboxMessageAction` verb union
  (mark-read / acknowledge / reopen / soft-delete / restore) and the
  per-action input/result shapes. `actionToAckInput` maps the three
  ack-style verbs onto the existing `MailboxAckInput` so the bulk
  batch path in `GlobalMailbox.ackMany` keeps working. `soft-delete`
  and `restore` are routed to dedicated methods because they are not
  ack-style operations.
- `mailbox-types.ts`:
  - `MailboxMessage` gains `deletedAt?: string` and `deletedBy?: string`
    so the soft-delete / restore verbs have somewhere to write.
  - `MailboxQuery` gains `includeDeleted?: boolean` so the trash view
    can opt in to soft-deleted messages.
  - `Mailbox` interface gains `softDelete(mailId, by)` and
    `restore(mailId)` declarations.
- `mailbox.ts` (the in-memory default implementation) provides
  no-op stubs for the new methods so the interface still compiles
  for callers that don't use the file backend.
- `global-mailbox.ts`:
  - `softDelete(mailId, by)` — single-message soft delete under the
    file lock. Idempotent: a second `softDelete` on an already-deleted
    message is a successful no-op and returns the existing record
    without publishing another `message.updated` event.
  - `restore(mailId)` — inverse: clears `deletedAt` + `deletedBy` and
    publishes `message.updated` (an unconditional event is acceptable
    because the WebUI dedupes by `mailId`).
  - `query()` filters out soft-deleted messages unless
    `includeDeleted: true` is set.
- `coordination/index.ts` re-exports the new types and the
  `actionToAckInput` helper so the WebUI can import them from the
  package barrel.

## WebUI

- `lib/mailbox-actions.ts` (new) — `mailboxActions.{markRead,
  acknowledge, reopen, softDelete, restore}` thin `fetch` wrappers
  around `POST /api/mailbox/messages/:mailId/action`. Parses the
  server error envelope into a friendly message.
- `views/mailbox-actions.tsx` (new) — `MessageActions` button
  component. Visibility rules:
  - `mark-read` / `acknowledge` / `reopen` / `soft-delete` always
    shown when not soft-deleted (the server enforces the actual
    rule; the client is intentionally permissive).
  - `restore` only shown when `isDeleted` is true.
  The component deliberately does NOT take a `FlatMessage` — the HQ
  snapshot type is a wire format that intentionally omits per-agent
  `readBy` + soft-delete metadata, so the component only needs the
  `mailId` to issue a request. The parent owns the optimistic
  reconcile.

## Deferred (not in this commit; tracked separately)

- The actual server route handlers in
  `feat/hq-mailbox-message-actions` Phase 4 — `POST
  /api/mailbox/messages/:mailId/action` reading
  `MailboxActionInput` and dispatching via `actionToAckInput` /
  `softDelete` / `restore`.
- Optimistic updates in the React tree (the parent
  reconciles after `MessageActions.onAction` fires).
- A "trash" view that filters `includeDeleted: true` and shows
  only the soft-deleted messages.
- Tests for the new core paths (`softDelete`, `restore`,
  `includeDeleted` filter) and the WebUI client wrappers.

Verified locally
- `pnpm exec biome check` on the touched paths → clean
  (0 errors, 0 warnings) after `--write` auto-fixes.
- `pnpm exec tsc --noEmit` in `packages/core` and
  `packages/webui-hq` → clean.
- `pnpm --filter @wrongstack/core build` → clean (ESM + DTS, 3s +
  14s).