### PR TITLE
docs(hq): document /api/mailbox-send and steer/btw/queue send types

### DIFF
--- a/docs/subcommands/hq.md
+++ b/docs/subcommands/hq.md
@@ -136,6 +136,103 @@ Consequences:
 | `/api/projects/:id` | GET | `application/json` (`ProjectDetail`) | Drilldown endpoint used by the project drawer |
 | `/ws/browser` | WS upgrade | Stream of `HqBrowserMessage` frames | Browser connects here. Receives the current snapshot immediately, then live updates |
 | `/ws/client` | WS upgrade | Stream of `HqClientMessage` / `HqServerMessage` frames (bidirectional) | Telemetry clients (TUI/REPL/WebUI) connect here. Protocol version mismatch → close `1008` |
+| `/api/command` | POST | `application/json` (`202` on accept) | **Control plane.** Enqueue a command to a **connected** client. Requires a browser token with `control.enqueue` (open mode allows any). Target client must advertise `control.receive`. See [Control plane](#control-plane) |
+| `/api/commands` | GET | `application/json` | Recent command audit entries (`?limit=`, default 200) |
+| `/api/mailbox-send` | POST | `application/json` (`202` on delivery) | **Direct mailbox write** — deliver a prompt even when **no client is connected**. Same auth as `/api/command`. See [Direct mailbox delivery](#direct-mailbox-delivery-apimailbox-send) |
+
+### Control plane
+
+The HQ dashboard can send prompts to running agents through the
+control plane. Two transports exist:
+
+1. **`POST /api/command`** — enqueues a typed command for a **connected**
+   client, drained when that client next polls (`client.command_poll`).
+   Requires a live client advertising `control.receive`.
+2. **`POST /api/mailbox-send`** — writes the prompt straight into the
+   project mailbox, so it lands **even with zero connected clients** (see
+   the next section).
+
+Both paths ultimately deliver a message into the project mailbox, so
+they inherit the agent's existing mailbox guardrails. **HQ prompts are
+raw** — they are directives injected into the agent loop and bypass
+prompt refinement.
+
+#### Send types
+
+The command `type` selects how the message reaches the target agent.
+The three prompt-carrying types are:
+
+| Type | Mailbox message type | Meaning for the receiving agent |
+|---|---|---|
+| `steer` | `steer` | **Change course now.** Adjust the current operation at the next stopping point. |
+| `btw` | `btw` | **FYI / context.** Absorbed as information; does *not* demand a course change. |
+| `queue` | `note` | **Waits its turn.** A plain note the agent picks up before its next step. |
+| `broadcast` | `broadcast` | Fan out to every agent on the target's project (`to: all`). |
+
+The full set of `HQ_COMMAND_TYPES` (see `packages/core/src/hq/commands.ts`)
+also includes `abort`, `spawn`, and the gated `run-command`. Only
+`steer` / `btw` / `queue` / `broadcast` write a prompt to the mailbox;
+the others route through the agent's decision loop.
+
+#### `/api/command` request
+
+```jsonc
+POST /api/command
+{
+  "clientId": "<connected client id>",  // required — target must be online
+  "type": "steer",                       // steer | btw | queue | broadcast | abort | spawn | run-command
+  "payload": {
+    "to": "leader",                      // agent address; omitted for broadcast
+    "subject": "HQ prompt",
+    "body": "switch to plan B",
+    "priority": "high"                   // low | normal | high (default normal)
+  }
+}
+```
+
+Responses: `202` `{ commandId, queued: true, clientId }` on accept;
+`401` (bad token), `403` (token lacks `control.enqueue`), `404`
+(client not connected), `409` (client lacks `control.receive`), `400`
+(malformed command).
+
+#### Direct mailbox delivery (`/api/mailbox-send`)
+
+`/api/command` needs a live client. When the HQ screen sends a prompt to
+a project that has **no connected agent** (e.g. a terminal open but no
+active leader run, or nothing running at all), the dashboard falls back
+to `POST /api/mailbox-send`. This writes the prompt directly into the
+project's `GlobalMailbox` on disk, where the next agent to run — or any
+open terminal/WebUI — picks it up.
+
+**Target resolution is server-side and path-safe.** The browser sends a
+`sessionId` (or `projectId`), never a filesystem path. The server
+resolves the `projectRoot` itself via the `SessionRegistry` (by
+`sessionId`, else by `projectSlug`), so the route cannot be used to
+write outside projects HQ already knows about.
+
+```jsonc
+POST /api/mailbox-send
+{
+  "sessionId": "<session id>",   // OR "projectId": "<project slug>"
+  "type": "steer",               // steer | btw | queue | broadcast
+  "to": "leader",                // agent address (default "leader"); ignored for broadcast
+  "subject": "HQ prompt",
+  "body": "continue please",
+  "priority": "high"
+}
+```
+
+Auth mirrors `/api/command` (browser token + `control.enqueue`).
+Responses:
+
+| Status | Meaning |
+|---|---|
+| `202` | Delivered. Body: `{ delivered: true, messageId, to, type }` (`type` is the emitted mailbox type — e.g. `queue` → `note`). |
+| `400` | Missing `type`/`body`, missing both `sessionId` and `projectId`, or an unrecognized/non-mailbox type. |
+| `401` | Missing/invalid browser token (token mode). |
+| `403` | Token lacks `control.enqueue`. |
+| `404` | Target project mailbox could not be resolved from the registry. |
+| `500` | Mailbox write failed. |
 
 ### `/api/snapshot` response shape — `HqSnapshot`
 

--- a/packages/core/skills/mailbox-bridge/SKILL.md
+++ b/packages/core/skills/mailbox-bridge/SKILL.md
@@ -161,6 +161,39 @@ Every error response follows the WrongStack API convention:
 - No rate limiting at the bridge layer — assume the bearer token is the
   only credential and trust the loopback network.
 
+## The HQ dashboard writes to the same mailbox
+
+The HQ command center (`wstack --hq`) shares this exact `GlobalMailbox`.
+When an operator sends a prompt from the HQ screen, it lands in the same
+`_mailbox.jsonl` an external agent reads through `/mailbox/query` — so an
+external agent participating via this bridge sees HQ prompts too.
+
+HQ delivers a prompt one of two ways:
+
+- **`POST /api/command`** on the HQ server — routes to a *connected*
+  client, which then calls `GlobalMailbox.send`.
+- **`POST /api/mailbox-send`** on the HQ server — writes to the project
+  mailbox **directly**, so the prompt is delivered even when no agent is
+  connected. The HQ server resolves the target `projectRoot` from its
+  `SessionRegistry` (never a browser-supplied path).
+
+Either way, the resulting mailbox message carries one of the HQ **send
+types**, which map onto the mailbox `type` field an external agent will
+observe:
+
+| HQ send type | Mailbox `type` | Intent for the receiver |
+|--------------|----------------|-------------------------|
+| `steer`      | `steer`        | Change course now.       |
+| `btw`        | `btw`          | FYI / context — no course change demanded. |
+| `queue`      | `note`         | A queued prompt; handle before the next step. |
+| `broadcast`  | `broadcast`    | Sent to all agents on the project (`to: all`). |
+
+An external agent does not need to distinguish HQ-originated messages —
+they arrive with `from` set to `hq@<tag>` and are read, acked, and
+completed through the same `/mailbox/query` + `/mailbox/ack` routes as
+any other message. Filter on `from` if you want to treat HQ prompts
+specially.
+
 ## Pairing with the external-facing skill
 
 This internal skill describes how to run the server. The


### PR DESCRIPTION
## Summary

Docs for the HQ send-types feature merged in #231 (backend + tests) and #233 (frontend). Docs-only, no code changes.

## Changes

### `docs/subcommands/hq.md`
- Added `/api/command`, `/api/commands`, and the new `/api/mailbox-send` to the HTTP routes table.
- New **Control plane** section:
  - Explains the two transports — `/api/command` (connected client) vs. `/api/mailbox-send` (direct, works with zero connected clients).
  - **Send-type table**: `steer → steer`, `btw → btw`, `queue → note`, `broadcast → broadcast`.
  - Notes that **HQ prompts are raw** (bypass prompt refinement).
  - Request/response schemas and status-code tables for both routes.
  - Documents that `/api/mailbox-send` resolves `projectRoot` server-side via `SessionRegistry` (never a browser-supplied path).

### `packages/core/skills/mailbox-bridge/SKILL.md`
- New section explaining that the HQ dashboard writes to the **same** `GlobalMailbox` external bridge agents read, with the send-type → mailbox-type mapping and the `from=hq@<tag>` attribution.

## Verification
- Biome clean on both files.
- Anchor links verified against GitHub heading-slug rules.
