### PR TITLE
feat(telegram): rename status command to telegram-health

### DIFF
--- a/packages/cli/src/slash-commands/telegram-setup.ts
+++ b/packages/cli/src/slash-commands/telegram-setup.ts
@@ -176,7 +176,7 @@ export function buildTelegramSetupCommand(opts: SlashCommandContext): SlashComma
             `${color.amber('⚠')}  Restart WrongStack for the plugin to pick up the new config.`,
             '',
             'After restart, try:',
-            `  ${color.cyan('/telegram:status')}   — check bot connection`,
+            `  ${color.cyan('/telegram')}          — check bot connection`,
             `  ${color.cyan('/telegram:send')}     — send a test message`,
           ].join('\n'),
         };

--- a/packages/telegram/README.md
+++ b/packages/telegram/README.md
@@ -8,7 +8,7 @@ Send messages, receive instructions, get notified when long tasks finish.
 - **`telegram_read`** — Agent reads incoming Telegram messages (newest first, filtered by chat, with ack support)
 - **`telegram_send`** — Agent sends messages via Telegram (HTML formatting, confirm permission)
 - **System prompt injection** — Unread messages appear in the agent's system prompt so it sees them naturally
-- **Slash commands** — `/telegram:status`, `/telegram:send`, `/telegram:chatid` in the TUI
+- **Slash commands** — `/telegram`, `/telegram-health`, `/telegram:send`, `/telegram:chatid` in the TUI
 - **Event notifications** — Session end summaries and long tool completions forwarded to Telegram
 - **Allowlist filtering** — Restrict which users/chats can interact with the bot
 - **Zero dependencies** — Uses Node.js native `fetch`, no third-party Telegram libraries
@@ -135,7 +135,8 @@ Message text supports Telegram HTML: `<b>bold</b>`, `<i>italic</i>`, `<code>mono
 
 | Command | Description |
 |---|---|
-| `/telegram:status` | Bot connection health, polling config, allowlist stats, notification settings |
+| `/telegram` | Plugin-name alias for Telegram bot health. |
+| `/telegram-health` | Explicit Telegram bot health command: connection, polling config, allowlist stats, notification settings. |
 | `/telegram:send [chat_id] <msg>` | Send a message from the terminal |
 | `/telegram:chatid` | Show the configured default chat ID |
 

--- a/packages/telegram/src/slash-commands/index.ts
+++ b/packages/telegram/src/slash-commands/index.ts
@@ -4,18 +4,19 @@ import type { TelegramBot } from '../bot.js';
 import type { TelegramPluginConfig } from '../config.js';
 
 // ---------------------------------------------------------------------------
-// /telegram:status
+// /telegram-health
 // ---------------------------------------------------------------------------
 
-export function tgStatusCommand(bot: TelegramBot, cfg: TelegramPluginConfig): SlashCommand {
+export function tgHealthCommand(bot: TelegramBot, cfg: TelegramPluginConfig): SlashCommand {
   return {
-    name: 'status',
-    aliases: ['tgstat', 'tgs'],
-    description: 'Show Telegram bot connection status and config',
-    help: `Usage: /telegram:status
+    name: 'telegram-health',
+    aliases: ['telegram', 'tgstat', 'tgs'],
+    description: 'Show Telegram bot connection health and config',
+    help: `Usage: /telegram-health
+Aliases: /telegram, /tgstat, /tgs
 
 Shows whether the bot is connected, its username, polling interval,
-allowlist status, and notification settings.`,
+allowlist health, and notification settings.`,
     async run(_args, _ctx) {
       const health = await bot.health();
       const lines = [
@@ -122,7 +123,7 @@ export function registerSlashCommands(
   cfg: TelegramPluginConfig,
 ): string[] {
   const cmds = [
-    tgStatusCommand(bot, cfg),
+    tgHealthCommand(bot, cfg),
     tgSendCommand(bot, cfg.notifyChatId),
     tgChatIdCommand(cfg.notifyChatId),
   ];

--- a/packages/telegram/tests/integration/plugin-entry.test.ts
+++ b/packages/telegram/tests/integration/plugin-entry.test.ts
@@ -65,16 +65,26 @@ function makeApi(): PluginAPI {
     },
     slashCommands: {
       register(cmd: SlashCommand) {
+        commands.set(cmd.name, cmd);
         commands.set(`${PLUGIN_NAME}:${cmd.name}`, cmd);
+        for (const alias of cmd.aliases ?? []) {
+          commands.set(alias, cmd);
+          commands.set(`${PLUGIN_NAME}:${alias}`, cmd);
+        }
       },
       unregister(name: string) {
-        commands.delete(name);
+        const cmd = commands.get(name);
+        if (!cmd) return false;
+        for (const [key, value] of commands.entries()) {
+          if (value === cmd) commands.delete(key);
+        }
+        return true;
       },
       get(name: string) {
         return commands.get(name);
       },
       list() {
-        return Array.from(commands.values());
+        return Array.from(new Set(commands.values()));
       },
     },
     session: {
@@ -152,7 +162,13 @@ describe('plugin entry', () => {
 
     expect(api.tools.get('telegram_send')).toBeDefined();
     expect(api.tools.get('telegram_read')).toBeDefined();
-    expect(api.slashCommands.get(`${PLUGIN_NAME}:status`)).toBeDefined();
+    expect(api.slashCommands.get('telegram-health')).toBeDefined();
+    expect(api.slashCommands.get('telegram')).toBeDefined();
+    expect(api.slashCommands.get('health')).toBeUndefined();
+    expect(api.slashCommands.get('status')).toBeUndefined();
+    expect(api.slashCommands.get(`${PLUGIN_NAME}:telegram-health`)).toBeDefined();
+    expect(api.slashCommands.get(`${PLUGIN_NAME}:telegram`)).toBeDefined();
+    expect(api.slashCommands.get(`${PLUGIN_NAME}:status`)).toBeUndefined();
     expect(api.slashCommands.get(`${PLUGIN_NAME}:send`)).toBeDefined();
     expect(api.slashCommands.get(`${PLUGIN_NAME}:chatid`)).toBeDefined();
 
@@ -163,7 +179,9 @@ describe('plugin entry', () => {
 
     expect(api.tools.get('telegram_send')).toBeUndefined();
     expect(api.tools.get('telegram_read')).toBeUndefined();
-    expect(api.slashCommands.get(`${PLUGIN_NAME}:status`)).toBeUndefined();
+    expect(api.slashCommands.get('telegram-health')).toBeUndefined();
+    expect(api.slashCommands.get('telegram')).toBeUndefined();
+    expect(api.slashCommands.get(`${PLUGIN_NAME}:telegram-health`)).toBeUndefined();
   });
 
   it('emits telegram:message_received when bot receives a message', async () => {

--- a/packages/telegram/tests/unit/slash-commands.test.ts
+++ b/packages/telegram/tests/unit/slash-commands.test.ts
@@ -5,7 +5,7 @@ import type { TelegramPluginConfig } from '../../src/config.js';
 import {
   tgChatIdCommand,
   tgSendCommand,
-  tgStatusCommand,
+  tgHealthCommand,
 } from '../../src/slash-commands/index.js';
 
 const log: Logger = {
@@ -47,10 +47,19 @@ function makeConfig(overrides?: Partial<TelegramPluginConfig>): TelegramPluginCo
 }
 
 // ---------------------------------------------------------------------------
-// /telegram:status
+// /telegram-health
 // ---------------------------------------------------------------------------
 
-describe('tgStatusCommand', () => {
+describe('tgHealthCommand', () => {
+  it('uses Telegram-specific slash names and plugin-name alias', () => {
+    const cmd = tgHealthCommand(makeBot(), makeConfig());
+
+    expect(cmd.name).toBe('telegram-health');
+    expect(cmd.aliases).toEqual(expect.arrayContaining(['telegram', 'tgstat', 'tgs']));
+    expect(cmd.help).toContain('/telegram-health');
+    expect(cmd.help).toContain('/telegram');
+  });
+
   // A single bot instance shared across tests so `bot.start()` (which
   // schedules a 60 s polling timer) is paired with `bot.stop()` in
   // afterEach — otherwise the timer keeps the test worker alive after
@@ -68,7 +77,7 @@ describe('tgStatusCommand', () => {
     // Mock health to return a healthy bot
     bot.health = vi.fn().mockResolvedValue({ ok: true, username: 'test_bot' });
 
-    const cmd = tgStatusCommand(bot, makeConfig());
+    const cmd = tgHealthCommand(bot, makeConfig());
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('✅ @test_bot');
@@ -84,7 +93,7 @@ describe('tgStatusCommand', () => {
     const bot = makeBot();
     bot.health = vi.fn().mockResolvedValue({ ok: false, error: 'Network error' });
 
-    const cmd = tgStatusCommand(bot, makeConfig());
+    const cmd = tgHealthCommand(bot, makeConfig());
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('❌ Network error');
@@ -95,7 +104,7 @@ describe('tgStatusCommand', () => {
     const bot = makeBot();
     bot.health = vi.fn().mockResolvedValue({ ok: false });
 
-    const cmd = tgStatusCommand(bot, makeConfig());
+    const cmd = tgHealthCommand(bot, makeConfig());
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('❌ offline');
@@ -105,7 +114,7 @@ describe('tgStatusCommand', () => {
     const bot = makeBot();
     bot.health = vi.fn().mockResolvedValue({ ok: true, username: 'b' });
 
-    const cmd = tgStatusCommand(bot, makeConfig());
+    const cmd = tgHealthCommand(bot, makeConfig());
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('Started:   N/A');
@@ -116,7 +125,7 @@ describe('tgStatusCommand', () => {
     bot.health = vi.fn().mockResolvedValue({ ok: true, username: 'b' });
 
     const cfg = makeConfig({ allowedUsers: [], allowedChats: [] });
-    const cmd = tgStatusCommand(bot, cfg);
+    const cmd = tgHealthCommand(bot, cfg);
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('everyone (users)');
@@ -128,7 +137,7 @@ describe('tgStatusCommand', () => {
     bot.health = vi.fn().mockResolvedValue({ ok: true, username: 'b' });
 
     const cfg = makeConfig({ notifyOnSessionEnd: false, longToolThresholdMs: 0 });
-    const cmd = tgStatusCommand(bot, cfg);
+    const cmd = tgHealthCommand(bot, cfg);
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('sessionEnd=false');
@@ -140,7 +149,7 @@ describe('tgStatusCommand', () => {
     bot.health = vi.fn().mockResolvedValue({ ok: true, username: 'b' });
 
     const cfg = makeConfig({ notifyOnSessionEnd: undefined, longToolThresholdMs: 0 });
-    const cmd = tgStatusCommand(bot, cfg);
+    const cmd = tgHealthCommand(bot, cfg);
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('sessionEnd=false');
@@ -150,7 +159,7 @@ describe('tgStatusCommand', () => {
     const bot = makeBot();
     bot.health = vi.fn().mockResolvedValue({ ok: true });
 
-    const cmd = tgStatusCommand(bot, makeConfig());
+    const cmd = tgHealthCommand(bot, makeConfig());
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('✅ @connected');
@@ -161,7 +170,7 @@ describe('tgStatusCommand', () => {
     bot.health = vi.fn().mockResolvedValue({ ok: true, username: 'b' });
 
     const cfg = makeConfig({ pollIntervalSec: undefined as never as number });
-    const cmd = tgStatusCommand(bot, cfg);
+    const cmd = tgHealthCommand(bot, cfg);
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('every 2s');
@@ -172,7 +181,7 @@ describe('tgStatusCommand', () => {
     bot.health = vi.fn().mockResolvedValue({ ok: true, username: 'b' });
 
     const cfg = makeConfig({ allowedUsers: undefined, allowedChats: undefined });
-    const cmd = tgStatusCommand(bot, cfg);
+    const cmd = tgHealthCommand(bot, cfg);
     const res = await cmd.run('', null as never);
 
     expect(res?.message).toContain('everyone (users)');


### PR DESCRIPTION
## Summary

Renames the Telegram plugin's slash command from `status` to `telegram-health`
to avoid claiming the generic `/status` bare name. The `SlashCommandRegistry`
allows official plugins to claim bare slash names, so the old `/telegram:status`
was also reachable as `/status` — a name another feature may want.

## Changes

- Command name: `status` -> `telegram-health` (self-describing, plugin-scoped)
- Added `telegram` as an alias so `/telegram` shows bot health
- Kept `tgstat` and `tgs` aliases for backward compatibility
- Factory renamed: `tgStatusCommand` -> `tgHealthCommand`
- Setup guidance in `telegram-setup.ts` now suggests `/telegram`
- Updated README slash command table
- Unit and integration tests updated; added assertions that `/status` and
  `/health` are NOT registered by Telegram

## Verification

Pre-commit hook passed: dist refreshed for cli+telegram, full monorepo
typecheck passed (17 packages).