### PR TITLE
test(webui-hq): add mailbox-time and mailbox-filters coverage

### DIFF
--- a/packages/webui-hq/tests/mailbox-filters.test.ts
+++ b/packages/webui-hq/tests/mailbox-filters.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import type { MailboxLiveFilterState } from '../src/views/mailbox-filters.js';
+import { EMPTY_LIVE_FILTER_STATE, mailboxLiveFilterReducer } from '../src/views/mailbox-filters.js';
+
+describe('mailbox-filters reducer', () => {
+  it('returns initial state on clear-all action', () => {
+    const dirtyState: MailboxLiveFilterState = {
+      types: new Set(['note']),
+      priorities: new Set(['high']),
+      projectIds: new Set(['demo']),
+      includeCompleted: false,
+      query: 'search query',
+    };
+    const next = mailboxLiveFilterReducer(dirtyState, { type: 'clear-all' });
+    expect(next).toEqual(EMPTY_LIVE_FILTER_STATE);
+  });
+
+  it('returns the canonical empty singleton on clear-all (reference equality)', () => {
+    // clear-all should return the shared frozen singleton verbatim so
+    // React's reference check can short-circuit a no-op re-render.
+    const dirtyState: MailboxLiveFilterState = {
+      types: new Set(['note']),
+      priorities: new Set(['high']),
+      projectIds: new Set(['demo']),
+      includeCompleted: false,
+      query: 'search query',
+    };
+    const next = mailboxLiveFilterReducer(dirtyState, { type: 'clear-all' });
+    expect(next).toBe(EMPTY_LIVE_FILTER_STATE);
+  });
+
+  it('handles toggle-type action', () => {
+    // Add a type
+    let state = mailboxLiveFilterReducer(EMPTY_LIVE_FILTER_STATE, {
+      type: 'toggle-type',
+      value: 'note',
+    });
+    expect(state.types.has('note')).toBe(true);
+
+    // Remove the type
+    state = mailboxLiveFilterReducer(state, {
+      type: 'toggle-type',
+      value: 'note',
+    });
+    expect(state.types.has('note')).toBe(false);
+  });
+
+  it('handles toggle-priority action', () => {
+    // Add priority
+    let state = mailboxLiveFilterReducer(EMPTY_LIVE_FILTER_STATE, {
+      type: 'toggle-priority',
+      value: 'high',
+    });
+    expect(state.priorities.has('high')).toBe(true);
+
+    // Remove priority
+    state = mailboxLiveFilterReducer(state, {
+      type: 'toggle-priority',
+      value: 'high',
+    });
+    expect(state.priorities.has('high')).toBe(false);
+  });
+
+  it('handles toggle-project action', () => {
+    // Add project
+    let state = mailboxLiveFilterReducer(EMPTY_LIVE_FILTER_STATE, {
+      type: 'toggle-project',
+      value: 'my-project',
+    });
+    expect(state.projectIds.has('my-project')).toBe(true);
+
+    // Remove project
+    state = mailboxLiveFilterReducer(state, {
+      type: 'toggle-project',
+      value: 'my-project',
+    });
+    expect(state.projectIds.has('my-project')).toBe(false);
+  });
+
+  it('handles set-query action', () => {
+    const state = mailboxLiveFilterReducer(EMPTY_LIVE_FILTER_STATE, {
+      type: 'set-query',
+      value: 'test query',
+    });
+    expect(state.query).toBe('test query');
+  });
+
+  it('handles set-include-completed action', () => {
+    let state = mailboxLiveFilterReducer(EMPTY_LIVE_FILTER_STATE, {
+      type: 'set-include-completed',
+      value: false,
+    });
+    expect(state.includeCompleted).toBe(false);
+
+    // Toggle back to true to exercise both directions.
+    state = mailboxLiveFilterReducer(state, {
+      type: 'set-include-completed',
+      value: true,
+    });
+    expect(state.includeCompleted).toBe(true);
+  });
+
+  describe('immutability', () => {
+    it('does not mutate the previous state when toggling a Set', () => {
+      const before = EMPTY_LIVE_FILTER_STATE;
+      const after = mailboxLiveFilterReducer(before, {
+        type: 'toggle-type',
+        value: 'note',
+      });
+      // A new state object is returned...
+      expect(after).not.toBe(before);
+      // ...the toggled Set is a fresh copy, not the shared instance...
+      expect(after.types).not.toBe(before.types);
+      // ...and the previous state (including the shared singleton's Set)
+      // is left untouched, so later `clear-all`s stay clean.
+      expect(before.types.has('note')).toBe(false);
+      expect(before.types.size).toBe(0);
+    });
+
+    it('preserves unrelated slices by reference on a partial update', () => {
+      const before = EMPTY_LIVE_FILTER_STATE;
+      const after = mailboxLiveFilterReducer(before, {
+        type: 'toggle-priority',
+        value: 'high',
+      });
+      // Only `priorities` changed; the other Sets are carried over by
+      // reference (spread), which keeps memoized selectors stable.
+      expect(after.priorities).not.toBe(before.priorities);
+      expect(after.types).toBe(before.types);
+      expect(after.projectIds).toBe(before.projectIds);
+    });
+
+    it('does not leak Set mutations across reducer calls', () => {
+      // Add then remove the same project; the intermediate state must not
+      // have been mutated in place by the second dispatch.
+      const added = mailboxLiveFilterReducer(EMPTY_LIVE_FILTER_STATE, {
+        type: 'toggle-project',
+        value: 'demo',
+      });
+      const removed = mailboxLiveFilterReducer(added, {
+        type: 'toggle-project',
+        value: 'demo',
+      });
+      expect(added.projectIds.has('demo')).toBe(true);
+      expect(removed.projectIds.has('demo')).toBe(false);
+      expect(removed.projectIds).not.toBe(added.projectIds);
+    });
+  });
+});

--- a/packages/webui-hq/tests/mailbox-time.test.ts
+++ b/packages/webui-hq/tests/mailbox-time.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatMailboxTime,
+  formatRelativeTime,
+  shortMailboxId,
+} from '../src/views/mailbox-time.js';
+
+describe('mailbox-time', () => {
+  describe('formatMailboxTime', () => {
+    it('formats valid ISO timestamp', () => {
+      const ts = '2026-07-04T12:00:00.000Z';
+      const formatted = formatMailboxTime(ts);
+      expect(formatted).toBe(new Date(ts).toLocaleString());
+    });
+
+    it('returns raw string on parse failure', () => {
+      const invalid = 'not-a-timestamp';
+      expect(formatMailboxTime(invalid)).toBe(invalid);
+    });
+  });
+
+  describe('formatRelativeTime', () => {
+    const mockNow = new Date('2026-07-04T12:00:00.000Z').getTime();
+
+    it('returns seconds ago', () => {
+      const ts = '2026-07-04T11:59:30.000Z'; // 30s ago
+      expect(formatRelativeTime(ts, mockNow)).toBe('30s ago');
+    });
+
+    it('returns minutes ago', () => {
+      const ts = '2026-07-04T11:55:00.000Z'; // 5m ago
+      expect(formatRelativeTime(ts, mockNow)).toBe('5m ago');
+    });
+
+    it('returns hours ago', () => {
+      const ts = '2026-07-04T09:00:00.000Z'; // 3h ago
+      expect(formatRelativeTime(ts, mockNow)).toBe('3h ago');
+    });
+
+    it('returns days ago', () => {
+      const ts = '2026-07-02T12:00:00.000Z'; // 2d ago
+      expect(formatRelativeTime(ts, mockNow)).toBe('2d ago');
+    });
+
+    it('returns weeks ago', () => {
+      const ts = '2026-06-20T12:00:00.000Z'; // 2w ago
+      expect(formatRelativeTime(ts, mockNow)).toBe('2w ago');
+    });
+
+    it('returns months ago', () => {
+      const ts = '2026-05-04T12:00:00.000Z'; // 2mo ago
+      expect(formatRelativeTime(ts, mockNow)).toBe('2mo ago');
+    });
+
+    it('returns years ago', () => {
+      const ts = '2024-07-04T12:00:00.000Z'; // 2y ago
+      expect(formatRelativeTime(ts, mockNow)).toBe('2y ago');
+    });
+
+    it('clamps future timestamps to "0s ago"', () => {
+      const future = '2026-07-04T12:00:30.000Z'; // 30s in the future
+      expect(formatRelativeTime(future, mockNow)).toBe('0s ago');
+    });
+
+    it('crosses the minute boundary at exactly 60s', () => {
+      const oneMinute = '2026-07-04T11:59:00.000Z'; // exactly 60s ago
+      expect(formatRelativeTime(oneMinute, mockNow)).toBe('1m ago');
+    });
+
+    it('defaults `now` to the current time', () => {
+      // Without an explicit `now`, a timestamp taken just now should
+      // read as a sub-minute "Ns ago" bucket rather than falling back
+      // to the raw string.
+      const justNow = new Date().toISOString();
+      expect(formatRelativeTime(justNow)).toMatch(/^\d+s ago$/);
+    });
+
+    it('returns raw string on invalid input', () => {
+      const invalid = 'invalid';
+      expect(formatRelativeTime(invalid, mockNow)).toBe(invalid);
+    });
+  });
+
+  describe('shortMailboxId', () => {
+    it('truncates UUID or long ID to 14 chars', () => {
+      const longId = '1234567890abcdef1234567890';
+      expect(shortMailboxId(longId)).toBe('12345678…7890');
+    });
+
+    it('returns short ID unchanged', () => {
+      const shortId = '123456';
+      expect(shortMailboxId(shortId)).toBe(shortId);
+    });
+
+    it('returns ID of exactly 14 characters unchanged', () => {
+      const fourteen = '12345678901234';
+      expect(shortMailboxId(fourteen)).toBe(fourteen);
+    });
+
+    it('truncates at the first char over the threshold (15)', () => {
+      const fifteen = '123456789012345';
+      // first 8 + ellipsis + last 4
+      expect(shortMailboxId(fifteen)).toBe('12345678…2345');
+    });
+
+    it('returns an empty string unchanged', () => {
+      expect(shortMailboxId('')).toBe('');
+    });
+  });
+});


### PR DESCRIPTION

  ### What
  Added and strengthened unit tests for two previously untested modules in `packages/webui-hq`:
  - `mailbox-time.ts` — ISO timestamp formatting, relative-time bucket boundaries
    (future-clamp, 60s crossover, default `now`), and ID truncation edge cases.
  - `mailbox-filters.ts` — the live-feed filter state reducer across all action types,
    with explicit immutability coverage (fresh Set copies, unrelated slices preserved
    by reference, `clear-all` returning the shared singleton for no-op render
    short-circuiting).

  ### Why
  `webui-hq` has 23 source files but only a couple of test files. These two modules are
  pure utility/reducer logic with zero side effects — ideal candidates for robust unit
  coverage to lock in behavior and prevent regressions.

  ### How to verify
  Run the vitest suite locally:
  `pnpm exec vitest run packages/webui-hq/tests/`

