### PR TITLE
feat(cli): adapt picker box width to the terminal instead of a fixed 74

### DIFF
--- a/packages/cli/src/picker.ts
+++ b/packages/cli/src/picker.ts
@@ -38,8 +38,41 @@ const BOX = {
   v: '│',
 } as const;
 
-/** Inner content width of the picker box, in columns. */
-const PICKER_WIDTH = 74;
+/**
+ * Inner content width of the picker box, in columns. Fixed default used when
+ * the terminal width is unknown (non-TTY: CI, piped stdin, tests) so those
+ * render paths stay deterministic. Also the lower clamp bound — the box never
+ * shrinks below this even in a very narrow terminal, since the model columns
+ * (id 34 + ctx 6 + cost 12 + caps) need the room.
+ */
+const PICKER_MIN_WIDTH = 74;
+
+/**
+ * Upper clamp bound. On very wide terminals the box stops growing here so the
+ * content (left-aligned columns) doesn't stretch into an unreadable full-screen
+ * band; the extra terminal space is left as margin on the right.
+ */
+const PICKER_MAX_WIDTH = 100;
+
+/**
+ * Resolve the box's inner content width from the live terminal. Adapts to
+ * `process.stdout.columns` when it's a TTY with a known width, clamped to
+ * [PICKER_MIN_WIDTH, PICKER_MAX_WIDTH] and inset by 2 columns so the box (which
+ * renders 2 columns wider than its inner width: the left+right borders) fits
+ * without wrapping. Falls back to PICKER_MIN_WIDTH when columns is undefined —
+ * this keeps non-TTY output (CI, pipes, tests) at a stable, deterministic
+ * width. Called by every box helper; within one synchronous render pass the
+ * terminal width is stable, so all borders line up.
+ */
+function pickerWidth(): number {
+  const cols = process.stdout.columns;
+  if (typeof cols !== 'number' || !Number.isFinite(cols) || cols <= 0) {
+    return PICKER_MIN_WIDTH;
+  }
+  // Reserve 2 columns for the box's own border characters.
+  const inner = cols - 2;
+  return Math.max(PICKER_MIN_WIDTH, Math.min(PICKER_MAX_WIDTH, inner));
+}
 
 /** Visible width of a string, ignoring ANSI color escapes. */
 function visibleWidth(s: string): number {
@@ -64,8 +97,9 @@ function padVisible(s: string, width: number): string {
 
 /** Top border with an embedded, accented title: `╭─ Title ───────╮`. */
 function boxTop(title: string): string {
+  const width = pickerWidth();
   const label = ` ${title} `;
-  const pad = Math.max(0, PICKER_WIDTH - visibleWidth(label) - 1);
+  const pad = Math.max(0, width - visibleWidth(label) - 1);
   return theme.chrome(
     `${BOX.tl}${BOX.h}${theme.accent(color.bold(label))}${theme.chrome(BOX.h.repeat(pad))}${BOX.tr}`,
   );
@@ -73,17 +107,17 @@ function boxTop(title: string): string {
 
 /** Bottom border. */
 function boxBottom(): string {
-  return theme.chrome(`${BOX.bl}${BOX.h.repeat(PICKER_WIDTH)}${BOX.br}`);
+  return theme.chrome(`${BOX.bl}${BOX.h.repeat(pickerWidth())}${BOX.br}`);
 }
 
 /** A content row wrapped in the box's vertical borders, padded to width. */
 function boxRow(content: string): string {
-  return `${theme.chrome(BOX.v)} ${padVisible(content, PICKER_WIDTH - 2)} ${theme.chrome(BOX.v)}`;
+  return `${theme.chrome(BOX.v)} ${padVisible(content, pickerWidth() - 2)} ${theme.chrome(BOX.v)}`;
 }
 
 /** A full-width dim separator row inside the box. */
 function boxDivider(): string {
-  return theme.chrome(`${BOX.v}${BOX.h.repeat(PICKER_WIDTH)}${BOX.v}`);
+  return theme.chrome(`${BOX.v}${BOX.h.repeat(pickerWidth())}${BOX.v}`);
 }
 
 /**


### PR DESCRIPTION
## What & why

Follow-up to the picker revamp (#227/#228). The picker box was hardcoded to a fixed 74-column inner width, so on wide terminals it left a lot of dead space and on narrow ones it could overflow. This makes the box **adapt to the terminal width**.

Single-file change: **`packages/cli/src/picker.ts`**.

## How

- Replaced `const PICKER_WIDTH = 74` with a `pickerWidth()` helper that reads `process.stdout.columns`, insets 2 columns for the box borders, and **clamps to `[74, 100]`**:
  - `PICKER_MIN_WIDTH = 74` — floor (the model columns id 34 / ctx 6 / cost 12 / caps need the room) **and** the deterministic fallback when `columns` is `undefined`.
  - `PICKER_MAX_WIDTH = 100` — ceiling, so ultra-wide terminals don't stretch the left-aligned content into an unreadable full-screen band.
- All four box helpers (`boxTop`/`boxRow`/`boxDivider`/`boxBottom`) call `pickerWidth()`. Within one synchronous render pass the terminal width is stable, so every border lines up.
- The live-picker cursor math (`cursorToQuery`) is unaffected — it already measures the visible query-line prefix via `stripAnsi` rather than assuming a fixed column.

## Determinism (why tests stay green)

`process.stdout.columns` is `undefined` under non-TTY (CI, piped stdin, vitest), so `pickerWidth()` returns the fixed `PICKER_MIN_WIDTH` there — the exact same 74/76 width as before. No test asserts on width, and all 187 picker/visibility tests still pass unchanged.

## Verification

Confirmed adaptive + aligned at several widths (throwaway preview):

| `columns` | box total width |
|-----------|-----------------|
| `undefined` (non-TTY) | 76 (fallback) |
| 60 (narrow)  | 76 (clamped up) |
| 90 (medium)  | 90 |
| 200 (wide)   | 102 (clamped down) |

Every line within each box is width-consistent (borders align).

- `picker.test.ts` 68/68 + `picker-visibility.test.ts` pass (187 total).
- Biome clean; `@wrongstack/cli` typecheck passes.

1 file changed, +40/−6. No files other than `picker.ts` touched.
