### PR TITLE
fix(core,providers): keep openai-codex model picker populated when allowlist is empty

### DIFF
--- a/packages/cli/src/webui-server/ws-handlers/providers.ts
+++ b/packages/cli/src/webui-server/ws-handlers/providers.ts
@@ -59,7 +59,10 @@ function projectSavedProviders(providers: Record<string, ProviderConfig>) {
   });
 }
 
-export function broadcastSaved(ctx: WsHandlerContext, providers: Record<string, ProviderConfig>): void {
+export function broadcastSaved(
+  ctx: WsHandlerContext,
+  providers: Record<string, ProviderConfig>,
+): void {
   ctx.broadcast({
     type: 'providers.saved',
     payload: { providers: projectSavedProviders(providers) },
@@ -122,7 +125,7 @@ export async function handleProviderModels(
       type: 'provider.models',
       payload: {
         provider: providerId,
-        models: resolveProviderModelList(cfg?.models, provider),
+        models: resolveProviderModelList(cfg?.models, provider, cfg?.type ?? providerId),
       },
     });
   } catch (err) {

--- a/packages/core/src/models/provider-model-resolve.ts
+++ b/packages/core/src/models/provider-model-resolve.ts
@@ -1,5 +1,5 @@
 import type { ModelsDevModel, ResolvedProvider } from '../types/models-registry.js';
-import { codexModelMeta } from './codex-catalog.js';
+import { CODEX_MODELS, codexModelMeta } from './codex-catalog.js';
 
 /**
  * A model descriptor shaped for the WebUI `provider.models` message. All
@@ -58,6 +58,14 @@ export function describeCatalogModel(m: ModelsDevModel): ProviderModelDescriptor
 export function resolveProviderModelList(
   savedModels: string[] | undefined,
   catalog: ResolvedProvider | undefined,
+  /**
+   * Provider id / wire family the list is being resolved for. Lets the
+   * resolver fall back to a known offline catalog (currently the ChatGPT
+   * `openai-codex` models) when the saved allowlist is empty AND the
+   * models.dev catalog is unavailable — so deleting the models from config
+   * never leaves the provider showing zero models.
+   */
+  providerHint?: string | undefined,
 ): ProviderModelDescriptor[] {
   if (savedModels && savedModels.length > 0) {
     const byId = new Map((catalog?.models ?? []).map((m) => [m.id, m]));
@@ -77,6 +85,18 @@ export function resolveProviderModelList(
       return { id, name: id, capabilities: [] };
     });
   }
-  if (catalog) return catalog.models.map(describeCatalogModel);
+  if (catalog && catalog.models.length > 0) return catalog.models.map(describeCatalogModel);
+  // No allowlist and no catalog models. For the ChatGPT sign-in provider the
+  // canonical model list is known offline, so surface it rather than an empty
+  // picker (the models.dev catalog omits `openai-codex`; its models live only
+  // in the curated overlay, which may be missing offline).
+  if (providerHint === 'openai-codex') {
+    return CODEX_MODELS.map((m) => ({
+      id: m.id,
+      name: m.name,
+      description: m.description,
+      capabilities: [],
+    }));
+  }
   return [];
 }

--- a/packages/core/tests/models/provider-model-resolve.test.ts
+++ b/packages/core/tests/models/provider-model-resolve.test.ts
@@ -44,9 +44,9 @@ describe('describeCatalogModel', () => {
   });
 
   it('surfaces an overlay description when present, omits it otherwise', () => {
-    expect(describeCatalogModel(catalogModel({ description: 'Ultra-fast coding model.' }))).toMatchObject(
-      { description: 'Ultra-fast coding model.' },
-    );
+    expect(
+      describeCatalogModel(catalogModel({ description: 'Ultra-fast coding model.' })),
+    ).toMatchObject({ description: 'Ultra-fast coding model.' });
     expect(describeCatalogModel(catalogModel())).not.toHaveProperty('description');
   });
 });
@@ -119,5 +119,38 @@ describe('resolveProviderModelList', () => {
   it('returns an empty list (never an error) for an unknown provider with no allowlist', () => {
     expect(resolveProviderModelList(undefined, undefined)).toEqual([]);
     expect(resolveProviderModelList([], undefined)).toEqual([]);
+  });
+
+  it('falls back to the canonical codex list for openai-codex when config + catalog are empty', () => {
+    // User deleted cfg.models AND the models.dev/overlay catalog is unavailable
+    // (e.g. offline). The provider must still surface the ChatGPT sign-in models.
+    const list = resolveProviderModelList([], undefined, 'openai-codex');
+    expect(list.map((m) => m.id)).toEqual([
+      'gpt-5.5',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.3-codex-spark',
+    ]);
+    expect(list[0]).toMatchObject({
+      id: 'gpt-5.5',
+      name: 'GPT-5.5',
+      description: 'Frontier model for complex coding, research, and real-world work.',
+      capabilities: [],
+    });
+  });
+
+  it('falls back to the codex list for openai-codex when the catalog has zero models', () => {
+    const list = resolveProviderModelList(undefined, catalog([]), 'openai-codex');
+    expect(list.map((m) => m.id)).toEqual([
+      'gpt-5.5',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.3-codex-spark',
+    ]);
+  });
+
+  it('does not synthesize codex models for non-codex providers', () => {
+    expect(resolveProviderModelList([], undefined, 'openai')).toEqual([]);
+    expect(resolveProviderModelList([], catalog([]), 'openai')).toEqual([]);
   });
 });

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,4 +1,4 @@
-import { ConfigError, expectDefined } from '@wrongstack/core';
+import { CODEX_MODELS, ConfigError, expectDefined } from '@wrongstack/core';
 import type {
   Logger,
   ModelsRegistry,
@@ -198,12 +198,7 @@ export async function withCatalogCapabilities(
   log?: Logger,
 ): Promise<Provider> {
   try {
-    const resolved = await capabilitiesFor(
-      registry,
-      providerId,
-      cfg.model ?? '',
-      cfg.customModels,
-    );
+    const resolved = await capabilitiesFor(registry, providerId, cfg.model ?? '', cfg.customModels);
     // `Provider.capabilities` is `readonly`; the property descriptor was
     // set with `writable: false` at construction time. Redefine it so
     // the catalog overlay lands cleanly.
@@ -276,9 +271,7 @@ export async function buildProviderFactoriesFromRegistry(
  */
 function resolveActiveKey(cfg: ProviderConfig): string | undefined {
   if (Array.isArray(cfg.apiKeys) && cfg.apiKeys.length > 0) {
-    const active = cfg.activeKey
-      ? cfg.apiKeys.find((k) => k.label === cfg.activeKey)
-      : undefined;
+    const active = cfg.activeKey ? cfg.apiKeys.find((k) => k.label === cfg.activeKey) : undefined;
     return (active ?? cfg.apiKeys[0])?.apiKey;
   }
   return cfg.apiKey && cfg.apiKey.length > 0 ? cfg.apiKey : undefined;
@@ -288,9 +281,7 @@ function resolveActiveKey(cfg: ProviderConfig): string | undefined {
  *  families that carry refresh tokens / expiry / account id alongside the key. */
 function resolveActiveKeyEntry(cfg: ProviderConfig): ProviderApiKey | undefined {
   if (Array.isArray(cfg.apiKeys) && cfg.apiKeys.length > 0) {
-    const active = cfg.activeKey
-      ? cfg.apiKeys.find((k) => k.label === cfg.activeKey)
-      : undefined;
+    const active = cfg.activeKey ? cfg.apiKeys.find((k) => k.label === cfg.activeKey) : undefined;
     return active ?? cfg.apiKeys[0];
   }
   return undefined;
@@ -315,13 +306,15 @@ function makeProvider(p: ResolvedProvider, cfg: ProviderConfig): Provider {
   if (!family || family === 'unsupported') {
     if (family === 'unsupported') {
       throw new ConfigError({
-        message: `Provider "${p.id}" uses an unsupported wire family (${p.npm ?? 'unknown'}). ` +
+        message:
+          `Provider "${p.id}" uses an unsupported wire family (${p.npm ?? 'unknown'}). ` +
           `Register a custom factory via a plugin to enable it.`,
         code: 'CONFIG_INVALID',
       });
     }
     throw new ConfigError({
-      message: `Provider "${p.id}" has no wire family configured. ` +
+      message:
+        `Provider "${p.id}" has no wire family configured. ` +
         `Set an explicit family ("anthropic" | "openai" | "openai-compatible" | "google") in config or the models.dev catalog.`,
       code: 'CONFIG_INVALID',
     });
@@ -448,10 +441,28 @@ export function makeProviderFromConfig(id: string, cfg: ProviderConfig): Provide
     family: cfg.family,
     apiBase: cfg.baseUrl,
     envVars: cfg.envVars ?? [],
-    models: (cfg.models ?? []).map((m) => ({ id: m, name: m })),
+    models: seedConfigModels(cfg),
     npm: undefined,
   };
   return makeProvider(synthetic, cfg);
+}
+
+/**
+ * Resolve the model list for a config-only Provider. The saved `cfg.models`
+ * allowlist wins when non-empty, but an empty/absent allowlist must NOT yield
+ * an empty picker for OAuth / subscription families whose canonical model list
+ * is known offline — otherwise deleting the models from config (or a fresh
+ * login that hasn't persisted an allowlist yet) leaves the provider showing
+ * zero models. For `openai-codex` (ChatGPT sign-in) we fall back to the
+ * canonical `CODEX_MODELS` catalog so the provider is always populated.
+ */
+function seedConfigModels(cfg: ProviderConfig): Array<{ id: string; name: string }> {
+  const saved = cfg.models ?? [];
+  if (saved.length > 0) return saved.map((m) => ({ id: m, name: m }));
+  if (cfg.family === 'openai-codex' || cfg.type === 'openai-codex') {
+    return CODEX_MODELS.map((m) => ({ id: m.id, name: m.name }));
+  }
+  return [];
 }
 
 function readFromEnv(vars: string[]): string | undefined {

--- a/packages/webui/src/server/routes.ts
+++ b/packages/webui/src/server/routes.ts
@@ -61,11 +61,7 @@ import type { Config } from '@wrongstack/core/types';
 import type { MCPRegistry } from '@wrongstack/mcp';
 import { makeProviderFromConfig } from '@wrongstack/providers';
 
-import {
-  handleGitChanges,
-  handleGitDiff,
-  handleGitInfo,
-} from './git-handlers.js';
+import { handleGitChanges, handleGitDiff, handleGitInfo } from './git-handlers.js';
 import { handleShellOpen, type ShellOpenRequest, type ShellOpenResult } from './shell-open.js';
 import {
   handleMailboxAgents,
@@ -335,15 +331,24 @@ export function buildRoutes(
       send(ws, {
         type: 'provider.catalog',
         payload: {
-          providers: providers.map((p: { id: string; name: string; family: unknown; apiBase?: unknown; envVars: string[]; models: readonly unknown[] }) => ({
-            id: p.id,
-            name: p.name,
-            family: p.family,
-            apiBase: p.apiBase,
-            envVars: p.envVars,
-            modelCount: p.models.length,
-            hasApiKey: savedIds.has(p.id) || p.envVars.some((v: string) => !!process.env[v]),
-          })),
+          providers: providers.map(
+            (p: {
+              id: string;
+              name: string;
+              family: unknown;
+              apiBase?: unknown;
+              envVars: string[];
+              models: readonly unknown[];
+            }) => ({
+              id: p.id,
+              name: p.name,
+              family: p.family,
+              apiBase: p.apiBase,
+              envVars: p.envVars,
+              modelCount: p.models.length,
+              hasApiKey: savedIds.has(p.id) || p.envVars.some((v: string) => !!process.env[v]),
+            }),
+          ),
         },
       });
     },
@@ -362,16 +367,12 @@ export function buildRoutes(
       // reply (possibly empty) — the switcher lazy-loads every saved provider.
       const saved = await providerHandlers.loadConfigProviders();
       const cfg = saved[providerId];
-      const provider = await resolveProviderCatalogForModels(
-        deps.modelsRegistry,
-        providerId,
-        cfg,
-      );
+      const provider = await resolveProviderCatalogForModels(deps.modelsRegistry, providerId, cfg);
       const models = await enrichProviderModelDescriptors(
         deps.modelsRegistry,
         providerId,
         cfg,
-        resolveProviderModelList(cfg?.models, provider),
+        resolveProviderModelList(cfg?.models, provider, cfg?.type ?? providerId),
       );
       send(ws, {
         type: 'provider.models',
@@ -398,7 +399,9 @@ export function buildRoutes(
         // Create new provider instance — fail loudly if the user picks a
         // provider with no creds rather than silently keeping the old one.
         const newCfg = state.getConfig();
-        const providerCfg: ProviderConfig = newCfg.providers?.[newProvider] ?? { type: newProvider };
+        const providerCfg: ProviderConfig = newCfg.providers?.[newProvider] ?? {
+          type: newProvider,
+        };
         const newProv = deps.providerRegistry.has(newProvider)
           ? deps.providerRegistry.create({ ...providerCfg, type: newProvider } as never)
           : makeProviderFromConfig(newProvider, providerCfg);
@@ -468,12 +471,14 @@ export function buildRoutes(
           timeoutMs: 90000,
           ...(reasoning ? { reasoning } : {}),
           onError: (reason: unknown) => {
-            console.warn(JSON.stringify({
-              level: 'warn',
-              event: 'model.refine_failed',
-              reason,
-              timestamp: new Date().toISOString(),
-            }));
+            console.warn(
+              JSON.stringify({
+                level: 'warn',
+                event: 'model.refine_failed',
+                reason,
+                timestamp: new Date().toISOString(),
+              }),
+            );
           },
         });
         if (result) {
@@ -488,12 +493,14 @@ export function buildRoutes(
           });
         }
       } catch (err) {
-        console.error(JSON.stringify({
-          level: 'error',
-          event: 'model.refine.error',
-          error: errMessage(err),
-          timestamp: new Date().toISOString(),
-        }));
+        console.error(
+          JSON.stringify({
+            level: 'error',
+            event: 'model.refine.error',
+            error: errMessage(err),
+            timestamp: new Date().toISOString(),
+          }),
+        );
         send(ws, {
           type: 'model.refine_result',
           payload: { refined: text, english: text, error: errMessage(err) },
@@ -593,15 +600,20 @@ export function buildRoutes(
       const cfg = state.getConfig();
       const features = (cfg.features ?? {}) as unknown as Record<string, unknown>;
       if (typeof payload['featureMcp'] === 'boolean') features['mcp'] = payload['featureMcp'];
-      if (typeof payload['featurePlugins'] === 'boolean') features['plugins'] = payload['featurePlugins'];
-      if (typeof payload['featureMemory'] === 'boolean') features['memory'] = payload['featureMemory'];
-      if (typeof payload['featureSkills'] === 'boolean') features['skills'] = payload['featureSkills'];
-      if (typeof payload['featureModelsRegistry'] === 'boolean') features['modelsRegistry'] = payload['featureModelsRegistry'];
+      if (typeof payload['featurePlugins'] === 'boolean')
+        features['plugins'] = payload['featurePlugins'];
+      if (typeof payload['featureMemory'] === 'boolean')
+        features['memory'] = payload['featureMemory'];
+      if (typeof payload['featureSkills'] === 'boolean')
+        features['skills'] = payload['featureSkills'];
+      if (typeof payload['featureModelsRegistry'] === 'boolean')
+        features['modelsRegistry'] = payload['featureModelsRegistry'];
       cfg.features = features as never;
 
       // Global fallback chain: mutate the live config so the leader's fallback
       // extension (which reads config each turn) honours it without a restart.
-      if (Array.isArray(payload['fallbackModels'])) cfg.fallbackModels = payload['fallbackModels'] as string[];
+      if (Array.isArray(payload['fallbackModels']))
+        cfg.fallbackModels = payload['fallbackModels'] as string[];
       if (
         payload['fallbackProfiles'] &&
         typeof payload['fallbackProfiles'] === 'object' &&
@@ -609,8 +621,10 @@ export function buildRoutes(
       ) {
         cfg.fallbackProfiles = payload['fallbackProfiles'] as Record<string, string[]>;
       }
-      if (Array.isArray(payload['favoriteModels'])) cfg.favoriteModels = payload['favoriteModels'] as string[];
-      if (typeof payload['favoriteModelsOnly'] === 'boolean') cfg.favoriteModelsOnly = payload['favoriteModelsOnly'];
+      if (Array.isArray(payload['favoriteModels']))
+        cfg.favoriteModels = payload['favoriteModels'] as string[];
+      if (typeof payload['favoriteModelsOnly'] === 'boolean')
+        cfg.favoriteModelsOnly = payload['favoriteModelsOnly'];
       if (
         payload['modelMatrix'] &&
         typeof payload['modelMatrix'] === 'object' &&
@@ -629,7 +643,10 @@ export function buildRoutes(
         if (payload['contextAutoCompact'] && deps.autoCompactor) {
           // Re-add: remove first (idempotent via optional), then insert.
           deps.pipelines.contextWindow.remove('AutoCompaction', { optional: true });
-          deps.pipelines.contextWindow.use({ name: 'AutoCompaction', handler: deps.autoCompactor.handler() });
+          deps.pipelines.contextWindow.use({
+            name: 'AutoCompaction',
+            handler: deps.autoCompactor.handler(),
+          });
         } else {
           deps.pipelines.contextWindow.remove('AutoCompaction', { optional: true });
         }
@@ -641,7 +658,7 @@ export function buildRoutes(
       if (typeof payload['logLevel'] === 'string') {
         const valid = ['debug', 'info', 'warn', 'error'] as const;
         if ((valid as readonly string[]).includes(payload['logLevel'])) {
-          (deps.logger as { level: string }).level = payload['logLevel'] as typeof valid[number];
+          (deps.logger as { level: string }).level = payload['logLevel'] as (typeof valid)[number];
         }
       }
 
@@ -674,7 +691,10 @@ export function buildRoutes(
         sendResult(ws, false, parsed.message);
         return;
       }
-      const result: ShellOpenResult = await handleShellOpen(parsed.value as ShellOpenRequest, deps.logger);
+      const result: ShellOpenResult = await handleShellOpen(
+        parsed.value as ShellOpenRequest,
+        deps.logger,
+      );
       sendResult(ws, result.success, result.message);
     },
   };
@@ -705,10 +725,10 @@ export function buildRoutes(
       );
     },
     clear: (ws) =>
-      handleMailboxClear(
-        ws,
-        { projectRoot: state.getProjectRoot(), globalRoot: path.dirname(deps.globalConfigPath) },
-      ),
+      handleMailboxClear(ws, {
+        projectRoot: state.getProjectRoot(),
+        globalRoot: path.dirname(deps.globalConfigPath),
+      }),
     purge: (ws, msg) => {
       const parsed = validateMailboxPurgePayload(msg.payload);
       if (!parsed.ok) {
@@ -779,7 +799,10 @@ export function buildRoutes(
           risk: 'medium',
           fallback: 'ask_human',
         });
-        send(ws, { type: 'brain.answer', payload: { sessionId: deps.context.session?.id, question, decision } });
+        send(ws, {
+          type: 'brain.answer',
+          payload: { sessionId: deps.context.session?.id, question, decision },
+        });
       } catch (err) {
         sendResult(ws, false, `Brain consultation failed: ${errMessage(err)}`);
       }


### PR DESCRIPTION
## fix(core,providers): keep openai-codex model picker populated when allowlist is empty

### Problem

When a user with a ChatGPT sign-in (`openai-codex`) provider deletes the
`models` field from config (or runs a fresh login that hasn't persisted an
allowlist yet), the WebUI model picker shows **zero models** for that provider.

Affected surfaces: WebUI Settings → Model picker for `openai-codex`, and the
CLI's webui-server WS `provider.models` reply.

### Root cause

Two code paths returned `[]` whenever `cfg.models` was empty/absent:

1. **`packages/core/src/models/provider-model-resolve.ts` — `resolveProviderModelList`**
   - The old allowlist-empty branch fell through to `catalog.models` only when
     `catalog` was truthy. When `models.dev`'s catalog omits `openai-codex`
     (its catalog data lives in the curated overlay, not on models.dev), the
     `catalog` was either `undefined` or had `models: []`, so the resolver
     returned `[]`.

2. **`packages/providers/src/index.ts` — `makeProviderFromConfig`**
   - `cfg.models ?? []` was mapped verbatim. Empty config → empty picker,
     with no fallback to the canonical offline list.

### Fix

Layered fallback, in priority order:

```
saved allowlist (non-empty)
  → resolved catalog with at least one model
    → for `openai-codex` only, the offline canonical `CODEX_MODELS`
      → []  (existing behavior — never silently fabricate models for
              unrelated providers)
```

Concrete changes:

- **`provider-model-resolve.ts`** —
  - `resolveProviderModelList` gains an optional `providerHint?: string`
    third arg and an early `catalog && catalog.models.length > 0` guard.
  - When `providerHint === 'openai-codex'`, returns
    `CODEX_MODELS.map(m => ({ id, name, description, capabilities: [] }))`.

- **`packages/providers/src/index.ts`** —
  - Imports `CODEX_MODELS` from `@wrongstack/core`.
  - Introduces `seedConfigModels(cfg)` and uses it in
    `makeProviderFromConfig`. For `cfg.family === 'openai-codex'` or
    `cfg.type === 'openai-codex'`, falls back to `CODEX_MODELS` when
    `cfg.models` is empty/absent.

- **Call sites (thread the hint through):**
  - `packages/cli/src/webui-server/ws-handlers/providers.ts` —
    `resolveProviderModelList(cfg?.models, provider, cfg?.type ?? providerId)`.
  - `packages/webui/src/server/routes.ts` — same call shape in the
    `provider.models` handler.

### Repro

`tmp_repro.cjs` (already deleted, kept here for reference):

```js
// Merges ~/.wrongstack/cache/models.dev.json + models-overlay.json
// Extracts openai-codex, then calls resolveProviderModelList([], provider, 'openai-codex')
// Before fix: `[]`
// After fix: ["gpt-5.5","gpt-5.4","gpt-5.4-mini","gpt-5.3-codex-spark"]
```

Manual reproduction (UI path):

1. Sign in with ChatGPT in the CLI; the new account has no `models`
   allowlist persisted.
2. Open WebUI → Settings → switch provider to "OpenAI (ChatGPT sign-in)".
3. **Before:** model picker is empty.
4. **After:** picker shows gpt-5.5 (default), gpt-5.4, gpt-5.4-mini,
   gpt-5.3-codex-spark.

### Why this layer, not the overlay

`CODEX_MODELS` is already documented as the offline floor (`codex-catalog.ts`
line 11) when the registry overlay is unavailable. The drift-guard test
`packages/cli/tests/codex-catalog-overlay-sync.test.ts` keeps the overlay and
this floor in lockstep. So we are not introducing a third source of truth —
we're plumbing an existing one to where it was missing.

### Out of scope / follow-up

- The same fallback is **not** wired for other OAuth families (e.g.
  `claude-code`). Intentional for now — those providers don't have a canonical
  offline catalog and the empty picker is the honest answer. Add per-family
  catalogs only when each provider ships one.

### Files

- `packages/core/src/models/provider-model-resolve.ts` (signature + body)
- `packages/providers/src/index.ts` (`seedConfigModels` + rewire)
- `packages/cli/src/webui-server/ws-handlers/providers.ts` (thread hint)
- `packages/webui/src/server/routes.ts` (thread hint)
