### PR TITLE
fix(hq): derive PromptDock subject from send-type so subject matches type

### DIFF
--- a/packages/cli/src/hq-dashboard-html.ts
+++ b/packages/cli/src/hq-dashboard-html.ts
@@ -1291,6 +1291,14 @@ async function boot(){
     // agent loop is actively running. HQ prompts are raw and bypass prompt
     // refinement — a steer/btw/queue is already a directive, not user input.
     var effectiveType = target && target.kind === 'broadcast' ? 'broadcast' : sendType;
+    // Derive the subject from the send-type so the two never drift (a steer
+    // must not carry a "queue"-flavored subject). Single source of truth,
+    // computed alongside effectiveType.
+    var effectiveSubject =
+      effectiveType === 'steer' ? 'HQ steer' :
+      effectiveType === 'btw' ? 'HQ note' :
+      effectiveType === 'broadcast' ? 'HQ broadcast' :
+      'HQ prompt'; // queue (and any future fallthrough)
     function submit(){
       if(!target || sending) return;
       var body = text.trim();
@@ -1304,11 +1312,11 @@ async function boot(){
       setStatus({ text: useDirect ? 'Delivering to mailbox…' : 'Queueing command…', cls: '' });
       var sendPromise;
       if(useDirect){
-        sendPromise = postHqMailboxSend(target, effectiveType, { subject: 'HQ prompt', body: body, priority: 'high' });
+        sendPromise = postHqMailboxSend(target, effectiveType, { subject: effectiveSubject, body: body, priority: 'high' });
       } else {
         var payload = target.kind === 'broadcast'
-          ? { subject: 'HQ prompt', body: body, priority: 'high' }
-          : { to: target.to, subject: 'HQ prompt', body: body, priority: 'high' };
+          ? { subject: effectiveSubject, body: body, priority: 'high' }
+          : { to: target.to, subject: effectiveSubject, body: body, priority: 'high' };
         sendPromise = postHqCommand(target.clientId, effectiveType, payload);
       }
       sendPromise


### PR DESCRIPTION
## What

The HQ PromptDock `submit()` path hardcoded `subject: 'HQ prompt'` at all three send sites regardless of the selected send-type. A steer therefore went out as `{ type: 'steer', subject: 'HQ prompt' }` — the subject did not match the type (visible as STEER messages with subject "HQ prompt").

## Fix

Introduce a single `effectiveSubject` derived from `effectiveType`, co-located with `effectiveType` as one source of truth, referenced at all three send sites:

| send-type | subject |
|-----------|---------|
| `steer` | `HQ steer` |
| `btw` | `HQ note` |
| `broadcast` | `HQ broadcast` |
| `queue` / fallthrough | `HQ prompt` |

## Behavior

Behavior-preserving: the mailbox `type` is unchanged; only the subject text now matches the type.

The `queue` case intentionally maps to `HQ prompt` on **both** the client fallthrough here and the server-side per-branch default in `hq-command-controller.ts`, so the two layers stay consistent. The server defaults remain in place as **defense-in-depth** for non-browser callers (curl / external agents that POST without a subject) — not dead code.

## Scope

- 1 file: `packages/cli/src/hq-dashboard-html.ts` (+11 / -3)
- Reviewed and approved by `leader@e839d31a` (author of #233 where the bug shipped)
- Pre-commit monorepo typecheck + build: green. Biome lint + format: clean.
