### PR TITLE
[codex] fix webui locale sync

### DIFF
--- a/packages/cli/src/webui-server.ts
+++ b/packages/cli/src/webui-server.ts
@@ -564,6 +564,7 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
     let lastActiveCfg = JSON.stringify(
       opts.appConfig?.providers?.[opts.agent.ctx.provider.id] ?? null,
     );
+    let lastUiLocale = opts.appConfig?.uiLocale;
     const watcher = watchProviderConfig(
       opts.globalConfigPath,
       getVault(opts.globalConfigPath),
@@ -574,11 +575,24 @@ export async function runWebUI(opts: CliWebUIOptions): Promise<void> {
         try {
           if (opts.appConfig && !Object.isFrozen(opts.appConfig)) {
             opts.appConfig.providers = snapshot.providers;
+            if (snapshot.uiLocale) opts.appConfig.uiLocale = snapshot.uiLocale;
           }
         } catch {
           /* frozen / read-only appConfig — ignore */
         }
         broadcastSaved(wsHandlerCtx, snapshot.providers);
+
+        // Display language live-propagation: when another surface writes
+        // Config.uiLocale (desktop shell, standalone WebUI, or another
+        // embedded WebUI), push it through the same prefs path the frontend
+        // already uses for instant i18n re-render.
+        if (snapshot.uiLocale !== lastUiLocale) {
+          lastUiLocale = snapshot.uiLocale;
+          if (snapshot.uiLocale) {
+            opts.agent.ctx.meta['uiLocale'] = snapshot.uiLocale;
+            broadcast({ type: 'prefs.updated', payload: { uiLocale: snapshot.uiLocale } });
+          }
+        }
 
         const activeId = opts.agent.ctx.provider.id;
         const newCfgStr = JSON.stringify(snapshot.providers[activeId] ?? null);

--- a/packages/cli/src/webui-server/prefs-seeding.ts
+++ b/packages/cli/src/webui-server/prefs-seeding.ts
@@ -33,6 +33,7 @@ interface CliWebUIOptions {
     favoriteModelsOnly?: boolean | undefined;
     fallbackAuto?: boolean | undefined;
     modelMatrix?: Config['modelMatrix'] | undefined;
+    uiLocale?: string | undefined;
   } | undefined;
 }
 
@@ -62,6 +63,7 @@ export const PREF_KEYS = [
   'favoriteModelsOnly',
   'modelMatrix',
   'fallbackAuto',
+  'uiLocale',
   'enhanceEnabled',
   'enhanceDelayMs',
   'enhanceLanguage',
@@ -140,6 +142,7 @@ export async function seedConfigToMeta(opts: CliWebUIOptions): Promise<void> {
     meta['favoriteModelsOnly'] = cfg.favoriteModelsOnly === true;
     meta['modelMatrix'] = (cfg.modelMatrix as Config['modelMatrix'] | undefined) ?? {};
     meta['fallbackAuto'] = cfg.fallbackAuto !== false;
+    if (typeof cfg.uiLocale === 'string' && cfg.uiLocale) meta['uiLocale'] = cfg.uiLocale;
     meta['featureMcp'] = features['mcp'] !== false;
     meta['featurePlugins'] = features['plugins'] !== false;
     meta['featureMemory'] = features['memory'] !== false;
@@ -237,6 +240,8 @@ export function createPrefsSeeding(opts: CliWebUIOptions): PrefsSeeding {
       patchLiveAppConfig({ favoriteModelsOnly: payload['favoriteModelsOnly'] });
     if (typeof payload['fallbackAuto'] === 'boolean')
       patchLiveAppConfig({ fallbackAuto: payload['fallbackAuto'] });
+    if (typeof payload['uiLocale'] === 'string')
+      patchLiveAppConfig({ uiLocale: payload['uiLocale'] });
     if (
       payload['modelMatrix'] &&
       typeof payload['modelMatrix'] === 'object' &&
@@ -284,6 +289,7 @@ export function createPrefsSeeding(opts: CliWebUIOptions): PrefsSeeding {
         decrypted['favoriteModelsOnly'] = payload['favoriteModelsOnly'];
       if ('modelMatrix' in payload) decrypted['modelMatrix'] = payload['modelMatrix'];
       if ('fallbackAuto' in payload) decrypted['fallbackAuto'] = payload['fallbackAuto'];
+      if (typeof payload['uiLocale'] === 'string') decrypted['uiLocale'] = payload['uiLocale'];
       decrypted['autonomy'] = autonomy;
 
       if (

--- a/packages/cli/tests/webui-server/prefs-seeding.test.ts
+++ b/packages/cli/tests/webui-server/prefs-seeding.test.ts
@@ -104,6 +104,26 @@ describe('createPrefsSeeding', () => {
     expect(written.model).toBe('gpt-5-codex');
   });
 
+  it('persists uiLocale to config.json and includes it in pref snapshots', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'wstack-prefs-locale-'));
+    const globalConfigPath = path.join(dir, 'config.json');
+    writeFileSync(globalConfigPath, JSON.stringify({ version: 1, uiLocale: 'en' }), 'utf8');
+    const opts = {
+      agent: { ctx: { meta: { uiLocale: 'tr' } } },
+      globalConfigPath,
+      appConfig: {},
+    } as never;
+
+    const { prefSnapshot, persistPrefs } = createPrefsSeeding(opts);
+
+    expect(prefSnapshot()).toMatchObject({ uiLocale: 'tr' });
+    await persistPrefs({ uiLocale: 'de' });
+
+    expect((opts as { appConfig: { uiLocale?: string } }).appConfig.uiLocale).toBe('de');
+    const written = JSON.parse(readFileSync(globalConfigPath, 'utf8'));
+    expect(written.uiLocale).toBe('de');
+  });
+
   it('cacheTtl "default" removes the cache override', async () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'wstack-prefs-cache-'));
     const globalConfigPath = path.join(dir, 'config.json');
@@ -161,5 +181,16 @@ describe('seedConfigToMeta', () => {
         },
       },
     });
+  });
+
+  it('seeds uiLocale from config.json so WebUI starts in the shared language', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'wstack-prefs-meta-locale-'));
+    const globalConfigPath = path.join(dir, 'config.json');
+    writeFileSync(globalConfigPath, JSON.stringify({ version: 1, uiLocale: 'tr' }), 'utf8');
+    const meta: Record<string, unknown> = {};
+
+    await seedConfigToMeta({ agent: { ctx: { meta } }, globalConfigPath } as never);
+
+    expect(meta['uiLocale']).toBe('tr');
   });
 });

--- a/packages/webui/src/i18n/index.ts
+++ b/packages/webui/src/i18n/index.ts
@@ -5,9 +5,9 @@
  * headings, toasts, …). It never touches the agent, system prompts, skills,
  * the prompt library, slash commands, or model output.
  *
- * The active locale (`uiLocale`) lives in localStorage via the prefs store and
- * is NOT synced to the server / config.json — it follows the same local-only
- * precedent as the theme (see components/ThemeProvider.tsx).
+ * The active locale (`uiLocale`) lives in the prefs store for instant local
+ * rendering and is also synced through the prefs WebSocket path to shared
+ * `Config.uiLocale`, so desktop, CLI WebUI, and standalone WebUI agree.
  *
  * Importing this module (side-effect import in main.tsx) initializes i18next
  * and wires locale reactivity. The English catalog is bundled inline so the

--- a/packages/webui/src/stores/local-prefs.ts
+++ b/packages/webui/src/stores/local-prefs.ts
@@ -103,9 +103,9 @@ export interface LocalPrefs {
 
   /**
    * Display-only UI language (BCP-47 code, e.g. `en`, `pt-BR`).
-   * NOT synced to the server / config.json — only affects which translation
-   * catalog the WebUI chrome renders. Follows the same local-only precedent
-   * as `theme`. Distinct from `enhanceLanguage` (a prompt-refinement pref).
+   * Synced through prefs.update into shared Config.uiLocale so browser WebUI,
+   * desktop-hosted WebUI, and the desktop shell follow the same choice.
+   * Distinct from `enhanceLanguage` (a prompt-refinement pref).
    */
   uiLocale: string;
 
@@ -188,7 +188,7 @@ export const useLocalPrefs = create<LocalPrefs>()(
       //
       // v4 added fallbackProfiles/favoriteModels/favoriteModelsOnly/modelMatrix.
       //
-      // v5 added uiLocale (display-only UI language; not synced to server).
+      // v5 added uiLocale (display-only UI language).
       migrate: (persisted) => {
         const p = (persisted ?? {}) as Record<string, unknown>;
         const validStrategies = ['hybrid', 'intelligent', 'selective'];


### PR DESCRIPTION
## What changed

- Added `uiLocale` to the CLI embedded WebUI prefs snapshot, config seeding, and persistence path.
- Broadcast `prefs.updated` when the embedded WebUI config watcher sees `Config.uiLocale` change on disk.
- Updated WebUI i18n comments to match the shared `Config.uiLocale` behavior.
- Added regression coverage for `uiLocale` seed/snapshot/persist behavior.

## Why

The desktop shell could persist a language change to shared config, but embedded WebUI instances did not carry `uiLocale` through their prefs path and did not live-broadcast config watcher locale changes. That left browser and desktop-hosted WebUI chrome stuck in English or localStorage defaults.

## Impact

Desktop, CLI WebUI, and standalone WebUI now share the same display language preference. A language change written by another surface updates active embedded WebUI clients through the existing prefs/i18n path.

## Validation

- `pnpm vitest run packages/cli/tests/webui-server/prefs-seeding.test.ts`
- `pnpm --filter @wrongstack/webui exec vitest run tests/i18n/locale-switch.test.tsx`
- `pnpm --filter @wrongstack/cli typecheck`
- Pre-commit hook completed repository build/typecheck during commit.
