### PR TITLE
fix(webui): lock accent-colors contract with focused tests

### DIFF
--- a/packages/webui/src/lib/accent-colors.ts
+++ b/packages/webui/src/lib/accent-colors.ts
@@ -1,0 +1,167 @@
+export type AccentThemeMode = 'light' | 'dark';
+
+export type AccentTokens = {
+  primary: string;
+  primaryForeground: string;
+  accent: string;
+  accentForeground: string;
+  ring: string;
+  running: string;
+};
+
+export type AccentPalette = {
+  id: string;
+  labelKey: string;
+  light: AccentTokens;
+  dark: AccentTokens;
+};
+
+export const DEFAULT_ACCENT_COLOR = 'cyan';
+
+export const ACCENT_PALETTES = [
+  {
+    id: 'cyan',
+    labelKey: 'settings:appearance.accentCyan',
+    light: {
+      primary: '194 84% 38%',
+      primaryForeground: '0 0% 100%',
+      accent: '166 36% 90%',
+      accentForeground: '180 64% 24%',
+      ring: '194 84% 38%',
+      running: '194 84% 38%',
+    },
+    dark: {
+      primary: '190 86% 54%',
+      primaryForeground: '240 7% 7%',
+      accent: '164 36% 18%',
+      accentForeground: '164 72% 66%',
+      ring: '190 86% 54%',
+      running: '190 86% 54%',
+    },
+  },
+  {
+    id: 'blue',
+    labelKey: 'settings:appearance.accentBlue',
+    light: {
+      primary: '217 88% 48%',
+      primaryForeground: '0 0% 100%',
+      accent: '214 76% 93%',
+      accentForeground: '217 72% 30%',
+      ring: '217 88% 48%',
+      running: '217 88% 48%',
+    },
+    dark: {
+      primary: '213 94% 68%',
+      primaryForeground: '222 47% 11%',
+      accent: '218 42% 20%',
+      accentForeground: '213 94% 78%',
+      ring: '213 94% 68%',
+      running: '213 94% 68%',
+    },
+  },
+  {
+    id: 'emerald',
+    labelKey: 'settings:appearance.accentEmerald',
+    light: {
+      primary: '151 68% 36%',
+      primaryForeground: '0 0% 100%',
+      accent: '150 45% 90%',
+      accentForeground: '152 70% 24%',
+      ring: '151 68% 36%',
+      running: '151 68% 36%',
+    },
+    dark: {
+      primary: '151 68% 52%',
+      primaryForeground: '156 38% 8%',
+      accent: '153 40% 17%',
+      accentForeground: '151 70% 68%',
+      ring: '151 68% 52%',
+      running: '151 68% 52%',
+    },
+  },
+  {
+    id: 'violet',
+    labelKey: 'settings:appearance.accentViolet',
+    light: {
+      primary: '262 72% 52%',
+      primaryForeground: '0 0% 100%',
+      accent: '262 70% 94%',
+      accentForeground: '263 70% 38%',
+      ring: '262 72% 52%',
+      running: '262 72% 52%',
+    },
+    dark: {
+      primary: '263 85% 72%',
+      primaryForeground: '260 25% 8%',
+      accent: '263 40% 22%',
+      accentForeground: '263 88% 80%',
+      ring: '263 85% 72%',
+      running: '263 85% 72%',
+    },
+  },
+  {
+    id: 'rose',
+    labelKey: 'settings:appearance.accentRose',
+    light: {
+      primary: '344 72% 48%',
+      primaryForeground: '0 0% 100%',
+      accent: '345 78% 94%',
+      accentForeground: '344 70% 34%',
+      ring: '344 72% 48%',
+      running: '344 72% 48%',
+    },
+    dark: {
+      primary: '343 85% 68%',
+      primaryForeground: '340 25% 8%',
+      accent: '343 44% 20%',
+      accentForeground: '343 88% 78%',
+      ring: '343 85% 68%',
+      running: '343 85% 68%',
+    },
+  },
+  {
+    id: 'amber',
+    labelKey: 'settings:appearance.accentAmber',
+    light: {
+      primary: '35 92% 44%',
+      primaryForeground: '36 45% 10%',
+      accent: '38 86% 91%',
+      accentForeground: '32 86% 28%',
+      ring: '35 92% 44%',
+      running: '35 92% 44%',
+    },
+    dark: {
+      primary: '38 94% 62%',
+      primaryForeground: '36 50% 9%',
+      accent: '36 42% 20%',
+      accentForeground: '38 94% 74%',
+      ring: '38 94% 62%',
+      running: '38 94% 62%',
+    },
+  },
+] as const satisfies readonly AccentPalette[];
+
+export type AccentColor = (typeof ACCENT_PALETTES)[number]['id'];
+
+export function isAccentColor(value: unknown): value is AccentColor {
+  return typeof value === 'string' && ACCENT_PALETTES.some((palette) => palette.id === value);
+}
+
+export function getAccentPalette(value: unknown): (typeof ACCENT_PALETTES)[number] {
+  return ACCENT_PALETTES.find((palette) => palette.id === value) ?? ACCENT_PALETTES[0];
+}
+
+export function applyAccentPalette(
+  root: HTMLElement,
+  accentColor: AccentColor,
+  mode: AccentThemeMode,
+): void {
+  const palette = getAccentPalette(accentColor);
+  const tokens = palette[mode];
+  root.style.setProperty('--primary', tokens.primary);
+  root.style.setProperty('--primary-foreground', tokens.primaryForeground);
+  root.style.setProperty('--accent', tokens.accent);
+  root.style.setProperty('--accent-foreground', tokens.accentForeground);
+  root.style.setProperty('--ring', tokens.ring);
+  root.style.setProperty('--running', tokens.running);
+}

--- a/packages/webui/tests/lib/accent-colors.test.ts
+++ b/packages/webui/tests/lib/accent-colors.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ACCENT_PALETTES,
+  DEFAULT_ACCENT_COLOR,
+  applyAccentPalette,
+  getAccentPalette,
+  isAccentColor,
+} from '@/lib/accent-colors';
+
+describe('accent-colors', () => {
+  const REQUIRED_TOKEN_KEYS = [
+    'primary',
+    'primaryForeground',
+    'accent',
+    'accentForeground',
+    'ring',
+    'running',
+  ] as const;
+
+  afterEach(() => {
+    // Reset CSS variables on the test root after each call.
+    document.documentElement.removeAttribute('style');
+  });
+
+  describe('ACCENT_PALETTES contract', () => {
+    it('exports a non-empty list of palettes', () => {
+      expect(ACCENT_PALETTES.length).toBeGreaterThan(0);
+    });
+
+    it('every palette has unique id, labelKey, and full light/dark token sets', () => {
+      const ids = new Set<string>();
+      const labelKeys = new Set<string>();
+      for (const palette of ACCENT_PALETTES) {
+        expect(ids.has(palette.id)).toBe(false);
+        expect(labelKeys.has(palette.labelKey)).toBe(false);
+        ids.add(palette.id);
+        labelKeys.add(palette.labelKey);
+
+        for (const mode of ['light', 'dark'] as const) {
+          for (const key of REQUIRED_TOKEN_KEYS) {
+            const tokens = palette[mode] as Record<string, string>;
+            expect(typeof tokens[key]).toBe('string');
+            expect(tokens[key].length).toBeGreaterThan(0);
+          }
+        }
+      }
+    });
+
+    it('DEFAULT_ACCENT_COLOR points to a real palette', () => {
+      expect(isAccentColor(DEFAULT_ACCENT_COLOR)).toBe(true);
+      expect(getAccentPalette(DEFAULT_ACCENT_COLOR).id).toBe(DEFAULT_ACCENT_COLOR);
+    });
+  });
+
+  describe('isAccentColor', () => {
+    it('accepts known palette ids', () => {
+      for (const palette of ACCENT_PALETTES) {
+        expect(isAccentColor(palette.id)).toBe(true);
+      }
+    });
+
+    it('rejects unknown values', () => {
+      expect(isAccentColor('not-a-real-color')).toBe(false);
+      expect(isAccentColor(null)).toBe(false);
+      expect(isAccentColor(undefined)).toBe(false);
+      expect(isAccentColor(123)).toBe(false);
+      expect(isAccentColor('')).toBe(false);
+    });
+  });
+
+  describe('getAccentPalette', () => {
+    it('returns the matching palette for a known id', () => {
+      const first = ACCENT_PALETTES[0];
+      expect(getAccentPalette(first.id).id).toBe(first.id);
+    });
+
+    it('falls back to the first palette for unknown values', () => {
+      expect(getAccentPalette('nope').id).toBe(ACCENT_PALETTES[0].id);
+      expect(getAccentPalette(null).id).toBe(ACCENT_PALETTES[0].id);
+      expect(getAccentPalette(undefined).id).toBe(ACCENT_PALETTES[0].id);
+    });
+  });
+
+  describe('applyAccentPalette', () => {
+    function readVars(root: HTMLElement): Record<string, string> {
+      const style = root.getAttribute('style') ?? '';
+      const map: Record<string, string> = {};
+      for (const decl of style.split(';')) {
+        const trimmed = decl.trim();
+        if (!trimmed) continue;
+        const sep = trimmed.indexOf(':');
+        if (sep <= 0) continue;
+        const name = trimmed.slice(0, sep).trim();
+        const value = trimmed.slice(sep + 1).trim();
+        map[name] = value;
+      }
+      return map;
+    }
+
+    it('sets all six CSS custom properties on the root for light mode', () => {
+      const root = document.documentElement;
+      const palette = ACCENT_PALETTES[0];
+      applyAccentPalette(root, palette.id, 'light');
+
+      const vars = readVars(root);
+      for (const key of REQUIRED_TOKEN_KEYS) {
+        const cssVar = key === 'primaryForeground' ? '--primary-foreground' : `--${key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`)}`;
+        const expected = palette.light[key as keyof typeof palette.light];
+        expect(vars[cssVar]).toBe(expected);
+      }
+    });
+
+    it('sets all six CSS custom properties on the root for dark mode', () => {
+      const root = document.documentElement;
+      const palette = ACCENT_PALETTES[0];
+      applyAccentPalette(root, palette.id, 'dark');
+
+      const vars = readVars(root);
+      const expected = palette.dark;
+      expect(vars['--primary']).toBe(expected.primary);
+      expect(vars['--primary-foreground']).toBe(expected.primaryForeground);
+      expect(vars['--accent']).toBe(expected.accent);
+      expect(vars['--accent-foreground']).toBe(expected.accentForeground);
+      expect(vars['--ring']).toBe(expected.ring);
+      expect(vars['--running']).toBe(expected.running);
+    });
+
+    it('overwrites previous palette values when called twice', () => {
+      const root = document.documentElement;
+      const first = ACCENT_PALETTES[0];
+      const second = ACCENT_PALETTES[ACCENT_PALETTES.length - 1];
+
+      applyAccentPalette(root, first.id, 'light');
+      applyAccentPalette(root, second.id, 'light');
+
+      const vars = readVars(root);
+      const expected = second.light;
+      expect(vars['--primary']).toBe(expected.primary);
+      expect(vars['--running']).toBe(expected.running);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `packages/webui/src/lib/accent-colors.ts` module landed in the
WebUI refresh (PR #225) but had no test coverage. This change keeps
the module in place and adds a focused 10-test suite that locks down
its public contract.

## What's tested

- `ACCENT_PALETTES` contract: non-empty, unique ids, unique labelKeys,
  every palette has all six required tokens for both light and dark modes
- `DEFAULT_ACCENT_COLOR` points to a real palette
- `isAccentColor`: accepts known ids, rejects `null` / `undefined` /
  numbers / empty string
- `getAccentPalette`: returns matching palette for known ids, falls
  back to the first palette for unknown / null / undefined inputs
- `applyAccentPalette`: writes all six CSS custom properties to the
  document root for both light and dark modes, correctly overwrites
  a previous palette when called twice

## Why

The module exports a clean palette/apply surface but had no consumer
in the WebUI tree at the time of merge. Future work that wires it into
a settings panel or theme switcher can rely on this suite to catch
silent contract drift.