### PR TITLE
fix(lint): clear the two biome error-level violations blocking CI

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -31,7 +31,7 @@ import {
   loadGoal,
   materializeTokens,
   normalizedEqual,
-  PromptUsageStore,
+  type PromptUsageStore,
   projectSlug,
   recentTextTurns,
   recordOverrides,

--- a/packages/webui/src/server/setup-screen.ts
+++ b/packages/webui/src/server/setup-screen.ts
@@ -43,6 +43,7 @@ function makeUnconfiguredProvider(): Provider {
   return {
     id: 'unconfigured',
     capabilities: UNCONFIGURED_CAPABILITIES,
+    // biome-ignore lint/correctness/useYield: Provider.stream must be an async generator; this unconfigured stub always throws before it can yield.
     async *stream() {
       throw new Error(message);
     },


### PR DESCRIPTION
## What & why

CI's `biome lint .` step is failing on `main` with **2 error-level violations**, which blocks **every** open PR (it's a repo-wide gate, unrelated to any single PR's changes). This clears both so CI goes green again.

## The 2 errors

1. **`packages/tui/src/app.tsx:31`** — `lint/style/useImportType`: `PromptUsageStore` was imported as a value but used only as a type. Fixed by marking it `type PromptUsageStore` (biome safe autofix, 1 line).
2. **`packages/webui/src/server/setup-screen.ts:46`** — `lint/correctness/useYield`: the `unconfigured` Provider's `async *stream()` stub never yields (it always throws before setup is complete). The `Provider` interface requires `stream()` to be an async generator (consumed via `[Symbol.asyncIterator]()`), so the generator form is intentional. Suppressed with a targeted `// biome-ignore lint/correctness/useYield` + rationale.

## Not touched

The 70 remaining biome **warnings** (e.g. `Math.pow` → `**`, unused test imports in `apps/desktop`) are warning-severity and do **not** fail CI — left as-is to keep this PR minimal and focused on unblocking the gate.

## Verification

- `pnpm lint` (i.e. `biome lint .`) now exits **0** (was exit 1: "2 errors").
- `@wrongstack/tui` and `@wrongstack/webui` typecheck clean.
- Both changes are behavior-neutral (a type qualifier and a lint-suppression comment).

2 files changed, +2/−1.
