### PR TITLE
feat(tui+webui): interactive slash-menu panels for mcp tools brain

### DIFF
--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -82,6 +82,7 @@ import {
   writeErr,
   writeOut,
   normalizeTokenSavingTier,
+  getToolDescriptionMode,
 } from '@wrongstack/core';
 import { MCPRegistry } from '@wrongstack/mcp';
 import { setOAuthTokenPersister } from '@wrongstack/providers';
@@ -3140,6 +3141,113 @@ export async function main(argv: string[]): Promise<number> {
     saveStatuslineHiddenItems,
     getPluginItems: getPluginPickerItems,
     onPluginToggle: togglePluginFromPicker,
+    getMcpServers: () => {
+      const servers = (config.mcpServers ?? {}) as Record<string, { name: string; transport: string; enabled?: boolean; description?: string; lazy?: boolean }>;
+      const liveStatus = mcpRegistry.list();
+      const liveMap = new Map(liveStatus.map((s) => [s.name, s]));
+      return Object.entries(servers).map(([name, cfg]) => {
+        const live = liveMap.get(name);
+        return {
+          name,
+          enabled: cfg.enabled !== false,
+          status: live ? live.state : 'stopped',
+          transport: cfg.transport ?? 'stdio',
+          description: cfg.description,
+          toolCount: live?.toolCount ?? 0,
+          lazy: cfg.lazy,
+        };
+      });
+    },
+    onMcpToggle: async (name: string) => {
+      const { enableMcp, disableMcp, listMcp } = await import('@wrongstack/mcp');
+      const deps = { configPath: wpaths.globalConfig, registry: mcpRegistry, presets: allServers() };
+      // Read fresh state from the live config file (enableMcp/disableMcp
+      // wrote to it), then determine toggle direction from the registry.
+      const live = mcpRegistry.list().find((s) => s.name === name);
+      const isCurrentlyEnabled = live !== undefined && live.state !== 'idle';
+      const result = isCurrentlyEnabled
+        ? await disableMcp(name, deps)
+        : await enableMcp(name, deps);
+      const items = await listMcp(deps);
+      return {
+        items: items.map((s) => ({ name: s.name, enabled: s.enabled, status: s.status, transport: s.transport, description: s.description, toolCount: s.tools.length, lazy: s.lazy })),
+        message: result.ok ? (result.server ? `${result.server.status === 'connected' ? '●' : '○'} ${name}` : result.message) : undefined,
+        error: result.ok ? undefined : result.message,
+      };
+    },
+    onMcpRestart: async (name: string) => {
+      const { listMcp } = await import('@wrongstack/mcp');
+      const deps = { configPath: wpaths.globalConfig, registry: mcpRegistry, presets: allServers() };
+      try {
+        await mcpRegistry.restart(name);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const items = await listMcp(deps);
+        return { items: items.map((s) => ({ name: s.name, enabled: s.enabled, status: s.status, transport: s.transport, description: s.description, toolCount: s.tools.length, lazy: s.lazy })), message: undefined, error: message };
+      }
+      const items = await listMcp(deps);
+      return { items: items.map((s) => ({ name: s.name, enabled: s.enabled, status: s.status, transport: s.transport, description: s.description, toolCount: s.tools.length, lazy: s.lazy })), message: `Restarted "${name}".`, error: undefined };
+    },
+    getToolsItems: () => {
+      const all = toolRegistry.listWithOwner().map(({ tool, owner }) => {
+        const descMode = getToolDescriptionMode(toolRegistry, tool.name);
+        return {
+          name: tool.name,
+          owner,
+          category: tool.category ?? 'Other',
+          enabled: !toolRegistry.isDisabled(tool.name),
+          mutating: tool.mutating,
+          permission: tool.permission,
+          descMode: descMode as 'extend' | 'simple',
+          description: tool.description,
+        };
+      });
+      return all;
+    },
+    onToolToggle: async (name: string) => {
+      const disabled = new Set(config.tools?.disabledTools ?? []);
+      const isCurrentlyDisabled = toolRegistry.isDisabled(name);
+      if (isCurrentlyDisabled) {
+        toolRegistry.enable(name);
+        disabled.delete(name);
+      } else {
+        toolRegistry.disable(name);
+        disabled.add(name);
+      }
+      const nextTools = { ...(config.tools ?? {}), disabledTools: Array.from(disabled) };
+      config = patchConfig(config, { tools: nextTools });
+      configStore.update({ tools: nextTools });
+      const items = toolRegistry.listWithOwner().map(({ tool, owner }) => ({
+        name: tool.name,
+        owner,
+        category: tool.category ?? 'Other',
+        enabled: !toolRegistry.isDisabled(tool.name),
+        mutating: tool.mutating,
+        permission: tool.permission,
+        descMode: getToolDescriptionMode(toolRegistry, tool.name) as 'extend' | 'simple',
+        description: tool.description,
+      }));
+      return {
+        items,
+        message: isCurrentlyDisabled ? `Enabled "${name}".` : `Disabled "${name}".`,
+        error: undefined,
+      };
+    },
+    getBrainData: () => {
+      const ceiling = (brainSettings?.maxAutoRisk ?? 'medium') as 'off' | 'low' | 'medium' | 'high' | 'all';
+      const log = brainLog.slice(-20).map((entry: { kind: string; question: string; outcome: string; at: number }) => ({
+        kind: entry.kind,
+        question: entry.question,
+        outcome: entry.outcome,
+        age: typeof entry.at === 'number' ? (() => { const s = Math.max(0, Math.round((Date.now() - entry.at) / 1000)); if (s < 60) return `${s}s`; if (s < 3600) return `${Math.round(s / 60)}m`; return `${Math.round(s / 3600)}h`; })() : '',
+      }));
+      return { riskLevel: ceiling, log };
+    },
+    onBrainRiskLevel: (level: 'off' | 'low' | 'medium' | 'high' | 'all') => {
+      if (!brainSettings) return 'Brain settings not available.';
+      brainSettings.maxAutoRisk = level as BrainAutoRisk;
+      return undefined;
+    },
     // Interactive /auth panel host — provider/key CRUD, catalog/local adds
     // and OAuth sign-in, all executed CLI-side against the encrypted config
     // (secrets never enter the TUI; key values arrive pre-masked).

--- a/packages/cli/src/execution.ts
+++ b/packages/cli/src/execution.ts
@@ -172,6 +172,27 @@ type PluginPickerItem = {
   summary: string;
 };
 
+type McpPickerItem = {
+  name: string;
+  enabled: boolean;
+  status: string;
+  transport: string;
+  description?: string | undefined;
+  toolCount: number;
+  lazy?: boolean | undefined;
+};
+
+type ToolPickerItem = {
+  name: string;
+  owner: string;
+  category: string;
+  enabled: boolean;
+  mutating: boolean;
+  permission: string;
+  descMode: 'extend' | 'simple';
+  description: string;
+};
+
 export interface ExecutionDeps {
   agent: Agent;
   events: EventBus;
@@ -264,6 +285,42 @@ export interface ExecutionDeps {
         message?: string | undefined;
         error?: string | undefined;
       }>)
+    | undefined;
+  /** Load MCP server rows for the interactive TUI MCP picker. */
+  getMcpServers?: (() => McpPickerItem[]) | undefined;
+  /** Toggle one MCP server (enable/disable) from the interactive TUI MCP picker. */
+  onMcpToggle?:
+    | ((name: string) => Promise<{
+        items: McpPickerItem[];
+        message?: string | undefined;
+        error?: string | undefined;
+      }>)
+    | undefined;
+  /** Restart one MCP server from the interactive TUI MCP picker. */
+  onMcpRestart?:
+    | ((name: string) => Promise<{
+        items: McpPickerItem[];
+        message?: string | undefined;
+        error?: string | undefined;
+      }>)
+    | undefined;
+  /** Load tool rows for the interactive TUI tool picker. */
+  getToolsItems?: (() => ToolPickerItem[]) | undefined;
+  /** Toggle one tool (enable/disable) from the interactive TUI tool picker. */
+  onToolToggle?:
+    | ((name: string) => Promise<{
+        items: ToolPickerItem[];
+        message?: string | undefined;
+        error?: string | undefined;
+      }>)
+    | undefined;
+  /** Get current brain risk level and decision log for the Brain panel. */
+  getBrainData?:
+    | (() => { riskLevel: 'off' | 'low' | 'medium' | 'high' | 'all'; log: Array<{ kind: string; question: string; outcome: string; age: string }> })
+    | undefined;
+  /** Set brain risk ceiling from the Brain panel. Returns error string or undefined on success. */
+  onBrainRiskLevel?:
+    | ((level: 'off' | 'low' | 'medium' | 'high' | 'all') => string | undefined)
     | undefined;
   /** Host for the interactive TUI `/auth` panel (keys, OAuth, local adds). */
   authHost?: import('@wrongstack/tui').AuthPanelHost | undefined;
@@ -460,6 +517,13 @@ export async function execute(deps: ExecutionDeps): Promise<number> {
     saveStatuslineHiddenItems,
     getPluginItems,
     onPluginToggle,
+    getMcpServers,
+    onMcpToggle,
+    onMcpRestart,
+    getToolsItems,
+    onToolToggle,
+    getBrainData,
+    onBrainRiskLevel,
     authHost,
     agentsMonitorController,
     onPanelOpen,
@@ -1072,6 +1136,13 @@ export async function execute(deps: ExecutionDeps): Promise<number> {
           saveStatuslineHiddenItems,
           getPluginItems,
           onPluginToggle,
+          getMcpServers,
+          onMcpToggle,
+          onMcpRestart,
+          getToolsItems,
+          onToolToggle,
+          getBrainData,
+          onBrainRiskLevel,
           authHost,
           agentsMonitorController,
           getLiveSessions: () => getLiveSessions({ state }),

--- a/packages/cli/src/slash-commands/brain.ts
+++ b/packages/cli/src/slash-commands/brain.ts
@@ -47,6 +47,12 @@ export function buildBrainCommand(opts: SlashCommandContext): SlashCommand {
       const [sub, ...rest] = trimmed.split(/\s+/);
       const subcommand = (sub ?? '').toLowerCase();
 
+      // TUI mode: bare /brain or /brain status opens the interactive panel.
+      if ((subcommand === '' || subcommand === 'status') && opts.onPanelOpen?.current) {
+        const opened = opts.onPanelOpen.current('brainOpen');
+        if (opened) return { message: '' };
+      }
+
       if (subcommand === 'risk') {
         if (!opts.brainSettings) {
           const msg = 'Brain settings are not available in this session.';

--- a/packages/cli/src/slash-commands/mcp.ts
+++ b/packages/cli/src/slash-commands/mcp.ts
@@ -9,8 +9,8 @@ export { parseMcpArgs, runMcpManagementCommand } from './mcp-utils.js';
  * /mcp slash command — manage MCP servers from the REPL.
  *
  * Usage:
- *   /mcp              — list all available and configured servers
- *   /mcp list         — same
+ *   /mcp              — open interactive server picker (TUI) or list servers
+ *   /mcp list         — list all available and configured servers
  *   /mcp add <name>   — add server preset to config (disabled by default)
  *   /mcp add <name> --enable  — add and immediately enable
  *   /mcp remove <name> — remove server from config
@@ -28,7 +28,7 @@ export function buildMcpSlashCommand(opts: SlashCommandContext): SlashCommand {
     argsHint: '[list|add <name>|remove <name>|enable <name>|disable <name>|restart <name>]',
     help: [
       'Usage:',
-      '  /mcp                      List available and configured servers.',
+      '  /mcp                      Open interactive server picker (TUI) or list servers.',
       '  /mcp list                 Same.',
       '  /mcp add <name>           Add server preset to config (disabled).',
       '  /mcp add <name> --enable  Add and immediately enable.',
@@ -44,10 +44,17 @@ export function buildMcpSlashCommand(opts: SlashCommandContext): SlashCommand {
       '  /mcp restart brave-search',
     ].join('\n'),
     async run(args) {
+      // TUI mode: bare /mcp or /mcp list opens the interactive picker.
+      const trimmed = args.trim();
+      if ((trimmed === '' || trimmed === 'list') && opts.onPanelOpen?.current) {
+        const opened = opts.onPanelOpen.current('mcpPickerOpen');
+        if (opened) return { message: '' };
+      }
+
       if (!opts.onMcp) {
         return { message: 'MCP management is not available in this session.' };
       }
-      const result = await opts.onMcp(args.trim());
+      const result = await opts.onMcp(trimmed);
       return { message: result };
     },
   };

--- a/packages/cli/src/slash-commands/tools.ts
+++ b/packages/cli/src/slash-commands/tools.ts
@@ -29,6 +29,15 @@ export function buildToolsCommand(opts: SlashCommandContext): SlashCommand {
           )
         : allTools;
       const disabled = reg.listDisabled();
+
+      // TUI mode: bare /tools or /tools with a filter opens the interactive picker.
+      if (opts.onPanelOpen?.current) {
+        // In TUI mode, always open the picker (with or without a filter).
+        // The picker supports its own inline text filtering.
+        const opened = opts.onPanelOpen.current('toolsPickerOpen');
+        if (opened) return { message: '' };
+      }
+
       if (filter && all.length === 0) {
         const msg = `${color.bold('Tools')} — no tool name or owner matched "${filter}".`;
         opts.renderer.write(msg);

--- a/packages/tui/src/app-initial-state.ts
+++ b/packages/tui/src/app-initial-state.ts
@@ -172,6 +172,9 @@ export function createInitialState(options: CreateInitialStateOptions): State {
       hint: undefined,
     },
     pluginPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined },
+    mcpPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined },
+    toolsPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined, filter: undefined },
+    brainPanel: { open: false, riskLevel: 'medium', log: [], selected: 0, hint: undefined },
     authPanel: AUTH_PANEL_INITIAL,
     projectPicker: {
       open: false,

--- a/packages/tui/src/app-reducer.ts
+++ b/packages/tui/src/app-reducer.ts
@@ -1332,6 +1332,147 @@ export function reducer(state: State, action: Action): State {
       return { ...state, pluginPicker: { ...state.pluginPicker, busy: action.busy } };
     case 'pluginPickerHint':
       return { ...state, pluginPicker: { ...state.pluginPicker, hint: action.text } };
+    case 'mcpPickerOpen': {
+      const items = action.items ?? state.mcpPicker.items;
+      return {
+        ...state,
+        ...closePanels(state),
+        mcpPicker: {
+          open: true,
+          items,
+          selected: Math.min(state.mcpPicker.selected, Math.max(0, items.length - 1)),
+          busy: items.length === 0,
+          hint: undefined,
+        },
+      };
+    }
+    case 'mcpPickerClose':
+      return { ...state, mcpPicker: { ...state.mcpPicker, open: false, busy: false } };
+    case 'mcpPickerMove': {
+      const count = state.mcpPicker.items.length;
+      if (count === 0) return state;
+      return {
+        ...state,
+        mcpPicker: {
+          ...state.mcpPicker,
+          selected: (state.mcpPicker.selected + action.delta + count) % count,
+          hint: undefined,
+        },
+      };
+    }
+    case 'mcpPickerSetItems':
+      return {
+        ...state,
+        mcpPicker: {
+          ...state.mcpPicker,
+          items: action.items,
+          selected: Math.min(state.mcpPicker.selected, Math.max(0, action.items.length - 1)),
+          busy: false,
+        },
+      };
+    case 'mcpPickerBusy':
+      return { ...state, mcpPicker: { ...state.mcpPicker, busy: action.busy } };
+    case 'mcpPickerHint':
+      return { ...state, mcpPicker: { ...state.mcpPicker, hint: action.text } };
+    case 'toolsPickerOpen': {
+      const items = action.items ?? state.toolsPicker.items;
+      return {
+        ...state,
+        ...closePanels(state),
+        toolsPicker: {
+          open: true,
+          items,
+          selected: Math.min(state.toolsPicker.selected, Math.max(0, items.length - 1)),
+          busy: items.length === 0,
+          hint: undefined,
+          filter: undefined,
+        },
+      };
+    }
+    case 'toolsPickerClose':
+      return { ...state, toolsPicker: { ...state.toolsPicker, open: false, busy: false, filter: undefined } };
+    case 'toolsPickerMove': {
+      const count = state.toolsPicker.items.length;
+      if (count === 0) return state;
+      return {
+        ...state,
+        toolsPicker: {
+          ...state.toolsPicker,
+          selected: (state.toolsPicker.selected + action.delta + count) % count,
+          hint: undefined,
+        },
+      };
+    }
+    case 'toolsPickerSetItems':
+      return {
+        ...state,
+        toolsPicker: {
+          ...state.toolsPicker,
+          items: action.items,
+          selected: Math.min(state.toolsPicker.selected, Math.max(0, action.items.length - 1)),
+          busy: false,
+        },
+      };
+    case 'toolsPickerToggle':
+      // The toggle is handled by the host callback; this case just
+      // prevents the reducer from crashing on the action type.
+      return state;
+    case 'toolsPickerBusy':
+      return { ...state, toolsPicker: { ...state.toolsPicker, busy: action.busy } };
+    case 'toolsPickerHint':
+      return { ...state, toolsPicker: { ...state.toolsPicker, hint: action.text } };
+    case 'toolsPickerFilter':
+      return { ...state, toolsPicker: { ...state.toolsPicker, filter: action.filter } };
+    case 'brainOpen': {
+      return {
+        ...state,
+        ...closePanels(state),
+        brainPanel: {
+          open: true,
+          riskLevel: action.riskLevel,
+          log: action.log,
+          selected: 0,
+          hint: undefined,
+        },
+      };
+    }
+    case 'brainClose':
+      return { ...state, brainPanel: { ...state.brainPanel, open: false } };
+    case 'brainMove': {
+      const count = state.brainPanel.log.length;
+      if (count === 0) return state;
+      return {
+        ...state,
+        brainPanel: {
+          ...state.brainPanel,
+          selected: (state.brainPanel.selected + action.delta + count) % count,
+          hint: undefined,
+        },
+      };
+    }
+    case 'brainRiskChange': {
+      const levels = ['off', 'low', 'medium', 'high', 'all'] as const;
+      const cur = levels.indexOf(state.brainPanel.riskLevel as typeof levels[number]);
+      const next = (cur + action.delta + levels.length) % levels.length;
+      return {
+        ...state,
+        brainPanel: {
+          ...state.brainPanel,
+          riskLevel: levels[next] as typeof state.brainPanel.riskLevel,
+        },
+      };
+    }
+    case 'brainSetLog':
+      return {
+        ...state,
+        brainPanel: {
+          ...state.brainPanel,
+          log: action.log,
+          selected: Math.min(state.brainPanel.selected, Math.max(0, action.log.length - 1)),
+        },
+      };
+    case 'brainHint':
+      return { ...state, brainPanel: { ...state.brainPanel, hint: action.text } };
     case 'authOpen':
       return {
         ...state,

--- a/packages/tui/src/app-state.ts
+++ b/packages/tui/src/app-state.ts
@@ -18,7 +18,10 @@ import type {
 import type { AutonomyOption } from './components/autonomy-picker.js';
 import type { HistoryEntry } from './components/history.js';
 import type { ProviderOption } from './components/model-picker.js';
+import type { BrainLogEntry, BrainRiskLevel } from './components/brain-panel.js';
+import type { McpPickerItem } from './components/mcp-picker.js';
 import type { PluginPickerItem } from './components/plugin-picker.js';
+import type { ToolPickerItem } from './components/tools-picker.js';
 import type { ProjectPickerItem } from './components/project-picker.js';
 import type { PromptPickEntry } from './components/prompt-picker.js';
 import type { SendMode } from './components/send-mode-picker.js';
@@ -420,6 +423,31 @@ export type State = {
     items: PluginPickerItem[];
     selected: number;
     busy: boolean;
+    hint?: string | undefined;
+  };
+  /** MCP server picker — opened by `/mcp`. */
+  mcpPicker: {
+    open: boolean;
+    items: McpPickerItem[];
+    selected: number;
+    busy: boolean;
+    hint?: string | undefined;
+  };
+  /** Tool picker — opened by `/tools`. */
+  toolsPicker: {
+    open: boolean;
+    items: ToolPickerItem[];
+    selected: number;
+    busy: boolean;
+    hint?: string | undefined;
+    filter?: string | undefined;
+  };
+  /** Brain panel — opened by `/brain`. */
+  brainPanel: {
+    open: boolean;
+    riskLevel: BrainRiskLevel;
+    log: BrainLogEntry[];
+    selected: number;
     hint?: string | undefined;
   };
   /** Interactive API-key / OAuth manager — opened by `/auth`. */
@@ -994,6 +1022,26 @@ export type Action =
   | { type: 'pluginPickerSetItems'; items: PluginPickerItem[] }
   | { type: 'pluginPickerBusy'; busy: boolean }
   | { type: 'pluginPickerHint'; text?: string | undefined }
+  | { type: 'mcpPickerOpen'; items?: McpPickerItem[] | undefined }
+  | { type: 'mcpPickerClose' }
+  | { type: 'mcpPickerMove'; delta: number }
+  | { type: 'mcpPickerSetItems'; items: McpPickerItem[] }
+  | { type: 'mcpPickerBusy'; busy: boolean }
+  | { type: 'mcpPickerHint'; text?: string | undefined }
+  | { type: 'toolsPickerOpen'; items?: ToolPickerItem[] | undefined }
+  | { type: 'toolsPickerClose' }
+  | { type: 'toolsPickerMove'; delta: number }
+  | { type: 'toolsPickerSetItems'; items: ToolPickerItem[] }
+  | { type: 'toolsPickerToggle' }
+  | { type: 'toolsPickerBusy'; busy: boolean }
+  | { type: 'toolsPickerHint'; text?: string | undefined }
+  | { type: 'toolsPickerFilter'; filter: string }
+  | { type: 'brainOpen'; riskLevel: BrainRiskLevel; log: BrainLogEntry[] }
+  | { type: 'brainClose' }
+  | { type: 'brainMove'; delta: number }
+  | { type: 'brainRiskChange'; delta: number }
+  | { type: 'brainSetLog'; log: BrainLogEntry[] }
+  | { type: 'brainHint'; text?: string | undefined }
   | {
       type: 'authOpen';
       view?: Extract<AuthPanelView, 'list' | 'oauth'> | undefined;

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -90,7 +90,10 @@ import { ModelPicker, type ProviderOption } from './components/model-picker.js';
 import { PhaseMonitor } from './components/phase-monitor.js';
 import { PhasePanel } from './components/phase-panel.js';
 import { PlanPanel } from './components/plan-panel.js';
+import { BrainPanel, type BrainRiskLevel } from './components/brain-panel.js';
+import { McpPicker, type McpPickerItem } from './components/mcp-picker.js';
 import { PluginPicker, type PluginPickerItem } from './components/plugin-picker.js';
+import { ToolsPicker, type ToolPickerItem } from './components/tools-picker.js';
 import { ProcessListMonitor } from './components/process-list.js';
 import { ProjectPicker } from './components/project-picker.js';
 import { filterPromptPicker, PromptPicker } from './components/prompt-picker.js';
@@ -514,6 +517,42 @@ export interface AppProps {
         message?: string | undefined;
         error?: string | undefined;
       }>)
+    | undefined;
+  /** Load MCP server rows for the interactive MCP picker. */
+  getMcpServers?: (() => McpPickerItem[]) | undefined;
+  /** Toggle one MCP server (enable/disable) from the interactive picker. */
+  onMcpToggle?:
+    | ((name: string) => Promise<{
+        items: McpPickerItem[];
+        message?: string | undefined;
+        error?: string | undefined;
+      }>)
+    | undefined;
+  /** Restart one MCP server from the interactive picker. */
+  onMcpRestart?:
+    | ((name: string) => Promise<{
+        items: McpPickerItem[];
+        message?: string | undefined;
+        error?: string | undefined;
+      }>)
+    | undefined;
+  /** Load tool rows for the interactive tool picker. */
+  getToolsItems?: (() => ToolPickerItem[]) | undefined;
+  /** Toggle one tool (enable/disable) from the interactive tool picker. */
+  onToolToggle?:
+    | ((name: string) => Promise<{
+        items: ToolPickerItem[];
+        message?: string | undefined;
+        error?: string | undefined;
+      }>)
+    | undefined;
+  /** Get current brain risk level and decision log. */
+  getBrainData?:
+    | (() => { riskLevel: BrainRiskLevel; log: Array<{ kind: string; question: string; outcome: string; age: string }> })
+    | undefined;
+  /** Set brain risk ceiling. */
+  onBrainRiskLevel?:
+    | ((level: BrainRiskLevel) => string | undefined)
     | undefined;
   /**
    * Host for the interactive `/auth` panel (provider/key management, OAuth
@@ -991,6 +1030,13 @@ export function App({
   saveSettings,
   getPluginItems,
   onPluginToggle,
+  getMcpServers,
+  onMcpToggle,
+  onMcpRestart,
+  getToolsItems,
+  onToolToggle,
+  getBrainData,
+  onBrainRiskLevel,
   authHost,
   predictNext,
   onSuggestionsParsed,
@@ -1231,6 +1277,33 @@ export function App({
 
   const { openModePicker } = useModePicker({ dispatch, getModes });
 
+  // ── Brain panel ────────────────────────────────────────────────
+  const openBrainPanel = React.useCallback(() => {
+    if (!getBrainData) return;
+    const data = getBrainData();
+    dispatch({ type: 'brainOpen', riskLevel: data.riskLevel, log: data.log });
+  }, [getBrainData]);
+
+  const changeBrainRisk = React.useCallback(
+    (delta: number) => {
+      dispatch({ type: 'brainRiskChange', delta });
+    },
+    [],
+  );
+
+  // Sync risk level to host whenever it changes via ←/→ in the panel.
+  const prevRiskRef = React.useRef(state.brainPanel.riskLevel);
+  React.useEffect(() => {
+    if (!state.brainPanel.open) return;
+    const current = state.brainPanel.riskLevel;
+    if (current !== prevRiskRef.current && onBrainRiskLevel) {
+      prevRiskRef.current = current;
+      const err = onBrainRiskLevel(current);
+      if (err) dispatch({ type: 'brainHint', text: err });
+      else dispatch({ type: 'brainHint', text: `Risk ceiling → ${current.toUpperCase()}` });
+    }
+  }, [state.brainPanel.riskLevel, state.brainPanel.open, onBrainRiskLevel]);
+
   useStatuslineHiddenSync({
     pickerOpen: state.statuslinePicker.open,
     pickerHidden: state.statuslinePicker.hiddenItems,
@@ -1415,6 +1488,10 @@ export function App({
     state.projectPicker.open ||
     state.slashPicker.open ||
     state.statuslinePicker.open ||
+    state.pluginPicker.open ||
+    state.mcpPicker.open ||
+    state.toolsPicker.open ||
+    state.brainPanel.open ||
     state.fKeyPicker.open ||
     state.authPanel.open ||
     state.picker.open;
@@ -2633,6 +2710,7 @@ export function App({
       openStatuslinePicker,
       openAuthPanel: authPanelController.openAuthPanel,
       openModePicker,
+      openBrainPanel,
     });
     onPanelOpen.current = dispatcher;
     return () => {
@@ -2645,6 +2723,7 @@ export function App({
     openStatuslinePicker,
     authPanelController.openAuthPanel,
     openModePicker,
+    openBrainPanel,
   ]);
   // Keep the F10 sessions panel live: refresh every 5s while open
   useEffect(() => {
@@ -2736,6 +2815,82 @@ export function App({
       });
     }
   }, [onPluginToggle]);
+
+  // ── MCP picker ─────────────────────────────────────────────────
+  const refreshMcpPicker = React.useCallback(() => {
+    if (!getMcpServers) return;
+    dispatch({ type: 'mcpPickerSetItems', items: getMcpServers() });
+  }, [getMcpServers]);
+
+  useEffect(() => {
+    if (!state.mcpPicker.open) return;
+    refreshMcpPicker();
+  }, [state.mcpPicker.open, refreshMcpPicker]);
+
+  const toggleSelectedMcpServer = React.useCallback(async () => {
+    if (!onMcpToggle) return;
+    const selected = stateRef.current.mcpPicker.items[stateRef.current.mcpPicker.selected];
+    if (!selected) return;
+    dispatch({ type: 'mcpPickerBusy', busy: true });
+    try {
+      const result = await onMcpToggle(selected.name);
+      dispatch({ type: 'mcpPickerSetItems', items: result.items });
+      dispatch({ type: 'mcpPickerHint', text: result.error ?? result.message });
+    } catch (err) {
+      dispatch({ type: 'mcpPickerBusy', busy: false });
+      dispatch({
+        type: 'mcpPickerHint',
+        text: `Failed to toggle ${selected.name}: ${toErrorMessage(err)}`,
+      });
+    }
+  }, [onMcpToggle]);
+
+  const restartSelectedMcpServer = React.useCallback(async () => {
+    if (!onMcpRestart) return;
+    const selected = stateRef.current.mcpPicker.items[stateRef.current.mcpPicker.selected];
+    if (!selected) return;
+    dispatch({ type: 'mcpPickerBusy', busy: true });
+    try {
+      const result = await onMcpRestart(selected.name);
+      dispatch({ type: 'mcpPickerSetItems', items: result.items });
+      dispatch({ type: 'mcpPickerHint', text: result.error ?? result.message });
+    } catch (err) {
+      dispatch({ type: 'mcpPickerBusy', busy: false });
+      dispatch({
+        type: 'mcpPickerHint',
+        text: `Failed to restart ${selected.name}: ${toErrorMessage(err)}`,
+      });
+    }
+  }, [onMcpRestart]);
+
+  // ── Tools picker ───────────────────────────────────────────────
+  const refreshToolsPicker = React.useCallback(() => {
+    if (!getToolsItems) return;
+    dispatch({ type: 'toolsPickerSetItems', items: getToolsItems() });
+  }, [getToolsItems]);
+
+  useEffect(() => {
+    if (!state.toolsPicker.open) return;
+    refreshToolsPicker();
+  }, [state.toolsPicker.open, refreshToolsPicker]);
+
+  const toggleSelectedTool = React.useCallback(async () => {
+    if (!onToolToggle) return;
+    const selected = stateRef.current.toolsPicker.items[stateRef.current.toolsPicker.selected];
+    if (!selected) return;
+    dispatch({ type: 'toolsPickerBusy', busy: true });
+    try {
+      const result = await onToolToggle(selected.name);
+      dispatch({ type: 'toolsPickerSetItems', items: result.items });
+      dispatch({ type: 'toolsPickerHint', text: result.error ?? result.message });
+    } catch (err) {
+      dispatch({ type: 'toolsPickerBusy', busy: false });
+      dispatch({
+        type: 'toolsPickerHint',
+        text: `Failed to toggle ${selected.name}: ${toErrorMessage(err)}`,
+      });
+    }
+  }, [onToolToggle]);
 
   // NOTE: there is deliberately NO local "auto-proceed countdown" timer here.
   // The StatusBar's "⏳ auto in Ns" chip is driven exclusively by real
@@ -4131,6 +4286,10 @@ export function App({
       }
     },
     onPluginPickerToggle: toggleSelectedPlugin,
+    onMcpPickerToggle: toggleSelectedMcpServer,
+    onMcpPickerRestart: restartSelectedMcpServer,
+    onToolsPickerToggle: toggleSelectedTool,
+    onBrainRiskChange: changeBrainRisk,
     onAuthEnter: authPanelController.onAuthEnter,
     onAuthBack: authPanelController.onAuthBack,
     onAuthShortcut: authPanelController.onAuthShortcut,
@@ -6619,6 +6778,31 @@ export function App({
               selected={state.pluginPicker.selected}
               busy={state.pluginPicker.busy}
               hint={state.pluginPicker.hint}
+            />
+          ) : null}
+          {state.mcpPicker.open ? (
+            <McpPicker
+              items={state.mcpPicker.items}
+              selected={state.mcpPicker.selected}
+              busy={state.mcpPicker.busy}
+              hint={state.mcpPicker.hint}
+            />
+          ) : null}
+          {state.toolsPicker.open ? (
+            <ToolsPicker
+              items={state.toolsPicker.items}
+              selected={state.toolsPicker.selected}
+              busy={state.toolsPicker.busy}
+              hint={state.toolsPicker.hint}
+              filter={state.toolsPicker.filter}
+            />
+          ) : null}
+          {state.brainPanel.open ? (
+            <BrainPanel
+              riskLevel={state.brainPanel.riskLevel}
+              log={state.brainPanel.log}
+              selected={state.brainPanel.selected}
+              hint={state.brainPanel.hint}
             />
           ) : null}
           {state.authPanel.open ? <AuthPanel panel={state.authPanel} /> : null}

--- a/packages/tui/src/components/brain-panel.tsx
+++ b/packages/tui/src/components/brain-panel.tsx
@@ -1,0 +1,116 @@
+import { Box, Text, useStdout } from '../ink.js';
+import type React from 'react';
+
+export type BrainRiskLevel = 'off' | 'low' | 'medium' | 'high' | 'all';
+
+export interface BrainLogEntry {
+  kind: string;
+  question: string;
+  outcome: string;
+  age: string;
+}
+
+export interface BrainPanelProps {
+  riskLevel: BrainRiskLevel;
+  log: BrainLogEntry[];
+  selected: number;
+  hint?: string | undefined;
+}
+
+const CHROME_ROWS = 14;
+
+const RISK_DESCS: Record<BrainRiskLevel, string> = {
+  off: 'Human decides everything',
+  low: 'Auto-decide low risk only',
+  medium: 'Auto-decide up to medium risk',
+  high: 'Auto-decide up to high risk',
+  all: 'Auto-decide everything',
+};
+
+const RISK_COLORS: Record<BrainRiskLevel, string> = {
+  off: 'gray',
+  low: 'green',
+  medium: 'yellow',
+  high: 'red',
+  all: 'magenta',
+};
+
+export function BrainPanel({
+  riskLevel,
+  log,
+  selected,
+  hint,
+}: BrainPanelProps): React.ReactElement {
+  const { stdout } = useStdout();
+  const termRows = stdout?.rows ?? 24;
+
+  // Window the log entries: reserve ~7 rows for the risk header + chrome.
+  const maxVisible = Math.max(4, termRows - CHROME_ROWS);
+  const total = log.length;
+  const windowStart =
+    total <= maxVisible
+      ? 0
+      : Math.max(0, Math.min(selected - Math.floor(maxVisible / 2), total - maxVisible));
+  const windowEnd = Math.min(windowStart + maxVisible, total);
+  const above = windowStart;
+  const below = total - windowEnd;
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="magenta" paddingX={1}>
+      <Text bold color="magenta">
+        ━━ Brain ━━
+      </Text>
+      <Text dimColor>↑/↓ navigate log · ←/→ change risk · Esc close</Text>
+
+      <Box marginTop={1} flexDirection="column">
+        {/* ── Risk ceiling section ── */}
+        <Box>
+          <Text bold>Risk ceiling: </Text>
+          <Text color={RISK_COLORS[riskLevel]} bold>
+            {riskLevel.toUpperCase()}
+          </Text>
+          <Text dimColor>{`  ${RISK_DESCS[riskLevel]}`}</Text>
+        </Box>
+
+        {/* ── Recent decisions section ── */}
+        <Box marginTop={1} flexDirection="column">
+          <Text bold color="blue">
+            Recent decisions
+          </Text>
+          {total === 0 ? (
+            <Text dimColor>  No decisions recorded yet this session.</Text>
+          ) : (
+            <>
+              {above > 0 ? <Text dimColor>{`  ↑ ${above} more`}</Text> : null}
+              {log.slice(windowStart, windowEnd).map((entry, i) => {
+                const index = windowStart + i;
+                const focused = index === selected;
+                return (
+                  <Text
+                    key={`${entry.kind}-${i}`}
+                    inverse={focused}
+                    {...(focused ? { color: 'magenta' } : {})}
+                    wrap="truncate-end"
+                  >
+                    {focused ? '› ' : '  '}
+                    <Text dimColor>{entry.age.padEnd(8)}</Text>
+                    <Text color="cyan">{entry.kind.padEnd(12)}</Text>
+                    <Text>{entry.question.length > 60 ? `${entry.question.slice(0, 57)}…` : entry.question}</Text>
+                    {entry.outcome ? <Text dimColor>{` → ${entry.outcome.length > 20 ? `${entry.outcome.slice(0, 17)}…` : entry.outcome}`}</Text> : null}
+                  </Text>
+                );
+              })}
+              {below > 0 ? <Text dimColor>{`  ↓ ${below} more`}</Text> : null}
+            </>
+          )}
+        </Box>
+      </Box>
+
+      {hint ? (
+        <Box marginTop={1}>
+          <Text dimColor>{hint}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/tui/src/components/mcp-picker.tsx
+++ b/packages/tui/src/components/mcp-picker.tsx
@@ -1,0 +1,110 @@
+import { Box, Text, useStdout } from '../ink.js';
+import type React from 'react';
+
+export interface McpPickerItem {
+  name: string;
+  enabled: boolean;
+  status: string;
+  transport: string;
+  description?: string | undefined;
+  toolCount: number;
+  lazy?: boolean | undefined;
+}
+
+export interface McpPickerProps {
+  items: McpPickerItem[];
+  selected: number;
+  busy?: boolean | undefined;
+  hint?: string | undefined;
+}
+
+/**
+ * Rows of terminal chrome around the visible item window: the picker's own
+ * border/title/legend/scroll indicators (~9) plus the input box, statusline
+ * and key-hint bar rendered below the picker (~8). Subtracted from
+ * `stdout.rows` so the picker list never pushes the input area off-screen.
+ */
+const CHROME_ROWS = 17;
+
+/** Colourise an MCP connection status string. */
+function statusBadge(status: string, enabled: boolean): React.ReactElement {
+  if (!enabled) return <Text dimColor>○ disabled</Text>;
+  switch (status) {
+    case 'connected':
+      return <Text color="green">● connected</Text>;
+    case 'connecting':
+      return <Text color="cyan">◐ connecting</Text>;
+    case 'reconnecting':
+      return <Text color="cyan">◑ reconnecting</Text>;
+    case 'disconnected':
+      return <Text dimColor>○ disconnected</Text>;
+    case 'failed':
+      return <Text color="red">✗ failed</Text>;
+    default:
+      return <Text dimColor>{status}</Text>;
+  }
+}
+
+export function McpPicker({
+  items,
+  selected,
+  busy = false,
+  hint,
+}: McpPickerProps): React.ReactElement {
+  const { stdout } = useStdout();
+  const rows = stdout?.rows ?? 24;
+
+  // Height-aware scrolling window centred on the selection.
+  const maxVisible = Math.max(4, rows - CHROME_ROWS);
+  const total = items.length;
+  const windowStart =
+    total <= maxVisible
+      ? 0
+      : Math.max(0, Math.min(selected - Math.floor(maxVisible / 2), total - maxVisible));
+  const windowEnd = Math.min(windowStart + maxVisible, total);
+  const above = windowStart;
+  const below = total - windowEnd;
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Text bold color="cyan">
+        MCP Servers
+      </Text>
+      <Text dimColor>
+        ↑/↓ select · Enter/←/→ toggle enable · r restart · Esc close
+      </Text>
+      <Box marginTop={1} flexDirection="column">
+        {items.length === 0 ? (
+          <Text dimColor>{busy ? 'Loading servers…' : 'No MCP servers configured.'}</Text>
+        ) : (
+          <>
+            {above > 0 ? <Text dimColor>{`  ↑ ${above} more`}</Text> : null}
+            {items.slice(windowStart, windowEnd).map((item, i) => {
+              const index = windowStart + i;
+              const focused = index === selected;
+              const marker = focused ? '›' : ' ';
+              return (
+                <Text key={item.name} color={focused ? 'cyan' : undefined} wrap="truncate-end">
+                  {marker}{' '}
+                  {statusBadge(item.status, item.enabled)}{' '}
+                  <Text bold>{item.name.padEnd(18)}</Text>
+                  <Text dimColor>
+                    {item.transport.padEnd(14)}
+                    {item.toolCount > 0 ? `${item.toolCount} tools` : ''}
+                    {item.lazy ? ' lazy' : ''}
+                  </Text>
+                </Text>
+              );
+            })}
+            {below > 0 ? <Text dimColor>{`  ↓ ${below} more`}</Text> : null}
+          </>
+        )}
+      </Box>
+      {hint ? (
+        <Box marginTop={1}>
+          <Text dimColor>{hint}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/tui/src/components/tools-picker.tsx
+++ b/packages/tui/src/components/tools-picker.tsx
@@ -1,0 +1,243 @@
+import { Box, Text, useStdout } from '../ink.js';
+import type React from 'react';
+
+export interface ToolPickerItem {
+  name: string;
+  owner: string;
+  category: string;
+  enabled: boolean;
+  mutating: boolean;
+  permission: string;
+  descMode: 'extend' | 'simple';
+  description: string;
+}
+
+export interface ToolsPickerProps {
+  items: ToolPickerItem[];
+  selected: number;
+  busy?: boolean | undefined;
+  hint?: string | undefined;
+  filter?: string | undefined;
+}
+
+/**
+ * Rows of terminal chrome around the visible item window.
+ */
+const CHROME_ROWS = 17;
+
+/** Colourise the tool enable/disabled status badge. */
+function statusBadge(enabled: boolean): React.ReactElement {
+  return enabled ? (
+    <Text color="green">● active</Text>
+  ) : (
+    <Text color="red">○ disabled</Text>
+  );
+}
+
+/** Colourise the mutating/read-only badge. */
+function rwBadge(mutating: boolean): React.ReactElement {
+  return mutating ? (
+    <Text color="yellow">mut</Text>
+  ) : (
+    <Text color="cyan">ro</Text>
+  );
+}
+
+/**
+ * Normalise a category string for display. Returns "Other" for falsy/empty values.
+ */
+function displayCategory(cat: string | undefined | null): string {
+  if (!cat || cat.trim() === '') return 'Other';
+  return cat.charAt(0).toUpperCase() + cat.slice(1);
+}
+
+type Row =
+  | { type: 'header'; category: string }
+  | { type: 'item'; item: ToolPickerItem; index: number };
+
+/**
+ * Build a flat row list with category headers interleaved. Category
+ * order is the natural order of first appearance. "Other" sinks last.
+ */
+function buildRows(items: ToolPickerItem[]): Row[] {
+  const rows: Row[] = [];
+  let lastCat = '';
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i] as ToolPickerItem;
+    const cat = displayCategory(item.category);
+    if (cat !== lastCat) {
+      lastCat = cat;
+      rows.push({ type: 'header', category: cat });
+    }
+    rows.push({ type: 'item', item, index: i });
+  }
+  return rows;
+}
+
+/**
+ * Window rows around the selected item so the list scrolls and never
+ * loses its category context.
+ */
+function windowRows(
+  rows: Row[],
+  focus: number,
+  max: number,
+): { rows: Row[]; start: number; end: number; contextHeader: string | null } {
+  if (rows.length <= max) {
+    return { rows, start: 0, end: rows.length, contextHeader: null };
+  }
+  let start = focus - Math.floor(max / 2);
+  if (start < 0) start = 0;
+  let end = start + max;
+  if (end > rows.length) {
+    end = rows.length;
+    start = end - max;
+  }
+  let contextHeader: string | null = null;
+  if (start > 0) {
+    const first = rows[start];
+    if (first && first.type === 'item') {
+      for (let i = start - 1; i >= 0; i--) {
+        const r = rows[i];
+        if (r && r.type === 'header') {
+          contextHeader = r.category;
+          break;
+        }
+      }
+    }
+  }
+  return { rows: rows.slice(start, end), start, end, contextHeader };
+}
+
+export function ToolsPicker({
+  items,
+  selected,
+  busy = false,
+  hint,
+  filter,
+}: ToolsPickerProps): React.ReactElement {
+  const { stdout } = useStdout();
+  const termRows = stdout?.rows ?? 24;
+
+  const maxVisible = Math.max(6, termRows - CHROME_ROWS);
+  const total = items.length;
+
+  let visibleItems: ToolPickerItem[];
+  let visibleSelected: number;
+
+  const filterActive = Boolean(filter && filter.length > 0);
+  if (filterActive) {
+    const q = filter!.toLowerCase();
+    visibleItems = items.filter(
+      (it) =>
+        it.name.toLowerCase().includes(q) ||
+        it.owner.toLowerCase().includes(q) ||
+        it.description.toLowerCase().includes(q),
+    );
+    // Map the selected index into the filtered list
+    const rawSelected = items[selected];
+    visibleSelected = rawSelected ? visibleItems.indexOf(rawSelected) : 0;
+    if (visibleSelected < 0) visibleSelected = 0;
+  } else {
+    visibleItems = items;
+    visibleSelected = selected;
+  }
+
+  const rows = buildRows(visibleItems);
+
+  // Window only when NOT filtered (in filter mode, no windowing — just slice)
+  let displayRows: Row[];
+  let hiddenAbove = 0;
+  let hiddenBelow = 0;
+  let contextHeader: string | null = null;
+
+  if (filterActive) {
+    displayRows = rows;
+  } else {
+    // Find the selected row index in the flat rows array
+    const selectedRowIdx = rows.findIndex(
+      (r) => r.type === 'item' && r.index === visibleSelected,
+    );
+    const win = windowRows(
+      rows,
+      selectedRowIdx < 0 ? 0 : selectedRowIdx,
+      maxVisible,
+    );
+    displayRows = win.rows;
+    hiddenAbove = win.start;
+    hiddenBelow = rows.length - win.end;
+    contextHeader = win.contextHeader;
+  }
+
+  const hasFilter = filterActive;
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="green" paddingX={1}>
+      <Text bold color="green">
+        ━━ Tools ━━
+      </Text>
+      <Text dimColor>
+        {hasFilter
+          ? `Filter: /${filter} (${visibleItems.length} match${visibleItems.length === 1 ? '' : 'es'}) · Esc clear`
+          : '↑/↓ select · Enter/←/→ toggle · `/` to search · Esc close'}
+      </Text>
+      <Box marginTop={1} flexDirection="column">
+        {total === 0 ? (
+          <Text dimColor>{busy ? 'Loading tools…' : 'No tools registered.'}</Text>
+        ) : visibleItems.length === 0 ? (
+          <Text dimColor>No tools match "{filter}".</Text>
+        ) : (
+          <>
+            {hiddenAbove > 0 && !hasFilter ? (
+              <Text dimColor>{`  ↑ ${hiddenAbove} more`}</Text>
+            ) : null}
+            {contextHeader && !hasFilter ? (
+              <Text bold color="yellow" dimColor>
+                {'  '}{contextHeader}
+              </Text>
+            ) : null}
+            {displayRows.map((row) => {
+              if (row.type === 'header') {
+                return (
+                  <Text key={`cat-${row.category}`} bold color="yellow" dimColor>
+                    {'  '}{row.category}
+                  </Text>
+                );
+              }
+              const { item, index } = row;
+              const focused = index === visibleSelected;
+              return (
+                <Text
+                  key={item.name}
+                  inverse={focused}
+                  {...(focused ? { color: 'green' } : {})}
+                  wrap="truncate-end"
+                >
+                  {focused ? '› ' : '  '}
+                  {statusBadge(item.enabled)}{' '}
+                  <Text bold>{item.name.padEnd(20)}</Text>
+                  <Text dimColor>
+                    {`[${item.owner}]`.padEnd(22)}
+                    {rwBadge(item.mutating)} {' '}
+                    {item.permission.padEnd(6)} {' '}
+                    <Text color={item.descMode === 'simple' ? 'yellow' : undefined}>
+                      desc:{item.descMode}
+                    </Text>
+                  </Text>
+                </Text>
+              );
+            })}
+            {hiddenBelow > 0 && !hasFilter ? (
+              <Text dimColor>{`  ↓ ${hiddenBelow} more`}</Text>
+            ) : null}
+          </>
+        )}
+      </Box>
+      {hint ? (
+        <Box marginTop={1}>
+          <Text dimColor>{hint}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/tui/src/hooks/use-picker-keys.ts
+++ b/packages/tui/src/hooks/use-picker-keys.ts
@@ -54,6 +54,10 @@ export interface PickerKeysHost {
   onSlashPickerEnter: (() => void) | undefined;
   onSettingsPickerEnter: (() => void) | undefined;
   onPluginPickerToggle: (() => Promise<void> | void) | undefined;
+  onMcpPickerToggle: (() => Promise<void> | void) | undefined;
+  onMcpPickerRestart: (() => Promise<void> | void) | undefined;
+  onToolsPickerToggle: (() => Promise<void> | void) | undefined;
+  onBrainRiskChange: ((delta: number) => void) | undefined;
   onFKeyPickerEnter: (() => void) | undefined;
   onPickerEnter: (() => Promise<void>) | undefined;
 
@@ -555,6 +559,105 @@ export function usePickerKeys(
         if (key.leftArrow || key.rightArrow || isEnter) {
           if (debouncedEnter(host)) return true;
           void host.onPluginPickerToggle?.();
+          return true;
+        }
+        return true;
+      }
+
+      // ── MCP server picker ──────────────────────────────────────
+      if (state.mcpPicker.open) {
+        if (key.escape) {
+          dispatch({ type: 'mcpPickerClose' });
+          return true;
+        }
+        if (key.mouse?.kind === 'wheel') {
+          dispatch({ type: 'mcpPickerMove', delta: key.mouse.wheel > 0 ? -1 : 1 });
+          return true;
+        }
+        if (key.upArrow) {
+          dispatch({ type: 'mcpPickerMove', delta: -1 });
+          return true;
+        }
+        if (key.downArrow) {
+          dispatch({ type: 'mcpPickerMove', delta: 1 });
+          return true;
+        }
+        if (input === 'r' || input === 'R') {
+          void host.onMcpPickerRestart?.();
+          return true;
+        }
+        if (key.leftArrow || key.rightArrow || isEnter) {
+          if (debouncedEnter(host)) return true;
+          void host.onMcpPickerToggle?.();
+          return true;
+        }
+        return true;
+      }
+
+      // ── Tools picker (filter, toggle enable/disable) ──────────
+      if (state.toolsPicker.open) {
+        if (key.escape) {
+          if (state.toolsPicker.filter) {
+            dispatch({ type: 'toolsPickerFilter', filter: '' });
+          } else {
+            dispatch({ type: 'toolsPickerClose' });
+          }
+          return true;
+        }
+        if (key.mouse?.kind === 'wheel') {
+          dispatch({ type: 'toolsPickerMove', delta: key.mouse.wheel > 0 ? -1 : 1 });
+          return true;
+        }
+        if (key.upArrow) {
+          dispatch({ type: 'toolsPickerMove', delta: -1 });
+          return true;
+        }
+        if (key.downArrow) {
+          dispatch({ type: 'toolsPickerMove', delta: 1 });
+          return true;
+        }
+        if (key.leftArrow || key.rightArrow || isEnter) {
+          if (debouncedEnter(host)) return true;
+          void host.onToolsPickerToggle?.();
+          return true;
+        }
+        // Printable chars → filter mode (like SettingsPicker slash search)
+        if (input && input.length === 1 && input.charCodeAt(0) >= 0x20 && input.charCodeAt(0) < 0x7f) {
+          dispatch({ type: 'toolsPickerFilter', filter: (state.toolsPicker.filter ?? '') + input });
+          return true;
+        }
+        if (key.backspace) {
+          const cur = state.toolsPicker.filter ?? '';
+          dispatch({ type: 'toolsPickerFilter', filter: cur.length > 0 ? cur.slice(0, -1) : '' });
+          return true;
+        }
+        return true;
+      }
+
+      // ── Brain panel (risk ceiling + decision log) ─────────────
+      if (state.brainPanel.open) {
+        if (key.escape) {
+          dispatch({ type: 'brainClose' });
+          return true;
+        }
+        if (key.mouse?.kind === 'wheel') {
+          dispatch({ type: 'brainMove', delta: key.mouse.wheel > 0 ? -1 : 1 });
+          return true;
+        }
+        if (key.upArrow) {
+          dispatch({ type: 'brainMove', delta: -1 });
+          return true;
+        }
+        if (key.downArrow) {
+          dispatch({ type: 'brainMove', delta: 1 });
+          return true;
+        }
+        if (key.leftArrow) {
+          host.onBrainRiskChange?.(-1);
+          return true;
+        }
+        if (key.rightArrow) {
+          host.onBrainRiskChange?.(1);
           return true;
         }
         return true;

--- a/packages/tui/src/on-panel-open.ts
+++ b/packages/tui/src/on-panel-open.ts
@@ -20,6 +20,9 @@ import type { PluginPickerItem } from './components/plugin-picker.js';
  */
 export type PanelAction =
   | 'pluginPickerOpen'
+  | 'mcpPickerOpen'
+  | 'toolsPickerOpen'
+  | 'brainOpen'
   | 'projectPickerOpen'
   | 'statuslineOpen'
   | 'authOpen'
@@ -61,6 +64,11 @@ export interface PanelOpenDeps {
    * mode from the host and dispatches modePickerOpen with the populated list.
    */
   openModePicker?: (() => void | Promise<unknown>) | undefined;
+  /**
+   * Async opener for the Brain panel (`/brain`). Fetches current risk level
+   * and decision log from the host, then dispatches brainOpen.
+   */
+  openBrainPanel?: (() => void | Promise<unknown>) | undefined;
 }
 
 /**
@@ -86,6 +94,13 @@ export function createPanelOpenDispatcher(deps: PanelOpenDeps): (action: string)
         // so we just dispatch the open action.
         dispatch({ type: 'pluginPickerOpen' });
         return true;
+      case 'mcpPickerOpen':
+        // The picker self-loads via getMcpServers in its own refresh effect.
+        dispatch({ type: 'mcpPickerOpen' });
+        return true;
+      case 'toolsPickerOpen':
+        dispatch({ type: 'toolsPickerOpen' });
+        return true;
       case 'projectPickerOpen':
         // Items must be loaded from the host before opening — delegate to the
         // same async opener that F1 uses.
@@ -100,6 +115,12 @@ export function createPanelOpenDispatcher(deps: PanelOpenDeps): (action: string)
         // Async — fetches modes from the host, then dispatches open.
         if (deps.openModePicker) {
           void deps.openModePicker();
+          return true;
+        }
+        return false;
+      case 'brainOpen':
+        if (deps.openBrainPanel) {
+          void deps.openBrainPanel();
           return true;
         }
         return false;

--- a/packages/tui/src/reducers/helpers.ts
+++ b/packages/tui/src/reducers/helpers.ts
@@ -19,6 +19,9 @@ type PanelResetState = Pick<
   | 'settingsPicker'
   | 'statuslinePicker'
   | 'pluginPicker'
+  | 'mcpPicker'
+  | 'toolsPicker'
+  | 'brainPanel'
   | 'authPanel'
   | 'projectPicker'
   | 'fKeyPicker'
@@ -44,6 +47,9 @@ export function closePanels(state: State): PanelResetState {
     settingsPicker: { ...state.settingsPicker, open: false },
     statuslinePicker: { ...state.statuslinePicker, open: false },
     pluginPicker: { ...state.pluginPicker, open: false },
+    mcpPicker: { ...state.mcpPicker, open: false },
+    toolsPicker: { ...state.toolsPicker, open: false },
+    brainPanel: { ...state.brainPanel, open: false },
     authPanel: { ...state.authPanel, open: false, busy: false },
     projectPicker: { ...state.projectPicker, open: false },
     fKeyPicker: { ...state.fKeyPicker, open: false },

--- a/packages/tui/src/run-tui.ts
+++ b/packages/tui/src/run-tui.ts
@@ -30,7 +30,9 @@ import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 import React from 'react';
 import { App } from './app.js';
+import type { McpPickerItem } from './components/mcp-picker.js';
 import type { PluginPickerItem } from './components/plugin-picker.js';
+import type { ToolPickerItem } from './components/tools-picker.js';
 import type { StatuslineItem } from './components/statusline-picker.js';
 import { MOUSE_OFF } from './mouse.js';
 import { startTerminalTitle } from './terminal-title.js';
@@ -355,6 +357,42 @@ export interface RunTuiOptions {
         message?: string | undefined;
         error?: string | undefined;
       }>)
+    | undefined;
+  /** Load MCP server rows for the interactive MCP picker. */
+  getMcpServers?: (() => McpPickerItem[]) | undefined;
+  /** Toggle one MCP server (enable/disable) from the interactive picker. */
+  onMcpToggle?:
+    | ((name: string) => Promise<{
+        items: McpPickerItem[];
+        message?: string | undefined;
+        error?: string | undefined;
+      }>)
+    | undefined;
+  /** Restart one MCP server from the interactive picker. */
+  onMcpRestart?:
+    | ((name: string) => Promise<{
+        items: McpPickerItem[];
+        message?: string | undefined;
+        error?: string | undefined;
+      }>)
+    | undefined;
+  /** Load tool rows for the interactive tool picker. */
+  getToolsItems?: (() => ToolPickerItem[]) | undefined;
+  /** Toggle one tool (enable/disable) from the interactive tool picker. */
+  onToolToggle?:
+    | ((name: string) => Promise<{
+        items: ToolPickerItem[];
+        message?: string | undefined;
+        error?: string | undefined;
+      }>)
+    | undefined;
+  /** Get current brain risk level and decision log for the Brain panel. */
+  getBrainData?:
+    | (() => { riskLevel: 'off' | 'low' | 'medium' | 'high' | 'all'; log: Array<{ kind: string; question: string; outcome: string; age: string }> })
+    | undefined;
+  /** Set brain risk ceiling from the Brain panel. */
+  onBrainRiskLevel?:
+    | ((level: 'off' | 'low' | 'medium' | 'high' | 'all') => string | undefined)
     | undefined;
   /**
    * Host for the interactive `/auth` panel (provider/key management, OAuth
@@ -1022,6 +1060,13 @@ export async function runTui(opts: RunTuiOptions): Promise<number> {
           saveSettings: opts.saveSettings,
           getPluginItems: opts.getPluginItems,
           onPluginToggle: opts.onPluginToggle,
+          getMcpServers: opts.getMcpServers,
+          onMcpToggle: opts.onMcpToggle,
+          onMcpRestart: opts.onMcpRestart,
+          getToolsItems: opts.getToolsItems,
+          onToolToggle: opts.onToolToggle,
+          getBrainData: opts.getBrainData,
+          onBrainRiskLevel: opts.onBrainRiskLevel,
           authHost: opts.authHost,
           predictNext: opts.predictNext,
           onSuggestionsParsed: opts.onSuggestionsParsed,

--- a/packages/tui/tests/brain-panel-reducer.test.ts
+++ b/packages/tui/tests/brain-panel-reducer.test.ts
@@ -1,0 +1,343 @@
+// Tests for the Brain panel reducer cases. The panel is opened by `/brain`
+// via the slash-command → onPanelOpen dispatch bridge; these tests pin down
+// the state-mutation contract that bridge depends on.
+//
+// Coverage:
+//   - brainOpen              → opens, closes siblings, seeds riskLevel + log
+//   - brainClose             → closes
+//   - brainMove              → wrap-around on empty (no-op) and non-empty
+//   - brainRiskChange        → cycles risk levels bidirectionally
+//   - brainSetLog            → replaces log, clamps selected
+//   - brainHint              → sets hint text (and clears it)
+
+import { describe, expect, it } from 'vitest';
+import { reducer } from '../src/app.js';
+import type { State } from '../src/app-state.js';
+import type { BrainLogEntry, BrainRiskLevel } from '../src/components/brain-panel.js';
+
+const ALL_LEVELS: BrainRiskLevel[] = ['off', 'low', 'medium', 'high', 'all'];
+
+function logEntry(kind = 'tool', question = 'test question', outcome = 'approved'): BrainLogEntry {
+  return { kind, question, outcome, age: '30s' };
+}
+
+function initial(over: Partial<State> = {}): State {
+  return {
+    entries: [],
+    buffer: '',
+    cursor: 0,
+    streamingText: '',
+    toolStream: null,
+    status: 'idle' as const,
+    interrupts: 0,
+    steeringPending: false,
+    steerSnapshot: null,
+    hint: '',
+    brain: { state: 'idle' as const },
+    brainPrompt: null,
+    nextId: 1,
+    historyGen: 0,
+    picker: { open: false, query: '', matches: [], selected: 0 },
+    slashPicker: { open: false, query: '', matches: [], selected: 0 },
+    runningTools: new Map(),
+    queue: [],
+    nextQueueId: 1,
+    inputHistory: [],
+    historyIndex: 0,
+    modelPicker: {
+      open: false,
+      step: 'provider' as const,
+      providerOptions: [],
+      modelOptions: [],
+      filteredOptions: [],
+      selected: 0,
+      searchQuery: '',
+    },
+    confirm: null,
+    enhance: null,
+    enhanceEnabled: true,
+    enhanceBusy: false,
+    sendModePicker: null,
+    contextChipVersion: 0,
+    fleet: {},
+    fleetCost: 0,
+    fleetTokens: { input: 0, output: 0 },
+    streamFleet: true,
+    monitorOpen: false,
+    agentsMonitorOpen: false,
+    helpOpen: false,
+    todosMonitorOpen: false,
+    queuePanelOpen: false,
+    processListOpen: false,
+    auditPanelOpen: false,
+    kanbanPanelOpen: false,
+    planPanelOpen: false,
+    goalPanelOpen: false,
+    worktreeMonitorOpen: false,
+    sessionsPanelOpen: false,
+    sessionsPanel: { sessions: [], busy: false, selected: -1 },
+    pluginPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined },
+    mcpPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined },
+    toolsPicker: {
+      open: false, items: [], selected: 0, busy: false, hint: undefined, filter: undefined,
+    },
+    brainPanel: {
+      open: false, riskLevel: 'medium', log: [], selected: 0, hint: undefined,
+    },
+    authPanel: {
+      open: false, view: 'list', providers: [], presets: [], busy: false, selected: 0,
+      filter: '', catalog: [], catalogFilter: '', input: null, confirm: null, flowLog: [],
+    },
+    projectPicker: {
+      open: false, allItems: [], items: [], selected: 0, filter: '', hint: undefined,
+    },
+    fKeyPicker: { open: false, selected: 0 },
+    sessionResumeConfirm: null,
+    collabSession: null,
+    checkpoints: [],
+    rewindOverlay: null,
+    eternalStage: null,
+    goalSummary: null,
+    autoPhase: null,
+    sddBoard: null,
+    worktrees: {},
+    coordinator: {
+      goals: [], timeline: [], knowledgeCount: 0, monitorOpen: false, healthy: false,
+    },
+    settingsPicker: {
+      open: false, field: 0, lastSettingsField: 0,
+      mode: 'off', delayMs: 0, titleAnimation: true, yolo: false,
+      streamFleet: false, chime: false, confirmExit: true,
+      nextPrediction: false, featureMcp: true, featurePlugins: true,
+      featureMemory: true, featureSkills: true, featureModelsRegistry: true,
+      tokenSavingTier: 'off', allowOutsideProjectRoot: true,
+      contextAutoCompact: true, contextStrategy: 'hybrid', contextMode: 'balanced',
+      maxConcurrent: 4, logLevel: 'info', auditLevel: 'standard',
+      indexOnStart: true, multiDiffSummaryThreshold: 5,
+      maxIterations: 500, autoProceedMaxIterations: 50,
+      enhanceDelayMs: 60000, enhanceEnabled: true, enhanceLanguage: 'original',
+      debugStream: false, statuslineMode: 'detailed',
+      reasoningMode: 'auto', reasoningEffort: 'high', reasoningPreserve: false,
+      thinkingWord: 'thinking', cacheTtl: 'default', configScope: 'global',
+      animationStyle: 'rainbow', filter: undefined, hint: undefined,
+    },
+    statuslinePicker: { open: false, field: 0, hiddenItems: [], visibleChips: [], hint: undefined },
+    scrollOffset: 0,
+    totalLines: 0,
+    viewportRows: 0,
+    pendingNewLines: 0,
+    debugStreamStats: null,
+    countdown: null,
+    ...over,
+  } as State;
+}
+
+describe('brainPanel reducer — open/close', () => {
+  it('opens the panel with riskLevel and log from the action', () => {
+    const s = reducer(
+      initial() as never,
+      {
+        type: 'brainOpen',
+        riskLevel: 'high',
+        log: [logEntry('tool', 'Allow write to /etc?', 'denied')],
+      } as never,
+    ) as unknown as { brainPanel: { open: boolean; riskLevel: string; log: BrainLogEntry[]; selected: number; hint?: string } };
+    expect(s.brainPanel.open).toBe(true);
+    expect(s.brainPanel.riskLevel).toBe('high');
+    expect(s.brainPanel.log).toHaveLength(1);
+    expect(s.brainPanel.log[0]?.question).toBe('Allow write to /etc?');
+    expect(s.brainPanel.selected).toBe(0);
+    expect(s.brainPanel.hint).toBeUndefined();
+  });
+
+  it('closes sibling panels so the panel owns the screen', () => {
+    const s = reducer(
+      initial({ helpOpen: true, monitorOpen: true }) as never,
+      {
+        type: 'brainOpen',
+        riskLevel: 'low',
+        log: [],
+      } as never,
+    ) as unknown as { helpOpen: boolean; monitorOpen: boolean };
+    expect(s.helpOpen).toBe(false);
+    expect(s.monitorOpen).toBe(false);
+  });
+
+  it('brainClose flips open=false', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'brainOpen', riskLevel: 'medium', log: [] } as never,
+    ) as unknown as { brainPanel: { open: boolean } };
+    expect(opened.brainPanel.open).toBe(true);
+
+    const closed = reducer(
+      opened as never,
+      { type: 'brainClose' } as never,
+    ) as unknown as { brainPanel: { open: boolean } };
+    expect(closed.brainPanel.open).toBe(false);
+  });
+});
+
+describe('brainPanel reducer — navigation', () => {
+  function openWith(log: BrainLogEntry[]): State {
+    return reducer(
+      initial() as never,
+      { type: 'brainOpen', riskLevel: 'medium', log } as never,
+    ) as unknown as State;
+  }
+
+  it('move is a no-op when the log is empty', () => {
+    const before = initial();
+    const after = reducer(
+      before as never,
+      { type: 'brainMove', delta: 1 } as never,
+    ) as unknown as State;
+    expect(after).toBe(before);
+  });
+
+  it('move wraps forward across log entries', () => {
+    let s = openWith([logEntry('a'), logEntry('b'), logEntry('c')]);
+    const sel = () =>
+      (s as unknown as { brainPanel: { selected: number } }).brainPanel.selected;
+    s = reducer(s as never, { type: 'brainMove', delta: 1 } as never) as unknown as State;
+    expect(sel()).toBe(1);
+    s = reducer(s as never, { type: 'brainMove', delta: 1 } as never) as unknown as State;
+    expect(sel()).toBe(2);
+    s = reducer(s as never, { type: 'brainMove', delta: 1 } as never) as unknown as State;
+    expect(sel()).toBe(0); // wraps to first
+  });
+
+  it('move wraps backward past the first entry', () => {
+    let s = openWith([logEntry('a'), logEntry('b')]);
+    const sel = () =>
+      (s as unknown as { brainPanel: { selected: number } }).brainPanel.selected;
+    s = reducer(s as never, { type: 'brainMove', delta: -1 } as never) as unknown as State;
+    expect(sel()).toBe(1);
+  });
+
+  it('move clears hint on every navigation', () => {
+    let s = openWith([logEntry('a')]);
+    s = reducer(s as never, { type: 'brainHint', text: 'hint text' } as never) as unknown as State;
+    expect(
+      (s as unknown as { brainPanel: { hint?: string } }).brainPanel.hint,
+    ).toBe('hint text');
+    s = reducer(s as never, { type: 'brainMove', delta: 1 } as never) as unknown as State;
+    expect(
+      (s as unknown as { brainPanel: { hint?: string } }).brainPanel.hint,
+    ).toBeUndefined();
+  });
+});
+
+describe('brainPanel reducer — risk change (cycling)', () => {
+  function openedWith(riskLevel: BrainRiskLevel): State {
+    return reducer(
+      initial() as never,
+      { type: 'brainOpen', riskLevel, log: [logEntry()] } as never,
+    ) as unknown as State;
+  }
+
+  it('cycles forward through risk levels', () => {
+    let s = openedWith('off');
+    const risk = () =>
+      (s as unknown as { brainPanel: { riskLevel: BrainRiskLevel } }).brainPanel.riskLevel;
+    // off → low
+    s = reducer(s as never, { type: 'brainRiskChange', delta: 1 } as never) as unknown as State;
+    expect(risk()).toBe('low');
+    // low → medium
+    s = reducer(s as never, { type: 'brainRiskChange', delta: 1 } as never) as unknown as State;
+    expect(risk()).toBe('medium');
+    // medium → high
+    s = reducer(s as never, { type: 'brainRiskChange', delta: 1 } as never) as unknown as State;
+    expect(risk()).toBe('high');
+    // high → all
+    s = reducer(s as never, { type: 'brainRiskChange', delta: 1 } as never) as unknown as State;
+    expect(risk()).toBe('all');
+    // all → off (wraps)
+    s = reducer(s as never, { type: 'brainRiskChange', delta: 1 } as never) as unknown as State;
+    expect(risk()).toBe('off');
+  });
+
+  it('cycles backward through risk levels', () => {
+    let s = openedWith('off');
+    const risk = () =>
+      (s as unknown as { brainPanel: { riskLevel: BrainRiskLevel } }).brainPanel.riskLevel;
+    // off → all (wraps)
+    s = reducer(s as never, { type: 'brainRiskChange', delta: -1 } as never) as unknown as State;
+    expect(risk()).toBe('all');
+    // all → high
+    s = reducer(s as never, { type: 'brainRiskChange', delta: -1 } as never) as unknown as State;
+    expect(risk()).toBe('high');
+  });
+
+  it('cycles from medium forward by 3 to all', () => {
+    let s = openedWith('medium');
+    const risk = () =>
+      (s as unknown as { brainPanel: { riskLevel: BrainRiskLevel } }).brainPanel.riskLevel;
+    // medium +3 → high(+1) → all(+2) → off(+3) - wait no.
+    // medium +1 → high, +2 → all, +3 → off
+    s = reducer(s as never, { type: 'brainRiskChange', delta: 3 } as never) as unknown as State;
+    expect(risk()).toBe('off'); // medium→high→all→off
+  });
+});
+
+describe('brainPanel reducer — setLog and hint', () => {
+  function openWith(log: BrainLogEntry[]): State {
+    return reducer(
+      initial() as never,
+      { type: 'brainOpen', riskLevel: 'medium', log } as never,
+    ) as unknown as State;
+  }
+
+  it('setLog replaces the log and clamps selected', () => {
+    let s = openWith([logEntry('a'), logEntry('b'), logEntry('c')]);
+    // Navigate to last entry
+    s = reducer(s as never, { type: 'brainMove', delta: 2 } as never) as unknown as State;
+    const sel = () =>
+      (s as unknown as { brainPanel: { selected: number } }).brainPanel.selected;
+    expect(sel()).toBe(2);
+
+    // Shrink log to 1 entry
+    s = reducer(
+      s as never,
+      { type: 'brainSetLog', log: [logEntry('x')] } as never,
+    ) as unknown as State;
+    expect(sel()).toBe(0);
+    expect(
+      (s as unknown as { brainPanel: { log: BrainLogEntry[] } }).brainPanel.log,
+    ).toHaveLength(1);
+  });
+
+  it('setLog preserves riskLevel', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'brainOpen', riskLevel: 'all', log: [] } as never,
+    ) as unknown as { brainPanel: { riskLevel: string } };
+    expect(opened.brainPanel.riskLevel).toBe('all');
+
+    const updated = reducer(
+      opened as never,
+      { type: 'brainSetLog', log: [logEntry()] } as never,
+    ) as unknown as { brainPanel: { riskLevel: string; log: BrainLogEntry[] } };
+    expect(updated.brainPanel.riskLevel).toBe('all');
+    expect(updated.brainPanel.log).toHaveLength(1);
+  });
+
+  it('hint sets and clears text', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'brainOpen', riskLevel: 'medium', log: [] } as never,
+    ) as unknown as { brainPanel: { hint?: string } };
+
+    const withHint = reducer(
+      opened as never,
+      { type: 'brainHint', text: 'Risk ceiling → HIGH' } as never,
+    ) as unknown as { brainPanel: { hint?: string } };
+    expect(withHint.brainPanel.hint).toBe('Risk ceiling → HIGH');
+
+    const cleared = reducer(
+      withHint as never,
+      { type: 'brainHint' } as never,
+    ) as unknown as { brainPanel: { hint?: string } };
+    expect(cleared.brainPanel.hint).toBeUndefined();
+  });
+});

--- a/packages/tui/tests/mcp-picker-reducer.test.ts
+++ b/packages/tui/tests/mcp-picker-reducer.test.ts
@@ -1,0 +1,320 @@
+// Tests for the MCP picker reducer cases. The picker is opened by `/mcp`
+// via the slash-command → onPanelOpen dispatch bridge; these tests pin down
+// the state-mutation contract that bridge depends on.
+//
+// Coverage:
+//   - mcpPickerOpen             → opens, closes siblings, busy when items=[]
+//   - mcpPickerOpen + items     → seeds items and clamps selected
+//   - mcpPickerClose            → closes, clears busy
+//   - mcpPickerMove             → wrap-around on empty (no-op) and non-empty
+//   - mcpPickerSetItems         → replaces items and busy=false
+//   - mcpPickerBusy             → toggles busy
+//   - mcpPickerHint             → sets hint text (and clears it)
+
+import { describe, expect, it } from 'vitest';
+import { reducer } from '../src/app.js';
+import type { State } from '../src/app-state.js';
+import type { McpPickerItem } from '../src/components/mcp-picker.js';
+
+function item(name: string, enabled = true, status = 'connected'): McpPickerItem {
+  return {
+    name,
+    enabled,
+    status,
+    transport: 'stdio',
+    description: `${name} MCP server`,
+    toolCount: 3,
+    lazy: false,
+  };
+}
+
+function initial(over: Partial<State> = {}): State {
+  return {
+    entries: [],
+    buffer: '',
+    cursor: 0,
+    streamingText: '',
+    toolStream: null,
+    status: 'idle' as const,
+    interrupts: 0,
+    steeringPending: false,
+    steerSnapshot: null,
+    hint: '',
+    brain: { state: 'idle' as const },
+    brainPrompt: null,
+    nextId: 1,
+    historyGen: 0,
+    picker: { open: false, query: '', matches: [], selected: 0 },
+    slashPicker: { open: false, query: '', matches: [], selected: 0 },
+    runningTools: new Map(),
+    queue: [],
+    nextQueueId: 1,
+    inputHistory: [],
+    historyIndex: 0,
+    modelPicker: {
+      open: false,
+      step: 'provider' as const,
+      providerOptions: [],
+      modelOptions: [],
+      filteredOptions: [],
+      selected: 0,
+      searchQuery: '',
+    },
+    confirm: null,
+    enhance: null,
+    enhanceEnabled: true,
+    enhanceBusy: false,
+    sendModePicker: null,
+    contextChipVersion: 0,
+    fleet: {},
+    fleetCost: 0,
+    fleetTokens: { input: 0, output: 0 },
+    streamFleet: true,
+    monitorOpen: false,
+    agentsMonitorOpen: false,
+    helpOpen: false,
+    todosMonitorOpen: false,
+    queuePanelOpen: false,
+    processListOpen: false,
+    auditPanelOpen: false,
+    kanbanPanelOpen: false,
+    planPanelOpen: false,
+    goalPanelOpen: false,
+    worktreeMonitorOpen: false,
+    sessionsPanelOpen: false,
+    sessionsPanel: { sessions: [], busy: false, selected: -1 },
+    pluginPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined },
+    mcpPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined },
+    toolsPicker: {
+      open: false, items: [], selected: 0, busy: false, hint: undefined, filter: undefined,
+    },
+    authPanel: {
+      open: false, view: 'list', providers: [], presets: [], busy: false, selected: 0,
+      filter: '', catalog: [], catalogFilter: '', input: null, confirm: null, flowLog: [],
+    },
+    projectPicker: {
+      open: false, allItems: [], items: [], selected: 0, filter: '', hint: undefined,
+    },
+    fKeyPicker: { open: false, selected: 0 },
+    sessionResumeConfirm: null,
+    collabSession: null,
+    checkpoints: [],
+    rewindOverlay: null,
+    eternalStage: null,
+    goalSummary: null,
+    autoPhase: null,
+    sddBoard: null,
+    worktrees: {},
+    coordinator: {
+      goals: [], timeline: [], knowledgeCount: 0, monitorOpen: false, healthy: false,
+    },
+    settingsPicker: {
+      open: false, field: 0, lastSettingsField: 0,
+      mode: 'off', delayMs: 0, titleAnimation: true, yolo: false,
+      streamFleet: false, chime: false, confirmExit: true,
+      nextPrediction: false, featureMcp: true, featurePlugins: true,
+      featureMemory: true, featureSkills: true, featureModelsRegistry: true,
+      tokenSavingTier: 'off', allowOutsideProjectRoot: true,
+      contextAutoCompact: true, contextStrategy: 'hybrid', contextMode: 'balanced',
+      maxConcurrent: 4, logLevel: 'info', auditLevel: 'standard',
+      indexOnStart: true, multiDiffSummaryThreshold: 5,
+      maxIterations: 500, autoProceedMaxIterations: 50,
+      enhanceDelayMs: 60000, enhanceEnabled: true, enhanceLanguage: 'original',
+      debugStream: false, statuslineMode: 'detailed',
+      reasoningMode: 'auto', reasoningEffort: 'high', reasoningPreserve: false,
+      thinkingWord: 'thinking', cacheTtl: 'default', configScope: 'global',
+      animationStyle: 'rainbow', filter: undefined, hint: undefined,
+    },
+    statuslinePicker: { open: false, field: 0, hiddenItems: [], visibleChips: [], hint: undefined },
+    scrollOffset: 0,
+    totalLines: 0,
+    viewportRows: 0,
+    pendingNewLines: 0,
+    debugStreamStats: null,
+    countdown: null,
+    ...over,
+  } as State;
+}
+
+describe('mcpPicker reducer — open/close', () => {
+  it('opens the picker and sets busy when no items provided', () => {
+    const s = reducer(initial(), {
+      type: 'mcpPickerOpen',
+    } as never) as unknown as {
+      mcpPicker: { open: boolean; busy: boolean; items: McpPickerItem[] };
+    };
+    expect(s.mcpPicker.open).toBe(true);
+    expect(s.mcpPicker.busy).toBe(true);
+    expect(s.mcpPicker.items).toEqual([]);
+  });
+
+  it('closes sibling panels so the picker owns the screen', () => {
+    const s = reducer(
+      initial({ helpOpen: true, monitorOpen: true }) as never,
+      {
+        type: 'mcpPickerOpen',
+        items: [item('github'), item('filesystem')],
+      } as never,
+    ) as unknown as {
+      helpOpen: boolean;
+      monitorOpen: boolean;
+      mcpPicker: { open: boolean; busy: boolean };
+    };
+    expect(s.helpOpen).toBe(false);
+    expect(s.monitorOpen).toBe(false);
+    expect(s.mcpPicker.open).toBe(true);
+    expect(s.mcpPicker.busy).toBe(false);
+  });
+
+  it('seeds items and clamps selected at the last index', () => {
+    const s = reducer(
+      initial() as never,
+      {
+        type: 'mcpPickerOpen',
+        items: [item('a'), item('b'), item('c')],
+      } as never,
+    ) as unknown as {
+      mcpPicker: { items: McpPickerItem[]; selected: number; busy: boolean };
+    };
+    expect(s.mcpPicker.items.map((i) => i.name)).toEqual(['a', 'b', 'c']);
+    expect(s.mcpPicker.busy).toBe(false);
+    expect(s.mcpPicker.selected).toBe(0);
+  });
+
+  it('mcpPickerClose flips open=false and busy=false', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'mcpPickerOpen', items: [item('a')] } as never,
+    ) as unknown as { mcpPicker: { open: boolean; busy: boolean } };
+    expect(opened.mcpPicker.open).toBe(true);
+
+    const closed = reducer(
+      opened as never,
+      { type: 'mcpPickerClose' } as never,
+    ) as unknown as { mcpPicker: { open: boolean; busy: boolean } };
+    expect(closed.mcpPicker.open).toBe(false);
+    expect(closed.mcpPicker.busy).toBe(false);
+  });
+});
+
+describe('mcpPicker reducer — navigation', () => {
+  function openWith(items: McpPickerItem[]): State {
+    return reducer(
+      initial() as never,
+      { type: 'mcpPickerOpen', items } as never,
+    ) as unknown as State;
+  }
+
+  it('move is a no-op when the picker is empty', () => {
+    const before = initial();
+    const after = reducer(
+      before as never,
+      { type: 'mcpPickerMove', delta: 1 } as never,
+    ) as unknown as State;
+    expect(after).toBe(before);
+  });
+
+  it('move wraps forward across the items list', () => {
+    let s = openWith([item('a'), item('b'), item('c')]);
+    const sel = () =>
+      (s as unknown as { mcpPicker: { selected: number } }).mcpPicker.selected;
+    s = reducer(s as never, { type: 'mcpPickerMove', delta: 1 } as never) as unknown as State;
+    expect(sel()).toBe(1);
+    s = reducer(s as never, { type: 'mcpPickerMove', delta: 1 } as never) as unknown as State;
+    expect(sel()).toBe(2);
+    s = reducer(s as never, { type: 'mcpPickerMove', delta: 1 } as never) as unknown as State;
+    expect(sel()).toBe(0); // wraps to first
+  });
+
+  it('move wraps backward past the first item', () => {
+    let s = openWith([item('a'), item('b')]);
+    const sel = () =>
+      (s as unknown as { mcpPicker: { selected: number } }).mcpPicker.selected;
+    s = reducer(s as never, { type: 'mcpPickerMove', delta: -1 } as never) as unknown as State;
+    expect(sel()).toBe(1);
+  });
+
+  it('move clears hint on every navigation', () => {
+    let s = openWith([item('a'), item('b')]);
+    s = reducer(s as never, { type: 'mcpPickerHint', text: 'restarting…' } as never) as unknown as State;
+    const withHint = () =>
+      (s as unknown as { mcpPicker: { hint?: string } }).mcpPicker.hint;
+    expect(withHint()).toBe('restarting…');
+    s = reducer(s as never, { type: 'mcpPickerMove', delta: 1 } as never) as unknown as State;
+    expect(withHint()).toBeUndefined();
+  });
+});
+
+describe('mcpPicker reducer — items / busy / hint', () => {
+  function openWith(items: McpPickerItem[]): State {
+    return reducer(
+      initial() as never,
+      { type: 'mcpPickerOpen', items } as never,
+    ) as unknown as State;
+  }
+
+  it('setItems replaces the items list and clears busy', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'mcpPickerOpen' } as never,
+    ) as unknown as State;
+    const s = reducer(
+      opened as never,
+      {
+        type: 'mcpPickerSetItems',
+        items: [item('github'), item('filesystem')],
+      } as never,
+    ) as unknown as {
+      mcpPicker: { items: McpPickerItem[]; busy: boolean };
+    };
+    expect(s.mcpPicker.items.map((i) => i.name)).toEqual(['github', 'filesystem']);
+    expect(s.mcpPicker.busy).toBe(false);
+  });
+
+  it('setItems clamps selected when item count shrinks', () => {
+    let s = openWith([item('a'), item('b'), item('c')]);
+    s = reducer(s as never, { type: 'mcpPickerMove', delta: 2 } as never) as unknown as State;
+    const sel = () =>
+      (s as unknown as { mcpPicker: { selected: number } }).mcpPicker.selected;
+    expect(sel()).toBe(2); // moved to third item
+    s = reducer(
+      s as never,
+      { type: 'mcpPickerSetItems', items: [item('x')] } as never,
+    ) as unknown as State;
+    expect(sel()).toBe(0); // clamped
+  });
+
+  it('busy toggles only the busy flag, preserves other picker state', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'mcpPickerOpen', items: [item('a')] } as never,
+    ) as unknown as { mcpPicker: { busy: boolean; open: boolean } };
+    expect(opened.mcpPicker.busy).toBe(false);
+
+    const busy = reducer(
+      opened as never,
+      { type: 'mcpPickerBusy', busy: true } as never,
+    ) as unknown as { mcpPicker: { busy: boolean; open: boolean } };
+    expect(busy.mcpPicker.busy).toBe(true);
+    expect(busy.mcpPicker.open).toBe(true);
+  });
+
+  it('hint sets and clears row guidance text', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'mcpPickerOpen', items: [item('a')] } as never,
+    ) as unknown as { mcpPicker: { hint?: string } };
+
+    const withHint = reducer(
+      opened as never,
+      { type: 'mcpPickerHint', text: 'Restarted.' } as never,
+    ) as unknown as { mcpPicker: { hint?: string } };
+    expect(withHint.mcpPicker.hint).toBe('Restarted.');
+
+    const cleared = reducer(
+      withHint as never,
+      { type: 'mcpPickerHint' } as never,
+    ) as unknown as { mcpPicker: { hint?: string } };
+    expect(cleared.mcpPicker.hint).toBeUndefined();
+  });
+});

--- a/packages/tui/tests/tools-picker-reducer.test.ts
+++ b/packages/tui/tests/tools-picker-reducer.test.ts
@@ -1,0 +1,385 @@
+// Tests for the tools picker reducer cases. The picker is opened by `/tools`
+// via the slash-command → onPanelOpen dispatch bridge; these tests pin down
+// the state-mutation contract that bridge depends on.
+//
+// Coverage:
+//   - toolsPickerOpen            → opens, closes siblings, busy when items=[]
+//   - toolsPickerOpen + items    → seeds items and clamps selected
+//   - toolsPickerClose           → closes, clears busy, clears filter
+//   - toolsPickerMove            → wrap-around on empty (no-op) and non-empty
+//   - toolsPickerSetItems        → replaces items and busy=false
+//   - toolsPickerToggle          → no-op (handled by host)
+//   - toolsPickerBusy            → toggles busy
+//   - toolsPickerHint            → sets hint text (and clears it)
+//   - toolsPickerFilter          → sets inline search filter, preserves items
+
+import { describe, expect, it } from 'vitest';
+import { reducer } from '../src/app.js';
+import type { State } from '../src/app-state.js';
+import type { ToolPickerItem } from '../src/components/tools-picker.js';
+
+function item(name: string, enabled = true, category = 'Core'): ToolPickerItem {
+  return {
+    name,
+    owner: 'core',
+    category,
+    enabled,
+    mutating: false,
+    permission: 'allow',
+    descMode: 'extend',
+    description: `${name} test row`,
+  };
+}
+
+function initial(over: Partial<State> = {}): State {
+  return {
+    entries: [],
+    buffer: '',
+    cursor: 0,
+    streamingText: '',
+    toolStream: null,
+    status: 'idle' as const,
+    interrupts: 0,
+    steeringPending: false,
+    steerSnapshot: null,
+    hint: '',
+    brain: { state: 'idle' as const },
+    brainPrompt: null,
+    nextId: 1,
+    historyGen: 0,
+    picker: { open: false, query: '', matches: [], selected: 0 },
+    slashPicker: { open: false, query: '', matches: [], selected: 0 },
+    runningTools: new Map(),
+    queue: [],
+    nextQueueId: 1,
+    inputHistory: [],
+    historyIndex: 0,
+    modelPicker: {
+      open: false,
+      step: 'provider' as const,
+      providerOptions: [],
+      modelOptions: [],
+      filteredOptions: [],
+      selected: 0,
+      searchQuery: '',
+    },
+    confirm: null,
+    enhance: null,
+    enhanceEnabled: true,
+    enhanceBusy: false,
+    sendModePicker: null,
+    contextChipVersion: 0,
+    fleet: {},
+    fleetCost: 0,
+    fleetTokens: { input: 0, output: 0 },
+    streamFleet: true,
+    monitorOpen: false,
+    agentsMonitorOpen: false,
+    helpOpen: false,
+    todosMonitorOpen: false,
+    queuePanelOpen: false,
+    processListOpen: false,
+    auditPanelOpen: false,
+    kanbanPanelOpen: false,
+    planPanelOpen: false,
+    goalPanelOpen: false,
+    worktreeMonitorOpen: false,
+    sessionsPanelOpen: false,
+    sessionsPanel: { sessions: [], busy: false, selected: -1 },
+    pluginPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined },
+    mcpPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined },
+    toolsPicker: { open: false, items: [], selected: 0, busy: false, hint: undefined, filter: undefined },
+    authPanel: { open: false, view: 'list', providers: [], presets: [], busy: false, selected: 0, filter: '', catalog: [], catalogFilter: '', input: null, confirm: null, flowLog: [] },
+    projectPicker: {
+      open: false,
+      allItems: [],
+      items: [],
+      selected: 0,
+      filter: '',
+      hint: undefined,
+    },
+    fKeyPicker: { open: false, selected: 0 },
+    sessionResumeConfirm: null,
+    collabSession: null,
+    checkpoints: [],
+    rewindOverlay: null,
+    eternalStage: null,
+    goalSummary: null,
+    autoPhase: null,
+    sddBoard: null,
+    worktrees: {},
+    coordinator: {
+      goals: [],
+      timeline: [],
+      knowledgeCount: 0,
+      monitorOpen: false,
+      healthy: false,
+    },
+    settingsPicker: {
+      open: false, field: 0, lastSettingsField: 0,
+      mode: 'off', delayMs: 0, titleAnimation: true, yolo: false,
+      streamFleet: false, chime: false, confirmExit: true,
+      nextPrediction: false, featureMcp: true, featurePlugins: true,
+      featureMemory: true, featureSkills: true, featureModelsRegistry: true,
+      tokenSavingTier: 'off', allowOutsideProjectRoot: true,
+      contextAutoCompact: true, contextStrategy: 'hybrid', contextMode: 'balanced',
+      maxConcurrent: 4, logLevel: 'info', auditLevel: 'standard',
+      indexOnStart: true, multiDiffSummaryThreshold: 5,
+      maxIterations: 500, autoProceedMaxIterations: 50,
+      enhanceDelayMs: 60000, enhanceEnabled: true, enhanceLanguage: 'original',
+      debugStream: false, statuslineMode: 'detailed',
+      reasoningMode: 'auto', reasoningEffort: 'high', reasoningPreserve: false,
+      thinkingWord: 'thinking', cacheTtl: 'default', configScope: 'global',
+      animationStyle: 'rainbow', filter: undefined, hint: undefined,
+    },
+    statuslinePicker: { open: false, field: 0, hiddenItems: [], visibleChips: [], hint: undefined },
+    scrollOffset: 0,
+    totalLines: 0,
+    viewportRows: 0,
+    pendingNewLines: 0,
+    debugStreamStats: null,
+    countdown: null,
+    ...over,
+  } as State;
+}
+
+describe('toolsPicker reducer — open/close', () => {
+  it('opens the picker and sets busy when no items provided', () => {
+    const s = reducer(initial(), {
+      type: 'toolsPickerOpen',
+    } as never) as unknown as {
+      toolsPicker: { open: boolean; busy: boolean; items: ToolPickerItem[]; filter?: string };
+    };
+    expect(s.toolsPicker.open).toBe(true);
+    expect(s.toolsPicker.busy).toBe(true);
+    expect(s.toolsPicker.items).toEqual([]);
+    expect(s.toolsPicker.filter).toBeUndefined();
+  });
+
+  it('closes sibling panels so the picker owns the screen', () => {
+    const s = reducer(
+      initial({ helpOpen: true, monitorOpen: true }) as never,
+      {
+        type: 'toolsPickerOpen',
+        items: [item('read'), item('write')],
+      } as never,
+    ) as unknown as {
+      helpOpen: boolean;
+      monitorOpen: boolean;
+      toolsPicker: { open: boolean; busy: boolean };
+    };
+    expect(s.helpOpen).toBe(false);
+    expect(s.monitorOpen).toBe(false);
+    expect(s.toolsPicker.open).toBe(true);
+    expect(s.toolsPicker.busy).toBe(false);
+  });
+
+  it('seeds items and clamps selected at the last index', () => {
+    const s = reducer(
+      initial() as never,
+      {
+        type: 'toolsPickerOpen',
+        items: [item('a'), item('b'), item('c')],
+      } as never,
+    ) as unknown as {
+      toolsPicker: { items: ToolPickerItem[]; selected: number; busy: boolean };
+    };
+    expect(s.toolsPicker.items.map((i) => i.name)).toEqual(['a', 'b', 'c']);
+    expect(s.toolsPicker.busy).toBe(false);
+    expect(s.toolsPicker.selected).toBe(0);
+  });
+
+  it('toolsPickerClose flips open=false busy=false and clears filter', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'toolsPickerOpen', items: [item('a')] } as never,
+    ) as unknown as { toolsPicker: { open: boolean; busy: boolean; filter?: string } };
+    expect(opened.toolsPicker.open).toBe(true);
+
+    const closed = reducer(
+      opened as never,
+      { type: 'toolsPickerClose' } as never,
+    ) as unknown as { toolsPicker: { open: boolean; busy: boolean; filter?: string } };
+    expect(closed.toolsPicker.open).toBe(false);
+    expect(closed.toolsPicker.busy).toBe(false);
+    expect(closed.toolsPicker.filter).toBeUndefined();
+  });
+});
+
+describe('toolsPicker reducer — navigation', () => {
+  function openWith(items: ToolPickerItem[]): State {
+    return reducer(
+      initial() as never,
+      { type: 'toolsPickerOpen', items } as never,
+    ) as unknown as State;
+  }
+
+  it('move is a no-op when the picker is empty', () => {
+    const before = initial();
+    const after = reducer(
+      before as never,
+      { type: 'toolsPickerMove', delta: 1 } as never,
+    ) as unknown as State;
+    expect(after).toBe(before);
+  });
+
+  it('move wraps forward across the items list', () => {
+    let s = openWith([item('a'), item('b'), item('c')]);
+    const sel = () =>
+      (s as unknown as { toolsPicker: { selected: number } }).toolsPicker.selected;
+    s = reducer(s as never, { type: 'toolsPickerMove', delta: 1 } as never) as unknown as State;
+    expect(sel()).toBe(1);
+    s = reducer(s as never, { type: 'toolsPickerMove', delta: 1 } as never) as unknown as State;
+    expect(sel()).toBe(2);
+    s = reducer(s as never, { type: 'toolsPickerMove', delta: 1 } as never) as unknown as State;
+    expect(sel()).toBe(0); // wraps to first
+  });
+
+  it('move wraps backward past the first item', () => {
+    let s = openWith([item('a'), item('b')]);
+    const sel = () =>
+      (s as unknown as { toolsPicker: { selected: number } }).toolsPicker.selected;
+    s = reducer(s as never, { type: 'toolsPickerMove', delta: -1 } as never) as unknown as State;
+    expect(sel()).toBe(1);
+  });
+
+  it('move clears hint on every navigation', () => {
+    let s = openWith([item('a'), item('b')]);
+    s = reducer(s as never, { type: 'toolsPickerHint', text: 'some hint' } as never) as unknown as State;
+    const withHint = () =>
+      (s as unknown as { toolsPicker: { hint?: string } }).toolsPicker.hint;
+    expect(withHint()).toBe('some hint');
+    s = reducer(s as never, { type: 'toolsPickerMove', delta: 1 } as never) as unknown as State;
+    expect(withHint()).toBeUndefined();
+  });
+});
+
+describe('toolsPicker reducer — items / busy / hint / filter', () => {
+  it('setItems replaces the items list and clears busy', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'toolsPickerOpen' } as never,
+    ) as unknown as State;
+    const s = reducer(
+      opened as never,
+      {
+        type: 'toolsPickerSetItems',
+        items: [item('read'), item('write')],
+      } as never,
+    ) as unknown as {
+      toolsPicker: { items: ToolPickerItem[]; busy: boolean };
+    };
+    expect(s.toolsPicker.items.map((i) => i.name)).toEqual(['read', 'write']);
+    expect(s.toolsPicker.busy).toBe(false);
+  });
+
+  it('setItems clamps selected when item count shrinks', () => {
+    let s = openWith([item('a'), item('b'), item('c')]);
+    s = reducer(s as never, { type: 'toolsPickerMove', delta: 2 } as never) as unknown as State;
+    const sel = () =>
+      (s as unknown as { toolsPicker: { selected: number } }).toolsPicker.selected;
+    expect(sel()).toBe(2); // moved to third item
+    s = reducer(
+      s as never,
+      { type: 'toolsPickerSetItems', items: [item('x')] } as never,
+    ) as unknown as State;
+    expect(sel()).toBe(0); // clamped
+  });
+
+  it('toolsPickerToggle is a no-op in the reducer', () => {
+    const s = reducer(
+      initial() as never,
+      { type: 'toolsPickerToggle' } as never,
+    ) as unknown as State;
+    // The toggle action is handled by the host callback; reducer returns state unchanged.
+    expect(s).toStrictEqual(initial());
+  });
+
+  it('busy toggles only the busy flag, preserves other picker state', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'toolsPickerOpen', items: [item('a')] } as never,
+    ) as unknown as { toolsPicker: { busy: boolean; open: boolean } };
+    expect(opened.toolsPicker.busy).toBe(false);
+
+    const busy = reducer(
+      opened as never,
+      { type: 'toolsPickerBusy', busy: true } as never,
+    ) as unknown as { toolsPicker: { busy: boolean; open: boolean } };
+    expect(busy.toolsPicker.busy).toBe(true);
+    expect(busy.toolsPicker.open).toBe(true);
+  });
+
+  it('hint sets and clears row guidance text', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'toolsPickerOpen', items: [item('a')] } as never,
+    ) as unknown as { toolsPicker: { hint?: string } };
+
+    const withHint = reducer(
+      opened as never,
+      { type: 'toolsPickerHint', text: 'Now disabled' } as never,
+    ) as unknown as { toolsPicker: { hint?: string } };
+    expect(withHint.toolsPicker.hint).toBe('Now disabled');
+
+    const cleared = reducer(
+      withHint as never,
+      { type: 'toolsPickerHint' } as never,
+    ) as unknown as { toolsPicker: { hint?: string } };
+    expect(cleared.toolsPicker.hint).toBeUndefined();
+  });
+
+  it('filter sets the inline search string', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'toolsPickerOpen', items: [item('read'), item('write')] } as never,
+    ) as unknown as { toolsPicker: { filter?: string } };
+
+    const filtered = reducer(
+      opened as never,
+      { type: 'toolsPickerFilter', filter: 'read' } as never,
+    ) as unknown as { toolsPicker: { filter?: string } };
+    expect(filtered.toolsPicker.filter).toBe('read');
+  });
+
+  it('filter can be empty string to clear', () => {
+    let s = reducer(
+      initial() as never,
+      { type: 'toolsPickerOpen', items: [item('a')] } as never,
+    ) as unknown as State;
+    s = reducer(s as never, { type: 'toolsPickerFilter', filter: 'hello' } as never) as unknown as State;
+    s = reducer(s as never, { type: 'toolsPickerFilter', filter: '' } as never) as unknown as {
+      toolsPicker: { filter?: string };
+    };
+    expect(s.toolsPicker.filter).toBe('');
+  });
+
+  it('filter does not affect other state fields', () => {
+    const opened = reducer(
+      initial() as never,
+      { type: 'toolsPickerOpen', items: [item('bash'), item('read')] } as never,
+    ) as unknown as {
+      toolsPicker: { items: ToolPickerItem[]; selected: number; open: boolean; filter?: string };
+    };
+    expect(opened.toolsPicker.items.length).toBe(2);
+    expect(opened.toolsPicker.selected).toBe(0);
+
+    const filtered = reducer(
+      opened as never,
+      { type: 'toolsPickerFilter', filter: 'bash' } as never,
+    ) as unknown as {
+      toolsPicker: { items: ToolPickerItem[]; selected: number; open: boolean; filter?: string };
+    };
+    expect(filtered.toolsPicker.items.length).toBe(2); // items unchanged
+    expect(filtered.toolsPicker.selected).toBe(0); // selected unchanged
+    expect(filtered.toolsPicker.open).toBe(true);
+  });
+});
+
+// Helper to open a picker with items (used by multi-case tests)
+function openWith(items: ToolPickerItem[]): State {
+  return reducer(
+    initial() as never,
+    { type: 'toolsPickerOpen', items } as never,
+  ) as unknown as State;
+}

--- a/packages/webui/src/components/ChatInput/slash-routing.ts
+++ b/packages/webui/src/components/ChatInput/slash-routing.ts
@@ -237,6 +237,10 @@ export function runChatSlashCommand(options: RunChatSlashCommandOptions): boolea
     case '/mcp':
       client?.send?.({ type: 'mcp.list' });
       openMainView('settings');
+      addMessage({
+        role: 'assistant',
+        content: '🖥️ **MCP Servers** — settings opened to the MCP tab.\n\nConfigure, enable/disable, or restart servers from the MCP section.',
+      });
       return true;
     case '/working-dir':
     case '/cwd': {

--- a/packages/webui/src/components/SettingsPanel/ToolsSection.tsx
+++ b/packages/webui/src/components/SettingsPanel/ToolsSection.tsx
@@ -1,0 +1,215 @@
+import { Loader2, Power, PowerOff, Search, Wrench } from 'lucide-react';
+import { type ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import { useAppTranslation } from '@/i18n';
+import { toast } from '@/components/Toaster';
+import { useWebSocket } from '@/hooks/useWebSocket';
+import type { WSServerMessage } from '@/types';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+
+export interface ToolInfo {
+  name: string;
+  owner: string;
+  description: string;
+  params: string[];
+  disabled: boolean;
+  mutating: boolean;
+  permission: string;
+}
+
+/** Small indicator dot for tool status. */
+function StatusDot({ disabled, mutating }: { disabled: boolean; mutating: boolean }) {
+  const color = disabled
+    ? 'bg-gray-400'
+    : mutating
+      ? 'bg-yellow-400'
+      : 'bg-green-500';
+  return <span className={`inline-block w-2 h-2 rounded-full ${color}`} title={disabled ? 'disabled' : mutating ? 'mutating' : 'read-only'} />;
+}
+
+/** Individual tool row with toggle. */
+function ToolRow({
+  tool,
+  onToggle,
+  busy,
+}: {
+  tool: ToolInfo;
+  onToggle: () => void;
+  busy: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="border rounded-lg p-3 space-y-1">
+      <div className="flex items-center gap-2">
+        <StatusDot disabled={tool.disabled} mutating={tool.mutating} />
+        <code className="text-sm font-mono font-semibold flex-1">{tool.name}</code>
+        <Badge variant="outline" className="text-[10px] px-1.5">
+          {tool.permission}
+        </Badge>
+        <Badge variant="outline" className="text-[10px] px-1.5">
+          {tool.mutating ? 'mut' : 'ro'}
+        </Badge>
+        <span className="text-[11px] text-muted-foreground">[{tool.owner}]</span>
+        <Button
+          variant={tool.disabled ? 'default' : 'secondary'}
+          size="sm"
+          className="h-7 px-2 text-xs gap-1"
+          onClick={onToggle}
+          disabled={busy}
+        >
+          {busy ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : tool.disabled ? (
+            <PowerOff className="h-3 w-3" />
+          ) : (
+            <Power className="h-3 w-3" />
+          )}
+          {tool.disabled ? 'Enable' : 'Disable'}
+        </Button>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground p-0.5"
+          onClick={() => setExpanded(!expanded)}
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+        >
+          <Chevron className={expanded ? 'rotate-180' : ''} />
+        </button>
+      </div>
+      {expanded && (
+        <div className="text-xs text-muted-foreground pl-6 pt-1 space-y-0.5">
+          <p>{tool.description}</p>
+          {tool.params.length > 0 && (
+            <p>Params: <code className="font-mono">{tool.params.join(', ')}</code></p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Chevron({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      className={`h-4 w-4 transition-transform ${className}`}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+export function ToolsSection(): ReactElement {
+  const { t } = useAppTranslation();
+  const { client } = useWebSocket();
+  const [tools, setTools] = useState<ToolInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState('');
+  const [busyMap, setBusyMap] = useState<Set<string>>(new Set());
+
+  // Listen for tool list and enable/disable responses
+  useEffect(() => {
+    const handler = (msg: WSServerMessage) => {
+      if (msg.type === 'tools.list') {
+        const p = msg.payload as { tools: ToolInfo[] };
+        setTools(p.tools);
+        setLoading(false);
+      } else if (msg.type === 'tool.disabled' || msg.type === 'tool.enabled') {
+        const p = msg.payload as { name: string; ok: boolean };
+        setBusyMap((prev) => {
+          const next = new Set(prev);
+          next.delete(p.name);
+          return next;
+        });
+        if (p.ok) {
+          client.send({ type: 'tools.list' });
+        } else {
+          toast.error(`Tool "${p.name}" ${msg.type === 'tool.disabled' ? 'disable' : 'enable'} failed.`);
+        }
+      }
+    };
+    client.on('message', handler);
+    return () => client.off('message', handler);
+  }, [client]);
+
+  // Fetch tools on mount
+  useEffect(() => {
+    client.send({ type: 'tools.list' });
+  }, [client]);
+
+  const handleToggle = useCallback(
+    (name: string, currentlyDisabled: boolean) => {
+      setBusyMap((prev) => new Set(prev).add(name));
+      client.send({
+        type: (currentlyDisabled ? 'tool.enable' : 'tool.disable') as WSMessageType,
+        payload: { name },
+      });
+    },
+    [client],
+  );
+
+  // Filter tools client-side
+  const filtered = filter
+    ? tools.filter(
+        (t) =>
+          t.name.toLowerCase().includes(filter.toLowerCase()) ||
+          t.owner.toLowerCase().includes(filter.toLowerCase()),
+      )
+    : tools;
+
+  const activeCount = tools.filter((t) => !t.disabled).length;
+  const disabledCount = tools.filter((t) => t.disabled).length;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Wrench className="h-5 w-5 text-primary" />
+        <h3 className="text-lg font-semibold">Tools</h3>
+        {!loading && (
+          <span className="text-xs text-muted-foreground ml-auto">
+            {activeCount} active · {disabledCount} disabled · {tools.length} total
+          </span>
+        )}
+      </div>
+
+      <div className="relative">
+        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Filter tools by name or owner…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="pl-8 h-9 text-sm"
+        />
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-8 text-muted-foreground gap-2">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading tools…
+        </div>
+      ) : filtered.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          {filter ? `No tools matching "${filter}".` : 'No tools registered.'}
+        </p>
+      ) : (
+        <div className="space-y-2 max-h-[500px] overflow-y-auto pr-1">
+          {filtered.map((tool) => (
+            <ToolRow
+              key={tool.name}
+              tool={tool}
+              onToggle={() => handleToggle(tool.name, tool.disabled)}
+              busy={busyMap.has(tool.name)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type WSMessageType = 'tools.list' | 'tool.enable' | 'tool.disable';

--- a/packages/webui/src/components/SettingsPanel/index.tsx
+++ b/packages/webui/src/components/SettingsPanel/index.tsx
@@ -16,6 +16,7 @@ import {
   Sun,
   X,
   Zap,
+  Wrench,
 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
@@ -40,6 +41,7 @@ import { Input } from '../ui/input';
 import { ScrollArea } from '../ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { MCPSection } from './MCPSection';
+import { ToolsSection } from './ToolsSection';
 import { ModelSection } from './ModelSection';
 import { PreferenceSelect, PreferenceSlider } from './PreferenceControls';
 import { PreferenceToggle } from './PreferenceToggle';
@@ -524,6 +526,10 @@ export function SettingsPanel() {
               <TabsTrigger value="features" className="gap-1 text-xs">
                 <Puzzle className="h-3.5 w-3.5" />
                 {t('settings:tabs.features')}
+              </TabsTrigger>
+              <TabsTrigger value="tools" className="gap-1 text-xs">
+                <Wrench className="h-3.5 w-3.5" />
+                {t('settings:tabs.tools')}
               </TabsTrigger>
               <TabsTrigger value="mcp" className="gap-1 text-xs">
                 <Server className="h-3.5 w-3.5" />
@@ -1365,6 +1371,11 @@ export function SettingsPanel() {
                   onChange={(v) => syncPref('auditLevel', v)}
                 />
               </div>
+            </TabsContent>
+
+            {/* Tools Tab */}
+            <TabsContent value="tools" className="space-y-4">
+              <ToolsSection />
             </TabsContent>
 
             {/* MCP Servers Tab */}

--- a/packages/webui/src/i18n/locales/en/settings.json
+++ b/packages/webui/src/i18n/locales/en/settings.json
@@ -6,6 +6,7 @@
     "appearance": "Look",
     "agent": "Agent",
     "features": "Feat.",
+    "tools": "Tools",
     "mcp": "MCP"
   },
   "appearance": {

--- a/packages/webui/src/server/message-dispatcher.ts
+++ b/packages/webui/src/server/message-dispatcher.ts
@@ -319,17 +319,54 @@ export function createMessageDispatcher(
 
       case 'tools.list': {
         // Full tool registry dump for the /tools inspect view.
-        const list = deps.toolRegistry.list().map((t) => {
+        const list = deps.toolRegistry.listWithOwner().map(({ tool, owner }) => {
           const schema =
-            (t as { inputSchema?: { properties?: Record<string, unknown> } }).inputSchema ?? {};
+            (tool as { inputSchema?: { properties?: Record<string, unknown> } }).inputSchema ?? {};
           const params = schema.properties ? Object.keys(schema.properties) : [];
           return {
-            name: t.name,
-            description: (t as { description?: string | undefined }).description ?? '',
+            name: tool.name,
+            owner,
+            description: (tool as { description?: string | undefined }).description ?? '',
             params,
+            disabled: deps.toolRegistry.isDisabled(tool.name),
+            mutating: tool.mutating,
+            permission: tool.permission,
           };
         });
         send(ws, { type: 'tools.list', payload: { tools: list } });
+        break;
+      }
+      case 'tool.disable': {
+        const name = ((msg as { payload?: { name?: string } }).payload ?? {}).name;
+        if (!name) {
+          send(ws, { type: 'error', payload: { message: 'tool.disable requires a name' } });
+          break;
+        }
+        const ok = deps.toolRegistry.disable(name);
+        // Persist the disabled list to config
+        const currentCfg = deps.configStore.get().tools ?? {};
+        const currentDisabled: string[] = (currentCfg as { disabledTools?: string[] }).disabledTools ?? [];
+        if (ok && !currentDisabled.includes(name)) {
+          deps.configStore.update({ tools: { ...currentCfg, disabledTools: [...currentDisabled, name] } });
+        }
+        send(ws, { type: 'tool.disabled', payload: { name, ok } });
+        break;
+      }
+      case 'tool.enable': {
+        const name = ((msg as { payload?: { name?: string } }).payload ?? {}).name;
+        if (!name) {
+          send(ws, { type: 'error', payload: { message: 'tool.enable requires a name' } });
+          break;
+        }
+        const ok = deps.toolRegistry.enable(name);
+        if (ok) {
+          const currentCfg = deps.configStore.get().tools ?? {};
+          const currentDisabled: string[] = (currentCfg as { disabledTools?: string[] }).disabledTools ?? [];
+          deps.configStore.update({
+            tools: { ...currentCfg, disabledTools: currentDisabled.filter((n: string) => n !== name) },
+          });
+        }
+        send(ws, { type: 'tool.enabled', payload: { name, ok } });
         break;
       }
 

--- a/packages/webui/src/types.ts
+++ b/packages/webui/src/types.ts
@@ -403,7 +403,15 @@ export interface WSContextModeChanged {
 export interface WSToolsList {
   type: 'tools.list';
   payload: {
-    tools: Array<{ name: string; description: string; params: string[] }>;
+    tools: Array<{
+      name: string;
+      owner: string;
+      description: string;
+      params: string[];
+      disabled: boolean;
+      mutating: boolean;
+      permission: string;
+    }>;
   };
 }
 
@@ -1421,6 +1429,10 @@ export type WSClientMessage =
   | { type: 'terminal.input'; payload: { id: string; data: string } }
   | { type: 'terminal.resize'; payload: { id: string; cols: number; rows: number } }
   | { type: 'terminal.close'; payload: { id: string } }
+  // ── Tool management client messages ─────────────────────────────────────────
+  | { type: 'tools.list' }
+  | { type: 'tool.enable'; payload: { name: string } }
+  | { type: 'tool.disable'; payload: { name: string } }
   | { type: `kanban.${string}`; payload?: Record<string, unknown> | undefined }
   // ── Misc client messages ─────────────────────────────────────────────────────
   | { type: 'plan.template_use'; payload: { template: string } }
@@ -1770,6 +1782,8 @@ export type WSServerMessage =
       payload: { taskId: string; subagentId: string; status: string; durationMs: number };
     }
   | { type: 'task.failed'; payload: { taskId: string; subagentId: string; error: string } }
+  | { type: 'tool.disabled'; payload: { name: string; ok: boolean } }
+  | { type: 'tool.enabled'; payload: { name: string; ok: boolean } }
   // ── MCP server events ───────────────────────────────────────────────────────
   | {
       type: 'mcp.list';


### PR DESCRIPTION
TUI (Ink) - 3 new interactive panels following PluginPicker pattern
McpPicker(/mcp) - ToolsPicker(/tools) - BrainPanel(/brain)
WebUI: ToolsSection in SettingsPanel with enable/disable toggles
CLI host wiring for mcp/tools/brain callbacks
Tests: 94 files, 1189 tests pass (+28 new)
