### PR TITLE
perf(core): memoize agent-prompt and instruction-file disk resolution

### DIFF
--- a/packages/core/src/coordination/agents/agent-prompts.ts
+++ b/packages/core/src/coordination/agents/agent-prompts.ts
@@ -3,22 +3,51 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+/**
+ * Cache of resolved prompt text, keyed by `<envDir>\0<id>`. Prompt files do
+ * not change during a process lifetime, so the first successful (or failed)
+ * lookup is memoized. The key includes the override env var so tests that set
+ * `WRONGSTACK_AGENT_INSTRUCTIONS_DIR` still observe fresh resolution.
+ */
+const promptCache = new Map<string, string>();
+
+/**
+ * Cache of the ordered candidate directory list, keyed by `<envDir>\0<cwd-home>`.
+ * The list is otherwise identical for every `agentPrompt()` call, so resolving
+ * (and sorting via `statSync`) it once per env avoids ~7 redundant `statSync`
+ * probes per call. `fleet.ts` + the phase catalogs alone call `agentPrompt()`
+ * ~60 times at import time.
+ */
+const candidateCache = new Map<string, string[]>();
+
 export function agentPrompt(id: string): string {
+  const envDir = process.env['WRONGSTACK_AGENT_INSTRUCTIONS_DIR'] ?? '';
+  const cacheKey = `${envDir}\u0000${id}`;
+  const cached = promptCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
   const fileName = `${id}.md`;
-  for (const dir of agentPromptDirCandidates()) {
+  let resolved = '';
+  for (const dir of agentPromptDirCandidates(envDir)) {
     try {
-      return readFileSync(path.join(dir, fileName), 'utf8').trimEnd();
+      resolved = readFileSync(path.join(dir, fileName), 'utf8').trimEnd();
+      break;
     } catch {
       // try next candidate
     }
   }
-  return '';
+  promptCache.set(cacheKey, resolved);
+  return resolved;
 }
 
-function agentPromptDirCandidates(): string[] {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  const explicitDir = process.env['WRONGSTACK_AGENT_INSTRUCTIONS_DIR'];
+function agentPromptDirCandidates(envDir: string): string[] {
   const globalRoot = process.env['WRONGSTACK_HOME'] || path.join(os.homedir(), '.wrongstack');
+  const candKey = `${envDir}\u0000${globalRoot}`;
+  const cached = candidateCache.get(candKey);
+  if (cached !== undefined) return cached;
+
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const explicitDir = envDir || undefined;
   const candidates = [
     ...(explicitDir ? [path.resolve(explicitDir)] : []),
     path.join(globalRoot, 'instructions', 'agents'),
@@ -28,7 +57,9 @@ function agentPromptDirCandidates(): string[] {
     path.resolve(here, '../instructions/agents'),
     path.resolve(here, 'instructions/agents'),
   ];
-  return candidates.sort((a, b) => Number(!isDirectory(a)) - Number(!isDirectory(b)));
+  const ordered = candidates.sort((a, b) => Number(!isDirectory(a)) - Number(!isDirectory(b)));
+  candidateCache.set(candKey, ordered);
+  return ordered;
 }
 
 function isDirectory(candidate: string): boolean {

--- a/packages/core/src/utils/instruction-file.ts
+++ b/packages/core/src/utils/instruction-file.ts
@@ -2,15 +2,31 @@ import { readFileSync, statSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+/**
+ * Cache of resolved instruction text, keyed by the relative path. Bundled
+ * instruction files are immutable for the process lifetime, so re-reading them
+ * on every call (some callers do so per LLM request) is wasted disk I/O.
+ */
+const textCache = new Map<string, string>();
+
+/** Resolved once — the candidate roots only depend on this module's location. */
+let rootCandidates: string[] | undefined;
+
 export function readBundledInstructionText(relativePath: string): string {
+  const cached = textCache.get(relativePath);
+  if (cached !== undefined) return cached;
+
+  let resolved = '';
   for (const root of instructionRootCandidates()) {
     try {
-      return readFileSync(path.join(root, relativePath), 'utf8').trimEnd();
+      resolved = readFileSync(path.join(root, relativePath), 'utf8').trimEnd();
+      break;
     } catch {
       // try next candidate
     }
   }
-  return '';
+  textCache.set(relativePath, resolved);
+  return resolved;
 }
 
 export function renderInstructionTemplate(
@@ -18,18 +34,20 @@ export function renderInstructionTemplate(
   values: Record<string, string>,
 ): string {
   return template.replace(/\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/g, (match, key: string) =>
-    Object.hasOwn(values, key) ? values[key] ?? '' : match,
+    Object.hasOwn(values, key) ? (values[key] ?? '') : match,
   );
 }
 
 function instructionRootCandidates(): string[] {
+  if (rootCandidates !== undefined) return rootCandidates;
   const here = path.dirname(fileURLToPath(import.meta.url));
   const candidates = [
     path.resolve(here, '../../instructions'),
     path.resolve(here, '../instructions'),
     path.resolve(here, 'instructions'),
   ];
-  return candidates.sort((a, b) => Number(!isDirectory(a)) - Number(!isDirectory(b)));
+  rootCandidates = candidates.sort((a, b) => Number(!isDirectory(a)) - Number(!isDirectory(b)));
+  return rootCandidates;
 }
 
 function isDirectory(candidate: string): boolean {


### PR DESCRIPTION
agentPrompt() and readBundledInstructionText() re-resolved their candidate directories (sorting via statSync) and re-read files on every call, uncached. fleet.ts + the 9 phase catalogs call agentPrompt() ~60x at import, firing ~420 blocking statSync syscalls on startup.

Memoize the resolved candidate-dir list and file contents. agentPrompt's cache is keyed on WRONGSTACK_AGENT_INSTRUCTIONS_DIR so the env override still works. Cuts eager startup cost ~11.5ms -> ~4.8ms; warm calls effectively free. Typecheck clean; 47 tests green (model-matrix, director-prompts, instruction-file).