### PR TITLE
chore(main): resolve pre-existing biome lint failures on main

### DIFF
--- a/packages/cli/src/hq-static-serve.ts
+++ b/packages/cli/src/hq-static-serve.ts
@@ -9,7 +9,7 @@
 import { createRequire } from 'node:module';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as http from 'node:http';
+import type * as http from 'node:http';
 
 const requireFromHere = createRequire(import.meta.url);
 

--- a/packages/cli/src/wiring/plugins.ts
+++ b/packages/cli/src/wiring/plugins.ts
@@ -318,7 +318,10 @@ export async function setupPlugins(params: PluginsWiringDeps): Promise<void> {
   // live under `~/.wrongstack/projects/<slug>/` and follows the intent
   // documented on `PluginsWiringDeps.paths.projectDir`.
   if (paths?.projectDir) {
-    const todoTrackerOpts = (pluginOptions['todo-tracker'] ??= {});
+    if (pluginOptions['todo-tracker'] === undefined) {
+      pluginOptions['todo-tracker'] = {};
+    }
+    const todoTrackerOpts = pluginOptions['todo-tracker'];
     if (typeof todoTrackerOpts['filePath'] !== 'string' || todoTrackerOpts['filePath'] === '') {
       todoTrackerOpts['filePath'] = join(paths.projectDir, 'todo-tracker.json');
     }

--- a/packages/tui/src/components/auth-panel.tsx
+++ b/packages/tui/src/components/auth-panel.tsx
@@ -218,10 +218,9 @@ export function AuthPanel({ panel }: AuthPanelProps): React.ReactElement {
       {panel.view === 'flow' ? (
         <Box flexDirection="column" marginTop={1}>
           {logWindow.length === 0 && !panel.flowDone ? <Text dimColor>Starting…</Text> : null}
-          {logWindow.map((line, i) => (
+          {logWindow.map((line) => (
             <Text
-              // biome-ignore lint/suspicious/noArrayIndexKey: append-only log window
-              key={`log-${i}`}
+              key={line}
               wrap="truncate-end"
               color={line.startsWith('✗') ? 'red' : line.startsWith('✓') ? 'green' : undefined}
               dimColor={!line.startsWith('✗') && !line.startsWith('✓')}

--- a/packages/webui-hq/src/app.tsx
+++ b/packages/webui-hq/src/app.tsx
@@ -2,7 +2,7 @@
  * HQ dashboard root — activity bar + view router + status bar.
  * Offline React app, no CDN. Connects to /ws/browser on mount.
  */
-import React from 'react';
+import type React from 'react';
 import { useHqStore, setActiveView, type ViewId } from './store.js';
 import { FleetMapView } from './views/fleet-map.js';
 import { LiveConsoleView } from './views/live-console.js';

--- a/packages/webui-hq/src/store.ts
+++ b/packages/webui-hq/src/store.ts
@@ -3,7 +3,7 @@
  * dependency). Holds the latest snapshot, recent events, active alerts, and
  * UI state (selected node, active view). Subscribes to the WS client once.
  */
-import { useEffect, useState, useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 import type { HqAlertMessage, HqEventEnvelope, HqSnapshot } from '@wrongstack/core';
 import { getHqClient } from './lib/hq-ws-client.js';
 

--- a/packages/webui-hq/src/views/alerts.tsx
+++ b/packages/webui-hq/src/views/alerts.tsx
@@ -2,7 +2,8 @@
  * Alerts view — live alert feed + active alerts.
  * Fed by `hq.alert` WS messages (Phase 6) + /api/alerts history.
  */
-import React, { useEffect, useState } from 'react';
+import type React from 'react';
+import { useEffect, useState } from 'react';
 import { useHqStore, fetchJson } from '../store.js';
 import type { HqAlert } from '@wrongstack/core';
 

--- a/packages/webui-hq/src/views/brain.tsx
+++ b/packages/webui-hq/src/views/brain.tsx
@@ -2,7 +2,7 @@
  * Brain view — decision requests, answers, denials, interventions timeline.
  * Fed by `brain.event` envelopes from Phase 1.
  */
-import React from 'react';
+import type React from 'react';
 import { useHqStore } from '../store.js';
 import type { HqBrainEventPayload } from '@wrongstack/core';
 

--- a/packages/webui-hq/src/views/control.tsx
+++ b/packages/webui-hq/src/views/control.tsx
@@ -2,7 +2,8 @@
  * Control view — enqueue commands to connected clients (steer/abort/spawn/broadcast).
  * Only clients advertising `control.receive` are targetable.
  */
-import React, { useState } from 'react';
+import type React from 'react';
+import { useState } from 'react';
 import { useHqStore, selectClient, postCommand } from '../store.js';
 
 type CmdType = 'steer' | 'abort' | 'spawn' | 'broadcast';

--- a/packages/webui-hq/src/views/cost.tsx
+++ b/packages/webui-hq/src/views/cost.tsx
@@ -1,7 +1,7 @@
 /**
  * Cost view — fleet-wide cost breakdown by project.
  */
-import React from 'react';
+import type React from 'react';
 import { useHqStore } from '../store.js';
 
 export function CostView(): React.ReactElement {

--- a/packages/webui-hq/src/views/fleet-map.tsx
+++ b/packages/webui-hq/src/views/fleet-map.tsx
@@ -2,7 +2,7 @@
  * FleetMap view — machine → project → terminal → agent tree.
  * The spine of the HQ dashboard. Click a session to open it in Console.
  */
-import React from 'react';
+import type React from 'react';
 import { useHqStore, selectSession } from '../store.js';
 import type { HqSessionSnapshotPayload } from '@wrongstack/core';
 

--- a/packages/webui-hq/src/views/live-console.tsx
+++ b/packages/webui-hq/src/views/live-console.tsx
@@ -2,7 +2,8 @@
  * LiveConsole view — full chat transcript for the selected session.
  * Fetches /api/sessions/:id/events on selection, then streams live.
  */
-import React, { useEffect, useState } from 'react';
+import type React from 'react';
+import { useEffect, useState } from 'react';
 import { useHqStore, fetchJson } from '../store.js';
 import type { HqTranscriptEntry } from '@wrongstack/core';
 

--- a/packages/webui-hq/src/views/trends.tsx
+++ b/packages/webui-hq/src/views/trends.tsx
@@ -1,7 +1,8 @@
 /**
  * Trends view — time-bucketed cost + activity from /api/trends/cost.
  */
-import React, { useEffect, useState } from 'react';
+import type React from 'react';
+import { useEffect, useState } from 'react';
 import { fetchJson } from '../store.js';
 import type { HqTimeseriesSample } from '@wrongstack/core';
 

--- a/packages/webui-hq/src/views/worktree.tsx
+++ b/packages/webui-hq/src/views/worktree.tsx
@@ -2,7 +2,7 @@
  * Worktree view — git worktree lifecycle swim-lanes (AutoPhase build phases).
  * Fed by `worktree.event` envelopes from Phase 1.
  */
-import React from 'react';
+import type React from 'react';
 import { useHqStore } from '../store.js';
 import type { HqWorktreeEventPayload } from '@wrongstack/core';
 

--- a/packages/webui/tests/i18n/locale-switch.test.tsx
+++ b/packages/webui/tests/i18n/locale-switch.test.tsx
@@ -21,7 +21,6 @@
  */
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import type React from 'react';
 import { i18n, useAppTranslation } from '../../src/i18n';
 import { useLocalPrefs } from '../../src/stores/local-prefs';
 import settings_en from '../../src/i18n/locales/en/settings.json';


### PR DESCRIPTION
Resolves the lint failures that have been blocking CI for subsequent merges.

**Auto-fixed** (\`biome lint --write --unsafe\`):
- packages/webui-hq/src/{app,store}.tsx — \`lint/style/useImportType\` for \`import React\` / \`import * as http\`.
- 8 view modules under packages/webui-hq/src/views/{alerts,brain,control,cost,fleet-map,live-console,trends,worktree}.tsx — same rule.
- packages/cli/src/hq-static-serve.ts — same rule for \`import * as http\`.
- packages/webui/tests/i18n/locale-switch.test.tsx — \`lint/correctness/noUnusedImports\` (\`import type React\`).

**Manually fixed**:
- packages/cli/src/wiring/plugins.ts — \`lint/suspicious/noAssignInExpressions\`: replaced \`(pluginOptions['todo-tracker'] ??= {})\` with an explicit undefined check.
- packages/tui/src/components/auth-panel.tsx — removed stale \`biome-ignore\` suppression and replaced index-based \`key={log-${i}}\` with a stable \`key={line}\`.

**Verification**: \`pnpm exec biome lint\` → Checked 2799 files in 1889ms. No fixes applied. Zero errors, zero warnings.

CI was previously red for every PR touching main because of these pre-existing lint rules. Merging this branch unblocks the lint step.