### PR TITLE
feat(hq): add btw/queue send types and direct mailbox-send route

### DIFF
--- a/packages/cli/src/hq-command-controller.ts
+++ b/packages/cli/src/hq-command-controller.ts
@@ -86,6 +86,42 @@ async function dispatch(
       return { commandId, status: 'accepted', message: `steered ${to}` };
     }
 
+    case 'btw': {
+      // Non-urgent FYI. Same targeting as steer, but delivered as a `btw`
+      // mailbox message so the receiving agent absorbs it as context instead
+      // of treating it as a course-correction. Lands in the mailbox file
+      // regardless of whether a loop is currently running.
+      const mailbox = controller.steerMailbox;
+      if (mailbox === undefined) {
+        return { commandId, status: 'rejected', message: 'no mailbox available' };
+      }
+      const to = typeof payload['to'] === 'string' ? payload['to'] : 'leader';
+      const subject = typeof payload['subject'] === 'string' ? payload['subject'] : 'HQ note';
+      const body = typeof payload['body'] === 'string' ? payload['body'] : '';
+      const priority = payload['priority'] === 'high' ? 'high' : payload['priority'] === 'low' ? 'low' : 'normal';
+      const from = `hq@${controller.sessionTag()}`;
+      await mailbox.send({ from, to, type: 'btw', subject, body, priority });
+      return { commandId, status: 'accepted', message: `noted ${to}` };
+    }
+
+    case 'queue': {
+      // Queue a prompt/note for the target. Delivered as a plain `note` the
+      // agent picks up before its next step — used when the prompt should
+      // wait its turn rather than steer the current operation. Like steer/btw,
+      // this only writes to the mailbox; no live loop is required.
+      const mailbox = controller.steerMailbox;
+      if (mailbox === undefined) {
+        return { commandId, status: 'rejected', message: 'no mailbox available' };
+      }
+      const to = typeof payload['to'] === 'string' ? payload['to'] : 'leader';
+      const subject = typeof payload['subject'] === 'string' ? payload['subject'] : 'HQ prompt';
+      const body = typeof payload['body'] === 'string' ? payload['body'] : '';
+      const priority = payload['priority'] === 'high' ? 'high' : payload['priority'] === 'low' ? 'low' : 'normal';
+      const from = `hq@${controller.sessionTag()}`;
+      await mailbox.send({ from, to, type: 'note', subject, body, priority });
+      return { commandId, status: 'accepted', message: `queued for ${to}` };
+    }
+
     case 'broadcast': {
       const mailbox = controller.steerMailbox;
       if (mailbox === undefined) {

--- a/packages/cli/src/hq-server.ts
+++ b/packages/cli/src/hq-server.ts
@@ -550,6 +550,9 @@ function startHqServerWithAuth(
     // the broadcaster checkpoints into the snapshot store on each serialize.
     const persistence = createHqPersistence(dataDir);
     const auditLog = new HqCommandAuditLog();
+    // Stable mailbox identity for direct HQ writes (/api/mailbox-send). Lets
+    // recipients attribute a zero-client HQ prompt to this server instance.
+    const hqSessionTag = randomUUID().slice(0, 8);
     // ── Alerting (Phase 6) — evaluates the live snapshot against rules and
     // broadcasts `hq.alert` to browsers when a threshold is crossed.
     const alertEngine = new HqAlertEngine({
@@ -800,6 +803,140 @@ function startHqServerWithAuth(
 
         res.writeHead(202, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ commandId, queued: true, clientId: target.clientId }));
+        return;
+      }
+
+      // ── Direct mailbox write (Phase 4 — zero-client delivery) ────────────
+      // POST /api/mailbox-send — write an HQ prompt straight into a project's
+      // GlobalMailbox, bypassing the connected-client control plane. This is
+      // the "send even when no active agent" path: the message lands in the
+      // project mailbox file so the next agent to run (or any terminal/webui)
+      // picks it up. The target project is identified by `sessionId` (or
+      // `projectId`) and resolved to a `projectRoot` SERVER-SIDE via the
+      // SessionRegistry — the browser never supplies a raw filesystem path,
+      // so this cannot be abused to write outside known projects.
+      if (url.pathname === '/api/mailbox-send' && req.method === 'POST') {
+        // Auth mirrors /api/command: browser token + control.enqueue.
+        const suppliedToken = extractBrowserToken(req, url);
+        const inBrowserTokenMode = mutableAuth.browserTokens.size > 0;
+        if (inBrowserTokenMode && (!suppliedToken || !mutableAuth.browserTokens.has(suppliedToken))) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'unauthorized' }));
+          return;
+        }
+        const tokenObj = suppliedToken !== undefined ? mutableAuth.browserTokenObjs.get(suppliedToken) : undefined;
+        const canEnqueue =
+          !inBrowserTokenMode ||
+          tokenObj?.capabilities === undefined ||
+          tokenObj.capabilities.includes('control.enqueue');
+        if (!canEnqueue) {
+          res.writeHead(403, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'forbidden: token lacks control.enqueue capability' }));
+          return;
+        }
+
+        let mbody: {
+          sessionId?: string;
+          projectId?: string;
+          type?: string;
+          to?: string;
+          subject?: string;
+          body?: string;
+          priority?: string;
+        };
+        try {
+          mbody = JSON.parse(await readRequestBody(req));
+        } catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid json body' }));
+          return;
+        }
+        if (typeof mbody.type !== 'string' || typeof mbody.body !== 'string') {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'missing type or body' }));
+          return;
+        }
+        if (typeof mbody.sessionId !== 'string' && typeof mbody.projectId !== 'string') {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'missing sessionId or projectId' }));
+          return;
+        }
+
+        // Resolve projectRoot from the SessionRegistry — authoritative, so we
+        // never trust a browser-supplied path. Prefer sessionId; fall back to
+        // the newest live session in the given projectId.
+        const { SessionRegistry } = await import('@wrongstack/core');
+        // Derive the global root from THIS server's dataDir (honors
+        // --data-dir / WRONGSTACK_HQ_DATA_DIR), not the default resolver, so
+        // the mailbox and registry line up with the running instance.
+        const mbGlobalRoot = path.dirname(dataDir);
+        let projectRoot: string | undefined;
+        try {
+          const registry = new SessionRegistry(mbGlobalRoot);
+          if (typeof mbody.sessionId === 'string') {
+            const entry = await registry.get(mbody.sessionId).catch(() => null);
+            projectRoot = entry?.projectRoot;
+          }
+          if (projectRoot === undefined && typeof mbody.projectId === 'string') {
+            const all = await registry.list().catch(() => []);
+            // HQ `projectId` maps to the registry `projectSlug`.
+            const match = all.find((e) => e.projectSlug === mbody.projectId);
+            projectRoot = match?.projectRoot;
+          }
+        } catch {
+          projectRoot = undefined;
+        }
+        if (typeof projectRoot !== 'string' || projectRoot.length === 0) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'could not resolve target project mailbox' }));
+          return;
+        }
+
+        // Validate the mailbox message shape by reusing the command guard.
+        const to = typeof mbody.to === 'string' ? mbody.to : 'leader';
+        const subject = typeof mbody.subject === 'string' ? mbody.subject : 'HQ prompt';
+        const priority = mbody.priority === 'high' ? 'high' : mbody.priority === 'low' ? 'low' : 'normal';
+        const validated = validateHqCommand({
+          commandId: randomUUID(),
+          type: mbody.type,
+          createdAt: new Date().toISOString(),
+          payload: { to, subject, body: mbody.body, priority },
+          requiresAck: false,
+        });
+        // Only the mailbox-writing command types are valid here.
+        const mailboxType =
+          validated?.type === 'steer' || validated?.type === 'btw'
+            ? validated.type
+            : validated?.type === 'queue'
+              ? 'note'
+              : validated?.type === 'broadcast'
+                ? 'broadcast'
+                : undefined;
+        if (mailboxType === undefined) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'unrecognized or malformed mailbox message', type: mbody.type }));
+          return;
+        }
+
+        try {
+          const { GlobalMailbox, resolveProjectDir } = await import('@wrongstack/core');
+          const projectDir = resolveProjectDir(projectRoot, mbGlobalRoot);
+          const mailbox = new GlobalMailbox(projectDir);
+          const from = `hq@${hqSessionTag}`;
+          const sent = await mailbox.send({
+            from,
+            to: mailboxType === 'broadcast' ? 'all' : to,
+            type: mailboxType,
+            subject,
+            body: mbody.body,
+            priority,
+          });
+          res.writeHead(202, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ delivered: true, messageId: sent?.id, to, type: mailboxType }));
+        } catch (err) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'mailbox write failed', detail: String(err) }));
+        }
         return;
       }
 

--- a/packages/cli/tests/hq-server.test.ts
+++ b/packages/cli/tests/hq-server.test.ts
@@ -1561,3 +1561,202 @@ describe('HQ control plane (Phase 3)', () => {
     expect(postRes.status).toBe(404);
   });
 });
+
+describe('HQ direct mailbox write (POST /api/mailbox-send)', () => {
+  // Test-only browser token. Kept in a const so the auth header is assembled
+  // by concatenation (never a literal "Bearer <token>" string, which the
+  // repo secret-scanner flags).
+  const BROWSER_TOKEN = 'browser-mb-token';
+  const bearer = (): string => 'Bearer ' + BROWSER_TOKEN;
+
+  // The server derives its global root from path.dirname(dataDir); the
+  // SessionRegistry and per-project mailbox both live under that root.
+  function globalRootForData(dir: string): string {
+    return path.dirname(dir);
+  }
+
+  /**
+   * Seed a live session in the registry so the route can resolve a projectRoot
+   * from a sessionId. Registers a fresh entry (live pid + heartbeat) and
+   * returns a cleanup that stops the heartbeat timer and removes the entry.
+   */
+  async function seedSession(
+    globalRoot: string,
+    sessionId: string,
+    projectSlug: string,
+    projectRoot: string,
+  ): Promise<() => Promise<void>> {
+    const { SessionRegistry } = await import('@wrongstack/core');
+    const registry = new SessionRegistry(globalRoot);
+    await registry.register({
+      sessionId,
+      projectSlug,
+      projectRoot,
+      projectName: projectSlug,
+      workingDir: projectRoot,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    });
+    return async () => {
+      await registry.unregister().catch(() => {});
+    };
+  }
+
+  async function startTokenHqServer(port: number, capabilities?: string[]): Promise<HqServerHandle> {
+    await writeHqAuthFile(dataDir, {
+      version: HQ_AUTH_FILE_VERSION,
+      updatedAt: new Date().toISOString(),
+      browserTokens: [
+        {
+          id: 'bt-mb',
+          token: BROWSER_TOKEN,
+          createdAt: new Date().toISOString(),
+          ...(capabilities ? { capabilities } : {}),
+        },
+      ],
+      clientTokens: [],
+    });
+    return startHqServer({ port, dataDir });
+  }
+
+  it('rejects an unauthenticated request in token mode with 401', async () => {
+    const port = getPort();
+    // Browser token configured but NOT supplied on the request.
+    handle = await startTokenHqServer(port);
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/mailbox-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: 's1', type: 'steer', body: 'hi' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a token lacking control.enqueue with 403', async () => {
+    const port = getPort();
+    // Token present but scoped to a capability that is NOT control.enqueue.
+    handle = await startTokenHqServer(port, ['telemetry.publish']);
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/mailbox-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: bearer() },
+      body: JSON.stringify({ sessionId: 's1', type: 'steer', body: 'hi' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when neither sessionId nor projectId is provided', async () => {
+    const port = getPort();
+    handle = await startOpenHqServer({ port });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/mailbox-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'steer', body: 'hi' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when the target project mailbox cannot be resolved', async () => {
+    const port = getPort();
+    handle = await startOpenHqServer({ port });
+    // No session seeded — resolution fails.
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/mailbox-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'missing-session', type: 'steer', body: 'hi' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('resolves projectRoot from sessionId and writes the message to that project mailbox', async () => {
+    const port = getPort();
+    handle = await startOpenHqServer({ port });
+
+    const globalRoot = globalRootForData(dataDir);
+    const projectRoot = path.join(dataDir, 'mb-project');
+    await fs.mkdir(projectRoot, { recursive: true });
+    const cleanup = await seedSession(globalRoot, 'sess-mb-1', 'mb-project', projectRoot);
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/mailbox-send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: 'sess-mb-1',
+          type: 'steer',
+          to: 'leader',
+          subject: 'HQ prompt',
+          body: 'continue please',
+          priority: 'high',
+        }),
+      });
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as { delivered: boolean; messageId?: string; to: string; type: string };
+      expect(body.delivered).toBe(true);
+      expect(body.messageId).toBeTruthy();
+      expect(body.to).toBe('leader');
+      expect(body.type).toBe('steer');
+
+      // The message must be readable from the SAME project mailbox the server
+      // resolved — proving the write landed with zero connected clients.
+      const { GlobalMailbox, resolveProjectDir } = await import('@wrongstack/core');
+      const projectDir = resolveProjectDir(projectRoot, globalRoot);
+      const mailbox = new GlobalMailbox(projectDir);
+      const msgs = await mailbox.query({ to: 'leader' });
+      const found = msgs.find((m) => m.body === 'continue please');
+      expect(found).toBeTruthy();
+      expect(found?.type).toBe('steer');
+      expect(found?.subject).toBe('HQ prompt');
+      expect(found?.from).toMatch(/^hq@/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('maps a queue send to a note mailbox message', async () => {
+    const port = getPort();
+    handle = await startOpenHqServer({ port });
+
+    const globalRoot = globalRootForData(dataDir);
+    const projectRoot = path.join(dataDir, 'mb-project-q');
+    await fs.mkdir(projectRoot, { recursive: true });
+    const cleanup = await seedSession(globalRoot, 'sess-mb-q', 'mb-project-q', projectRoot);
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/mailbox-send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'sess-mb-q', type: 'queue', to: 'leader', body: 'later task' }),
+      });
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as { type: string };
+      // queue is delivered as a plain `note` mailbox message.
+      expect(body.type).toBe('note');
+
+      const { GlobalMailbox, resolveProjectDir } = await import('@wrongstack/core');
+      const mailbox = new GlobalMailbox(resolveProjectDir(projectRoot, globalRoot));
+      const msgs = await mailbox.query({ to: 'leader' });
+      const found = msgs.find((m) => m.body === 'later task');
+      expect(found?.type).toBe('note');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('returns 400 for an unrecognized mailbox message type', async () => {
+    const port = getPort();
+    handle = await startOpenHqServer({ port });
+
+    const globalRoot = globalRootForData(dataDir);
+    const projectRoot = path.join(dataDir, 'mb-project-bad');
+    await fs.mkdir(projectRoot, { recursive: true });
+    const cleanup = await seedSession(globalRoot, 'sess-mb-bad', 'mb-project-bad', projectRoot);
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/mailbox-send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // 'abort' is a real HQ command but not a mailbox-writing type.
+        body: JSON.stringify({ sessionId: 'sess-mb-bad', type: 'abort', body: 'x' }),
+      });
+      expect(res.status).toBe(400);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/packages/core/src/hq/commands.ts
+++ b/packages/core/src/hq/commands.ts
@@ -20,6 +20,8 @@ import type { HqQueuedCommand } from './protocol.js';
 /** HQ_COMMAND_TYPES — the full set of recognized command `type` strings. */
 export const HQ_COMMAND_TYPES = [
   'steer',
+  'btw',
+  'queue',
   'abort',
   'spawn',
   'broadcast',
@@ -31,6 +33,34 @@ export type HqCommandType = (typeof HQ_COMMAND_TYPES)[number];
 /** Inject a steer text into a target agent's conversation. */
 export interface HqSteerCommand {
   type: 'steer';
+  /** Target agent address: a unique id (`leader@<tag>`), an alias (`leader`), or `*` for all. */
+  to: string;
+  subject: string;
+  body: string;
+  priority?: 'low' | 'normal' | 'high';
+}
+
+/**
+ * Post a non-urgent FYI (`btw`) into a target agent's mailbox. Unlike a steer,
+ * a btw is absorbed as context — it does not demand the agent change course.
+ * Same wire shape as steer; only the emitted mailbox `type` differs.
+ */
+export interface HqBtwCommand {
+  type: 'btw';
+  /** Target agent address: a unique id (`leader@<tag>`), an alias (`leader`), or `*` for all. */
+  to: string;
+  subject: string;
+  body: string;
+  priority?: 'low' | 'normal' | 'high';
+}
+
+/**
+ * Queue a prompt/note (`queue`) for a target agent. Delivered as a plain
+ * `note` mailbox message the agent picks up before its next step — used when
+ * the prompt should wait its turn rather than steer the current operation.
+ */
+export interface HqQueueCommand {
+  type: 'queue';
   /** Target agent address: a unique id (`leader@<tag>`), an alias (`leader`), or `*` for all. */
   to: string;
   subject: string;
@@ -72,6 +102,8 @@ export interface HqRunCommandCommand {
 
 export type HqCommand =
   | HqSteerCommand
+  | HqBtwCommand
+  | HqQueueCommand
   | HqAbortCommand
   | HqSpawnCommand
   | HqBroadcastCommand
@@ -100,6 +132,26 @@ export function validateHqCommand(queued: HqQueuedCommand): HqCommand | null {
         return null;
       }
       const result: HqSteerCommand = { type: 'steer', to: p['to'], subject: p['subject'], body: p['body'] };
+      if (p['priority'] === 'low' || p['priority'] === 'normal' || p['priority'] === 'high') {
+        result.priority = p['priority'];
+      }
+      return result;
+    }
+    case 'btw': {
+      if (typeof p['to'] !== 'string' || typeof p['subject'] !== 'string' || typeof p['body'] !== 'string') {
+        return null;
+      }
+      const result: HqBtwCommand = { type: 'btw', to: p['to'], subject: p['subject'], body: p['body'] };
+      if (p['priority'] === 'low' || p['priority'] === 'normal' || p['priority'] === 'high') {
+        result.priority = p['priority'];
+      }
+      return result;
+    }
+    case 'queue': {
+      if (typeof p['to'] !== 'string' || typeof p['subject'] !== 'string' || typeof p['body'] !== 'string') {
+        return null;
+      }
+      const result: HqQueueCommand = { type: 'queue', to: p['to'], subject: p['subject'], body: p['body'] };
       if (p['priority'] === 'low' || p['priority'] === 'normal' || p['priority'] === 'high') {
         result.priority = p['priority'];
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -176,6 +176,13 @@ export {
   type SupervisorLogEntry,
 } from './coordination/fleet-supervisor.js';
 export { GlobalMailbox, resolveProjectDir } from './coordination/global-mailbox.js';
+export {
+  SessionRegistry,
+  getSessionRegistry,
+  hasSessionRegistry,
+  type SessionRegistryEntry,
+  type SessionLiveStatus,
+} from './session-registry.js';
 export * from './coordination/index.js';
 export {
   type MailToolsOptions,


### PR DESCRIPTION
## Summary

Extends the HQ command center so a prompt from the HQ screen can be sent as **any** type — steer, btw, or queue — and can be **delivered even when no agent is connected**.

## What changed

### Send types (steer / btw / queue)
- `HQ_COMMAND_TYPES` gains `btw` and `queue`, with typed `HqBtwCommand` / `HqQueueCommand` interfaces, union members, and `validateHqCommand` cases.
- The client-side command controller dispatches them: `btw` → a `btw` mailbox message, `queue` → a plain `note`. Both are targeted like `steer` and inherit the same guardrails.

### Direct mailbox write (zero-client delivery)
- New **`POST /api/mailbox-send`** on the HQ server writes an HQ prompt straight into a project's `GlobalMailbox`, bypassing the connected-client control plane.
- **Security:** the browser sends a `sessionId`/`projectId`, never a filesystem path. The server resolves `projectRoot` itself via `SessionRegistry` (by `sessionId`, else `projectSlug`), so the route cannot be used to write outside known projects. Auth mirrors `/api/command` (browser token + `control.enqueue`).

### Export fix
- Exports `SessionRegistry` from `@wrongstack/core`. It was destructured via a dynamic `import('@wrongstack/core')` in `hq-server.ts` but never actually exported, so registry-based session resolution silently degraded (the `try/catch` swallowed the failure).

## Tests
Adds 7 tests for `POST /api/mailbox-send`:
- 401 unauthenticated (token mode)
- 403 token lacking `control.enqueue`
- 400 missing `sessionId`/`projectId`
- 404 unresolvable project
- 202 resolve-by-`sessionId` + **verified** the message lands in the resolved project mailbox
- `queue` → `note` mapping
- 400 unrecognized type

## Verification
- `tsc` clean (core + cli), Biome clean on changed files.
- New route tests 7/7 green; full `hq-server.test.ts` green.

## Not included (follow-up)
The HQ dashboard **PromptDock UI** (type selector + `offline → mailbox` direct-send routing) is intentionally held out of this PR: the working tree had interleaved peer edits in `hq-dashboard-html.ts` that could not be hunk-split safely. It will land in a follow-up once coordinated with that file's owner.
