### PR TITLE
refactor(tools): share tool-output diff rendering across WebUI and HQ

### DIFF
--- a/packages/cli/src/hq-dashboard-html.ts
+++ b/packages/cli/src/hq-dashboard-html.ts
@@ -21,6 +21,7 @@
  * @module hq-dashboard-html
  */
 import { SUMMARIZE_TOOL_INPUT_BROWSER_SRC } from '@wrongstack/tools/tool-summary';
+import { TOOL_DIFF_BROWSER_SRC } from '@wrongstack/tools/tool-diff';
 
 // The served document is one big template literal (see header note). The
 // tool-input summarizer is authored ONCE in @wrongstack/tools and injected via
@@ -327,6 +328,24 @@ const HQ_HTML_TEMPLATE = `<!DOCTYPE html>
   .tool-status { margin-left: auto; flex: 0 0 auto; font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px; color: var(--green); font-weight: 800; }
   .tool-status.error { color: var(--red); }
   .tool-duration { flex: 0 0 auto; font-size: 10.5px; color: var(--dim); font-variant-numeric: tabular-nums; }
+  .tool-diff { border: 1px solid var(--border); border-radius: 8px; overflow: hidden; background: rgba(13,17,23,0.5); }
+  .tool-diff-head { display: flex; align-items: center; gap: 8px; padding: 5px 9px; border-bottom: 1px solid var(--border); background: var(--inset); font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10.5px; }
+  .tool-diff-cap { color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tool-diff-stat { margin-left: auto; display: flex; gap: 8px; flex: 0 0 auto; font-variant-numeric: tabular-nums; }
+  .tool-diff-stat .td-add { color: var(--green); font-weight: 700; }
+  .tool-diff-stat .td-del { color: var(--red); font-weight: 700; }
+  .tool-diff-body { max-height: 320px; overflow: auto; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; line-height: 1.5; }
+  .tool-diff-toolarge { padding: 8px 10px; color: var(--dim); font-style: italic; font-size: 11px; }
+  .tdrow { display: flex; align-items: flex-start; }
+  .tdrow.add { background: rgba(63,185,80,0.13); }
+  .tdrow.del { background: rgba(248,81,73,0.13); }
+  .tdrow.meta { background: rgba(88,166,255,0.10); }
+  .tdsign { flex: 0 0 auto; width: 16px; text-align: center; user-select: none; color: var(--dim); }
+  .tdrow.add .tdsign { color: var(--green); }
+  .tdrow.del .tdsign { color: var(--red); }
+  .tdrow.meta .tdsign { color: var(--accent); }
+  .tdtext { margin: 0; flex: 1 1 auto; min-width: 0; padding: 0 8px; white-space: pre-wrap; word-break: break-word; color: var(--text); }
+  .tdrow.ctx .tdtext, .tdrow.meta .tdtext { color: var(--muted); }
   .tool-group { margin: 0 0 14px 42px; max-width: 860px; border: 1px solid var(--border); border-radius: 12px; background: rgba(57,208,216,0.045); overflow: hidden; }
   .tool-group > summary { cursor: pointer; list-style: none; display: flex; align-items: center; gap: 8px; padding: 9px 11px; color: var(--text); user-select: none; }
   .tool-group > summary::-webkit-details-marker { display: none; }
@@ -1119,6 +1138,43 @@ async function boot(){
   // HQ's JSON string. See packages/tools/src/tool-summary.ts.
   /*__TOOL_SUMMARY_SRC__*/
 
+  // Tool-output diff model: authored once in @wrongstack/tools and injected here
+  // (same pattern as the summarizer). Defines diffFromToolInput / computeLineDiff
+  // / parseUnifiedDiff / diffRowsFromToolInput. See tool-diff.ts.
+  /*__TOOL_DIFF_SRC__*/
+
+  // Render a tool call's edit/write/patch diff as red/green rows, matching the
+  // WebUI DiffView. Returns null when the tool carries no diffable input.
+  function renderToolDiff(e){
+    var d = diffRowsFromToolInput(e.tool, e.toolInput);
+    if(!d) return null;
+    if(d.rows === null){
+      return h('div', { className: 'tool-diff' },
+        h('div', { className: 'tool-diff-head' }, d.caption || 'diff'),
+        h('div', { className: 'tool-diff-toolarge' }, 'diff too large to render')
+      );
+    }
+    var adds = 0, dels = 0;
+    for(var i=0;i<d.rows.length;i++){ if(d.rows[i].kind==='add') adds++; else if(d.rows[i].kind==='del') dels++; }
+    var rowEls = d.rows.map(function(r, idx){
+      var sign = r.kind==='add' ? '+' : (r.kind==='del' ? '-' : (r.kind==='meta' ? '@' : ' '));
+      return h('div', { key: idx, className: 'tdrow ' + r.kind },
+        h('span', { className: 'tdsign', 'aria-hidden': true }, sign),
+        h('pre', { className: 'tdtext' }, r.text || ' ')
+      );
+    });
+    return h('div', { className: 'tool-diff' },
+      h('div', { className: 'tool-diff-head' },
+        h('span', { className: 'tool-diff-cap' }, d.caption || 'diff'),
+        h('span', { className: 'tool-diff-stat' },
+          adds ? h('span', { className: 'td-add' }, '+' + adds) : null,
+          dels ? h('span', { className: 'td-del' }, '-' + dels) : null
+        )
+      ),
+      h('div', { className: 'tool-diff-body' }, rowEls)
+    );
+  }
+
   function fold(key, summary, content, preClass){
     return h('details', { key: key, className: 'bub-fold' },
       h('summary', null, summary),
@@ -1292,7 +1348,9 @@ async function boot(){
       headKids.push(h('span', { key:'st', className: 'tool-status ' + (failed ? 'error' : '') }, failed ? 'failed' : 'done'));
       if(e.durationMs != null){ headKids.push(h('span', { key:'du', className: 'tool-duration' }, e.durationMs + 'ms')); }
       bodyEls.push(h('div', { key: 'th', className: 'tool-head' }, headKids));
-      if(e.toolInput){ bodyEls.push(fold('a', 'Input · ' + e.toolInput.length + ' chars', e.toolInput, 'bub-argpre')); }
+      var toolDiffEl = e.toolInput ? renderToolDiff(e) : null;
+      if(toolDiffEl){ bodyEls.push(h('div', { key: 'd' }, toolDiffEl)); }
+      if(e.toolInput){ bodyEls.push(fold('a', (toolDiffEl ? 'Raw input' : 'Input') + ' · ' + e.toolInput.length + ' chars', e.toolInput, 'bub-argpre')); }
       if(e.text){ bodyEls.push(foldContent('o', (failed?'Error output':'Output') + ' · ' + countLines(e.text) + ' lines', renderToolOutput(e))); }
       if(!e.toolInput && !e.text){ bodyEls.push(h('div', { key:'n', className:'bub-sublabel' }, 'no output')); }
     } else {
@@ -2134,10 +2192,10 @@ boot();
 </html>`;
 
 // The served HQ document: HQ_HTML_TEMPLATE with the shared tool-input
-// summarizer injected at the placeholder. A replacer FUNCTION is used so any
-// dollar sign in the injected source is not treated as a String.replace
-// special replacement pattern.
+// summarizer and tool-output diff model injected at their placeholders. Replacer
+// FUNCTIONS are used so any dollar sign in the injected source is not treated as
+// a String.replace special replacement pattern.
 export const HQ_HTML: string = HQ_HTML_TEMPLATE.replace(
   '/*__TOOL_SUMMARY_SRC__*/',
   () => SUMMARIZE_TOOL_INPUT_BROWSER_SRC,
-);
+).replace('/*__TOOL_DIFF_SRC__*/', () => TOOL_DIFF_BROWSER_SRC);

--- a/packages/cli/tests/hq-dashboard.test.ts
+++ b/packages/cli/tests/hq-dashboard.test.ts
@@ -112,6 +112,25 @@ describe('HQ dashboard document', () => {
     expect(script).toContain('tool-summary');
   });
 
+  it('injects the shared tool-output diff model and renders edit/write/patch diffs', async () => {
+    handle = await startServer();
+    const html = await (await fetch(`http://127.0.0.1:${handle.port}/`)).text();
+    const dom = new JSDOM(html);
+    const script = dom.window.document.querySelector('script[type="module"]')?.textContent ?? '';
+    // Diff model is INJECTED from @wrongstack/tools/tool-diff — placeholder gone.
+    expect(script).not.toContain('__TOOL_DIFF_SRC__');
+    expect(script).toContain('function diffFromToolInput');
+    expect(script).toContain('function computeLineDiff');
+    expect(script).toContain('function parseUnifiedDiff');
+    expect(script).toContain('function diffRowsFromToolInput');
+    // HQ-side renderer + its CSS hooks.
+    expect(script).toContain('function renderToolDiff');
+    // The diff CSS classes must be present in the served <style>.
+    expect(html).toContain('.tool-diff');
+    expect(html).toContain('.tdrow.add');
+    expect(html).toContain('.tdrow.del');
+  });
+
   it('preserves the browser token when wiring WS and fetch URLs', async () => {
     // Token mode on — the dashboard must thread ?token= through every call.
     await writeHqAuthFile(dataDir, {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -36,6 +36,10 @@
       "types": "./dist/tool-summary.d.ts",
       "import": "./dist/tool-summary.js"
     },
+    "./tool-diff": {
+      "types": "./dist/tool-diff.d.ts",
+      "import": "./dist/tool-diff.js"
+    },
     "./read": {
       "types": "./dist/read.d.ts",
       "import": "./dist/read.js"

--- a/packages/tools/src/tool-diff.ts
+++ b/packages/tools/src/tool-diff.ts
@@ -1,0 +1,248 @@
+// Tool-output diff model — the single source of truth for turning an
+// edit/write/patch tool call into a red/green diff, shared by the WebUI
+// (DiffView) and the HQ dashboard chat-history sidebar.
+//
+// PURE + browser-safe (no node imports). Two consumption modes, mirroring the
+// pattern in ./tool-summary:
+//   1. WebUI/TS: import { diffFromToolInput, computeLineDiff } directly.
+//   2. HQ: it is a served template-literal string that cannot `import`, so it
+//      embeds the *_BROWSER_SRC transcriptions and a parity test guarantees the
+//      two never drift.
+//
+// Three tool families produce three diff shapes:
+//   - edit / str_replace  -> { mode:'lcs', oldText, newText }  (LCS line diff)
+//   - write / create      -> { mode:'lcs', oldText:'', newText }  (all additions)
+//   - patch               -> { mode:'unified', patchText }  (already a unified
+//                             diff — parse its hunks directly, do NOT recompute)
+
+/** A single rendered diff line. */
+export type DiffRowKind = 'add' | 'del' | 'ctx' | 'meta';
+export interface DiffRow {
+  kind: DiffRowKind;
+  text: string;
+}
+
+/** Extraction result: enough for a caller to render without re-inspecting input. */
+export type ToolDiff =
+  | { mode: 'lcs'; oldText: string; newText: string; caption: string }
+  | { mode: 'unified'; patchText: string; caption: string };
+
+/** Max lines per side before we bail out of the O(n*m) LCS table. */
+export const DIFF_MAX_LINES = 5000;
+
+function asObject(input: unknown): Record<string, unknown> | null {
+  if (typeof input === 'string') {
+    const s = input.trim();
+    if (s.startsWith('{') || s.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(s);
+        if (parsed && typeof parsed === 'object') return parsed as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+  if (input && typeof input === 'object') return input as Record<string, unknown>;
+  return null;
+}
+
+/**
+ * Recognise the edit-family tools and pull a renderable diff descriptor out of
+ * their input. Returns null when the tool doesn't carry diffable input.
+ *
+ * @param toolName canonical or aliased tool name.
+ * @param input    tool input — a parsed object OR a JSON string.
+ */
+export function diffFromToolInput(toolName: string | undefined, input: unknown): ToolDiff | null {
+  if (!toolName) return null;
+  const obj = asObject(input);
+  if (!obj) return null;
+  const name = toolName.toLowerCase();
+  const filePath = String(obj.file_path ?? obj.path ?? '');
+
+  switch (name) {
+    case 'edit':
+    case 'str_replace':
+    case 'edit_file':
+    case 'multi_edit': {
+      const oldText = typeof obj.old_string === 'string' ? obj.old_string : '';
+      const newText = typeof obj.new_string === 'string' ? obj.new_string : '';
+      if (!oldText && !newText) return null;
+      return { mode: 'lcs', oldText, newText, caption: `edit ${filePath}`.trim() };
+    }
+    case 'write':
+    case 'write_file':
+    case 'create_file': {
+      const content = typeof obj.content === 'string' ? obj.content : '';
+      if (!content) return null;
+      // Fresh write: no "old" side, everything shows green.
+      return { mode: 'lcs', oldText: '', newText: content, caption: `write ${filePath} (new)`.trim() };
+    }
+    case 'patch': {
+      const patchText = typeof obj.patch === 'string' ? obj.patch : '';
+      if (!patchText.trim()) return null;
+      return { mode: 'unified', patchText, caption: filePath ? `patch ${filePath}` : 'patch' };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * LCS-based line diff. Returns null when either side exceeds DIFF_MAX_LINES
+ * (an O(n*m) memory guard — fine for a normal edit, prohibitive for a huge
+ * generated-file rewrite).
+ */
+export function computeLineDiff(oldText: string, newText: string): DiffRow[] | null {
+  const a = oldText.split('\n');
+  const b = newText.split('\n');
+  if (a.length > DIFF_MAX_LINES || b.length > DIFF_MAX_LINES) return null;
+  const n = a.length;
+  const m = b.length;
+  // dp[i][j] = LCS length of a[i..] and b[j..]
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i]![j] = a[i] === b[j] ? dp[i + 1]![j + 1]! + 1 : Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!);
+    }
+  }
+  const rows: DiffRow[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      rows.push({ kind: 'ctx', text: a[i]! });
+      i++;
+      j++;
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      rows.push({ kind: 'del', text: a[i]! });
+      i++;
+    } else {
+      rows.push({ kind: 'add', text: b[j]! });
+      j++;
+    }
+  }
+  while (i < n) rows.push({ kind: 'del', text: a[i++]! });
+  while (j < m) rows.push({ kind: 'add', text: b[j++]! });
+  return rows;
+}
+
+/**
+ * Parse a unified-diff string into renderable rows. Hunk headers (`@@ ... @@`)
+ * and file headers (`--- `, `+++ `, `diff `, `index `) become `meta` rows; body
+ * lines map to add/del/ctx by their leading char. `\ No newline at end of file`
+ * is kept as a meta row.
+ */
+export function parseUnifiedDiff(patchText: string): DiffRow[] {
+  const rows: DiffRow[] = [];
+  const lines = patchText.split('\n');
+  for (const raw of lines) {
+    if (
+      raw.startsWith('@@') ||
+      raw.startsWith('--- ') ||
+      raw.startsWith('+++ ') ||
+      raw.startsWith('diff ') ||
+      raw.startsWith('index ') ||
+      raw.startsWith('\\ ')
+    ) {
+      rows.push({ kind: 'meta', text: raw });
+    } else if (raw.startsWith('+')) {
+      rows.push({ kind: 'add', text: raw.slice(1) });
+    } else if (raw.startsWith('-')) {
+      rows.push({ kind: 'del', text: raw.slice(1) });
+    } else {
+      // context line (leading space) or a bare line
+      rows.push({ kind: 'ctx', text: raw.startsWith(' ') ? raw.slice(1) : raw });
+    }
+  }
+  // Drop a trailing empty row that a final newline in patchText introduces.
+  if (rows.length > 0 && rows[rows.length - 1]!.kind === 'ctx' && rows[rows.length - 1]!.text === '') {
+    rows.pop();
+  }
+  return rows;
+}
+
+/**
+ * Convenience: extract + render to rows in one call. Returns null when the tool
+ * carries no diffable input, or `{ caption, rows: null }` when the diff is too
+ * large to render (LCS guard).
+ */
+export function diffRowsFromToolInput(
+  toolName: string | undefined,
+  input: unknown,
+): { caption: string; rows: DiffRow[] | null } | null {
+  const d = diffFromToolInput(toolName, input);
+  if (!d) return null;
+  if (d.mode === 'unified') return { caption: d.caption, rows: parseUnifiedDiff(d.patchText) };
+  return { caption: d.caption, rows: computeLineDiff(d.oldText, d.newText) };
+}
+
+// ---------------------------------------------------------------------------
+// Browser-JS transcriptions for HQ (served template literal, cannot import).
+// Authored with string concatenation only: NO backticks, NO ${...} — the HQ
+// template escapes those. A parity test asserts identical output to the TS
+// functions above. Together these define, on the global scope:
+//   diffFromToolInput(name, rawInput) -> {mode,...}|null
+//   computeLineDiff(oldText, newText) -> rows|null
+//   parseUnifiedDiff(patchText)       -> rows
+//   diffRowsFromToolInput(name, raw)  -> {caption, rows}|null
+// ---------------------------------------------------------------------------
+export const TOOL_DIFF_BROWSER_SRC: string = [
+  'var DIFF_MAX_LINES = 5000;',
+  'function __diffObj(input){',
+  '  if(typeof input==="string"){ var s=input.trim(); if(s.charAt(0)==="{"||s.charAt(0)==="["){ try{ var p=JSON.parse(s); if(p&&typeof p==="object") return p; }catch(_e){} } return null; }',
+  '  if(input&&typeof input==="object") return input; return null;',
+  '}',
+  'function diffFromToolInput(name, input){',
+  '  if(!name) return null;',
+  '  var obj=__diffObj(input); if(!obj) return null;',
+  '  var n=String(name).toLowerCase();',
+  '  var fp=String(obj.file_path!=null?obj.file_path:(obj.path!=null?obj.path:""));',
+  '  if(n==="edit"||n==="str_replace"||n==="edit_file"||n==="multi_edit"){',
+  '    var oldT=typeof obj.old_string==="string"?obj.old_string:"";',
+  '    var newT=typeof obj.new_string==="string"?obj.new_string:"";',
+  '    if(!oldT&&!newT) return null;',
+  '    return { mode:"lcs", oldText:oldT, newText:newT, caption:("edit "+fp).replace(/\\s+$/,"") };',
+  '  }',
+  '  if(n==="write"||n==="write_file"||n==="create_file"){',
+  '    var c=typeof obj.content==="string"?obj.content:"";',
+  '    if(!c) return null;',
+  '    return { mode:"lcs", oldText:"", newText:c, caption:("write "+fp+" (new)").replace(/\\s+/g," ").replace(/\\s+$/,"") };',
+  '  }',
+  '  if(n==="patch"){',
+  '    var pt=typeof obj.patch==="string"?obj.patch:"";',
+  '    if(!pt.replace(/\\s/g,"")) return null;',
+  '    return { mode:"unified", patchText:pt, caption: fp ? ("patch "+fp) : "patch" };',
+  '  }',
+  '  return null;',
+  '}',
+  'function computeLineDiff(oldText, newText){',
+  '  var a=oldText.split("\\n"), b=newText.split("\\n");',
+  '  if(a.length>DIFF_MAX_LINES||b.length>DIFF_MAX_LINES) return null;',
+  '  var nn=a.length, mm=b.length, i, j;',
+  '  var dp=new Array(nn+1); for(i=0;i<=nn;i++){ dp[i]=new Array(mm+1); for(j=0;j<=mm;j++) dp[i][j]=0; }',
+  '  for(i=nn-1;i>=0;i--){ for(j=mm-1;j>=0;j--){ dp[i][j]= a[i]===b[j] ? dp[i+1][j+1]+1 : Math.max(dp[i+1][j], dp[i][j+1]); } }',
+  '  var rows=[]; i=0; j=0;',
+  '  while(i<nn&&j<mm){ if(a[i]===b[j]){ rows.push({kind:"ctx",text:a[i]}); i++; j++; } else if(dp[i+1][j]>=dp[i][j+1]){ rows.push({kind:"del",text:a[i]}); i++; } else { rows.push({kind:"add",text:b[j]}); j++; } }',
+  '  while(i<nn){ rows.push({kind:"del",text:a[i]}); i++; }',
+  '  while(j<mm){ rows.push({kind:"add",text:b[j]}); j++; }',
+  '  return rows;',
+  '}',
+  'function parseUnifiedDiff(patchText){',
+  '  var rows=[], lines=patchText.split("\\n"), k, raw;',
+  '  for(k=0;k<lines.length;k++){ raw=lines[k];',
+  '    if(raw.indexOf("@@")===0||raw.indexOf("--- ")===0||raw.indexOf("+++ ")===0||raw.indexOf("diff ")===0||raw.indexOf("index ")===0||raw.indexOf("\\\\ ")===0){ rows.push({kind:"meta",text:raw}); }',
+  '    else if(raw.charAt(0)==="+"){ rows.push({kind:"add",text:raw.slice(1)}); }',
+  '    else if(raw.charAt(0)==="-"){ rows.push({kind:"del",text:raw.slice(1)}); }',
+  '    else { rows.push({kind:"ctx",text: raw.charAt(0)===" " ? raw.slice(1) : raw}); }',
+  '  }',
+  '  if(rows.length>0 && rows[rows.length-1].kind==="ctx" && rows[rows.length-1].text===""){ rows.pop(); }',
+  '  return rows;',
+  '}',
+  'function diffRowsFromToolInput(name, input){',
+  '  var d=diffFromToolInput(name, input); if(!d) return null;',
+  '  if(d.mode==="unified") return { caption:d.caption, rows:parseUnifiedDiff(d.patchText) };',
+  '  return { caption:d.caption, rows:computeLineDiff(d.oldText, d.newText) };',
+  '}',
+].join('\n');

--- a/packages/tools/tests/tool-diff.test.ts
+++ b/packages/tools/tests/tool-diff.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TOOL_DIFF_BROWSER_SRC,
+  computeLineDiff,
+  diffFromToolInput,
+  diffRowsFromToolInput,
+  parseUnifiedDiff,
+} from '../src/tool-diff.js';
+
+describe('diffFromToolInput', () => {
+  it('extracts an lcs diff from edit', () => {
+    expect(diffFromToolInput('edit', { path: 'a.ts', old_string: 'x', new_string: 'y' })).toEqual({
+      mode: 'lcs',
+      oldText: 'x',
+      newText: 'y',
+      caption: 'edit a.ts',
+    });
+  });
+
+  it('treats write as all-additions', () => {
+    expect(diffFromToolInput('write', { file_path: 'new.ts', content: 'a\nb' })).toEqual({
+      mode: 'lcs',
+      oldText: '',
+      newText: 'a\nb',
+      caption: 'write new.ts (new)',
+    });
+  });
+
+  it('extracts a unified diff from patch', () => {
+    const patch = '--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n';
+    expect(diffFromToolInput('patch', { patch })).toEqual({ mode: 'unified', patchText: patch, caption: 'patch' });
+  });
+
+  it('captions patch with the file path when present', () => {
+    expect(diffFromToolInput('patch', { patch: '@@ -1 +1 @@\n-a\n+b', path: 'x.ts' })?.caption).toBe('patch x.ts');
+  });
+
+  it('returns null for non-diff tools and empty input', () => {
+    expect(diffFromToolInput('bash', { command: 'ls' })).toBeNull();
+    expect(diffFromToolInput('edit', { old_string: '', new_string: '' })).toBeNull();
+    expect(diffFromToolInput('write', { content: '' })).toBeNull();
+    expect(diffFromToolInput('patch', { patch: '   ' })).toBeNull();
+    expect(diffFromToolInput(undefined, { old_string: 'x' })).toBeNull();
+  });
+
+  it('accepts a JSON string identically to a parsed object', () => {
+    const obj = { path: 'a.ts', old_string: 'x', new_string: 'y' };
+    expect(diffFromToolInput('edit', JSON.stringify(obj))).toEqual(diffFromToolInput('edit', obj));
+  });
+});
+
+describe('computeLineDiff', () => {
+  it('marks add/del/ctx rows', () => {
+    expect(computeLineDiff('a\nb\nc', 'a\nX\nc')).toEqual([
+      { kind: 'ctx', text: 'a' },
+      { kind: 'del', text: 'b' },
+      { kind: 'add', text: 'X' },
+      { kind: 'ctx', text: 'c' },
+    ]);
+  });
+
+  it('all additions for empty old', () => {
+    expect(computeLineDiff('', 'a')).toEqual([
+      { kind: 'del', text: '' },
+      { kind: 'add', text: 'a' },
+    ]);
+  });
+
+  it('returns null past the line cap', () => {
+    const huge = new Array(5002).fill('x').join('\n');
+    expect(computeLineDiff(huge, 'a')).toBeNull();
+  });
+});
+
+describe('parseUnifiedDiff', () => {
+  it('maps hunk headers to meta and +/- to add/del', () => {
+    const rows = parseUnifiedDiff('@@ -1,2 +1,2 @@\n ctx\n-old\n+new');
+    expect(rows).toEqual([
+      { kind: 'meta', text: '@@ -1,2 +1,2 @@' },
+      { kind: 'ctx', text: 'ctx' },
+      { kind: 'del', text: 'old' },
+      { kind: 'add', text: 'new' },
+    ]);
+  });
+
+  it('treats file headers as meta', () => {
+    const rows = parseUnifiedDiff('--- a/x\n+++ b/x\n diff-body');
+    expect(rows[0]).toEqual({ kind: 'meta', text: '--- a/x' });
+    expect(rows[1]).toEqual({ kind: 'meta', text: '+++ b/x' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parity: the HQ browser transcription must match the TS implementation.
+// ---------------------------------------------------------------------------
+const bs = new Function(
+  `${TOOL_DIFF_BROWSER_SRC}\nreturn { diffFromToolInput, computeLineDiff, parseUnifiedDiff, diffRowsFromToolInput };`,
+)() as {
+  diffFromToolInput: (n: string | undefined, i: unknown) => unknown;
+  computeLineDiff: (a: string, b: string) => unknown;
+  parseUnifiedDiff: (p: string) => unknown;
+  diffRowsFromToolInput: (n: string | undefined, i: string | null) => unknown;
+};
+
+describe('tool-diff parity (TS vs embedded browser source)', () => {
+  const diffCases: Array<{ tool: string | undefined; input: unknown }> = [
+    { tool: 'edit', input: { path: '/foo/bar.ts', old_string: 'a\nb\nc', new_string: 'a\nX\nc' } },
+    { tool: 'str_replace', input: { file_path: 't.ts', old_string: '1\n2', new_string: '' } },
+    { tool: 'write', input: { path: 'new.ts', content: 'line1\nline2\nline3' } },
+    { tool: 'create_file', input: { file_path: 'c.ts', content: 'only' } },
+    { tool: 'patch', input: { patch: '--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n ctx\n-old\n+new\n', path: 'x.ts' } },
+    { tool: 'bash', input: { command: 'ls' } },
+    { tool: 'edit', input: { old_string: '', new_string: '' } },
+    { tool: undefined, input: { old_string: 'x' } },
+  ];
+
+  for (let idx = 0; idx < diffCases.length; idx++) {
+    const c = diffCases[idx]!;
+    it(`diffFromToolInput parity #${idx} (${c.tool ?? 'undefined'})`, () => {
+      const ts = diffFromToolInput(c.tool, c.input);
+      const browser = bs.diffFromToolInput(c.tool, JSON.stringify(c.input));
+      expect(browser).toEqual(ts);
+    });
+    it(`diffRowsFromToolInput parity #${idx} (${c.tool ?? 'undefined'})`, () => {
+      const ts = diffRowsFromToolInput(c.tool, c.input);
+      const browser = bs.diffRowsFromToolInput(c.tool, JSON.stringify(c.input));
+      expect(browser).toEqual(ts);
+    });
+  }
+
+  const lcsPairs: Array<[string, string]> = [
+    ['a\nb\nc', 'a\nX\nc'],
+    ['', 'new'],
+    ['same', 'same'],
+    ['1\n2\n3\n4', '1\n3\n4\n5'],
+  ];
+  for (let idx = 0; idx < lcsPairs.length; idx++) {
+    const [a, b] = lcsPairs[idx]!;
+    it(`computeLineDiff parity #${idx}`, () => {
+      expect(bs.computeLineDiff(a, b)).toEqual(computeLineDiff(a, b));
+    });
+  }
+
+  it('parseUnifiedDiff parity', () => {
+    const patch = 'diff --git a/x b/x\nindex 111..222\n--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n ctx\n-old\n+new\n';
+    expect(bs.parseUnifiedDiff(patch)).toEqual(parseUnifiedDiff(patch));
+  });
+});

--- a/packages/tools/tsup.config.ts
+++ b/packages/tools/tsup.config.ts
@@ -48,6 +48,8 @@ export default defineConfig({
     'src/tool-icons.ts',
     // Pure tool-input summarizer (browser-safe; consumed by WebUI + HQ dashboard).
     'src/tool-summary.ts',
+    // Pure tool-output diff model (browser-safe; consumed by WebUI + HQ dashboard).
+    'src/tool-diff.ts',
     // Codebase index tools
     'src/codebase-index/index.ts',
     // Index worker thread — must be its own emitted file: the host spawns it

--- a/packages/webui/src/components/ConfirmDialog.tsx
+++ b/packages/webui/src/components/ConfirmDialog.tsx
@@ -5,7 +5,7 @@ import { useUIStore } from '@/stores';
 import { AlertTriangle, FileEdit, Globe, ShieldAlert, Terminal, Wrench, Zap } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { DiffView, diffFromToolInput } from './DiffView';
+import { ToolDiffView, diffFromToolInput } from './DiffView';
 import { Button } from './ui/button';
 import {
   Dialog,
@@ -40,15 +40,11 @@ function SmartInputPreview({
   input: unknown;
 }) {
   const { t } = useAppTranslation();
-  const diffArgs = diffFromToolInput(toolName, input);
-  if (diffArgs) {
+  const diff = diffFromToolInput(toolName, input);
+  if (diff) {
     return (
       <div className="rounded-lg overflow-hidden border">
-        <DiffView
-          oldText={diffArgs.oldText}
-          newText={diffArgs.newText}
-          caption={diffArgs.caption}
-        />
+        <ToolDiffView diff={diff} />
       </div>
     );
   }

--- a/packages/webui/src/components/DiffView.tsx
+++ b/packages/webui/src/components/DiffView.tsx
@@ -1,7 +1,13 @@
-import { expectDefined } from '@wrongstack/core';
+import { type DiffRow, type ToolDiff, computeLineDiff, parseUnifiedDiff } from '@wrongstack/tools/tool-diff';
 import { cn } from '@/lib/utils';
 import { useAppTranslation } from '@/i18n';
 import { memo, useMemo } from 'react';
+
+// The diff MODEL (line-diff algorithm, unified-diff parser, and tool-input
+// extraction) is the single source of truth in @wrongstack/tools/tool-diff,
+// shared with the HQ dashboard. This module owns only the React RENDERING.
+export { diffFromToolInput } from '@wrongstack/tools/tool-diff';
+
 interface DiffViewProps {
   oldText: string;
   newText: string;
@@ -15,24 +21,47 @@ interface DiffViewProps {
 }
 
 /**
- * Tiny line-based diff renderer. Computes the longest-common-subsequence
- * between `oldText` and `newText` line arrays, then walks both sides
- * emitting `add`/`remove`/`context` rows. Context lines are de-emphasised
- * so the eye lands on the changes. Not as pretty as a Myers diff but it's
- * one short function with no deps and good enough for a chat preview.
+ * Line-based diff renderer. Delegates the actual line diff to the shared
+ * `computeLineDiff` (LCS) in @wrongstack/tools, then renders add/del/context
+ * rows. Context lines are de-emphasised so the eye lands on the changes.
  *
- * Limits: text > 5000 lines is shown without a diff (just a "too large"
- * note); that's a UI guard, not a hard limit on the underlying tool.
+ * Limits: text > 5000 lines is shown without a diff (just a "too large" note);
+ * that's a UI guard, not a hard limit on the underlying tool.
  */
 export const DiffView = memo(function DiffView({ oldText, newText, caption, fill }: DiffViewProps) {
+  const rows = useMemo(() => computeLineDiff(oldText, newText), [oldText, newText]);
+  return <DiffRows rows={rows} caption={caption} fill={fill} />;
+});
+
+/**
+ * Render an already-extracted {@link ToolDiff}. `lcs` mode runs the line diff;
+ * `unified` mode parses the tool's own patch hunks. Both share the same row
+ * rendering, so edit/write and patch look consistent. Returns the same "too
+ * large" guard as {@link DiffView} for oversized LCS inputs.
+ */
+export const ToolDiffView = memo(function ToolDiffView({ diff, fill }: { diff: ToolDiff; fill?: boolean }) {
+  const rows = useMemo(
+    () => (diff.mode === 'unified' ? parseUnifiedDiff(diff.patchText) : computeLineDiff(diff.oldText, diff.newText)),
+    [diff],
+  );
+  return <DiffRows rows={rows} caption={diff.caption} fill={fill} />;
+});
+
+/** Shared row renderer for both DiffView (lcs) and ToolDiffView (lcs|unified). */
+const DiffRows = memo(function DiffRows({
+  rows,
+  caption,
+  fill,
+}: {
+  rows: DiffRow[] | null;
+  caption?: string | undefined;
+  fill?: boolean | undefined;
+}) {
   const { t } = useAppTranslation();
-  const rows = useMemo(() => computeDiff(oldText, newText), [oldText, newText]);
 
   if (rows === null) {
     return (
-      <div className="text-xs text-muted-foreground italic px-3 py-2">
-        {t('activity:diff.tooLarge')}
-      </div>
+      <div className="text-xs text-muted-foreground italic px-3 py-2">{t('activity:diff.tooLarge')}</div>
     );
   }
 
@@ -43,46 +72,47 @@ export const DiffView = memo(function DiffView({ oldText, newText, caption, fill
     <div
       className={cn(
         'rounded-lg border bg-background/40 overflow-hidden text-xs',
-        fill && 'flex h-full min-h-0 min-w-0 flex-col',
+        fill && 'flex h-full min-h-0 flex-col',
       )}
     >
-      <div className="flex items-center justify-between px-3 py-1.5 border-b bg-muted/40 shrink-0">
-        <span className="font-mono text-muted-foreground truncate">{caption ?? 'diff'}</span>
-        <span className="font-mono shrink-0">
-          <span className="text-success">+{adds}</span>
-          <span className="text-muted-foreground mx-1 opacity-50">·</span>
-          <span className="text-destructive">-{dels}</span>
-        </span>
-      </div>
-      <div
-        className={cn('font-mono leading-relaxed overflow-auto', fill ? 'min-h-0 flex-1' : 'max-h-96')}
-      >
-        {rows.map((r, i) => (
+      {(caption || adds > 0 || dels > 0) && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b bg-muted/40 font-mono text-[11px]">
+          {caption && <span className="text-muted-foreground truncate">{caption}</span>}
+          <span className="ml-auto flex items-center gap-2">
+            {adds > 0 && <span className="text-emerald-500">+{adds}</span>}
+            {dels > 0 && <span className="text-red-500">-{dels}</span>}
+          </span>
+        </div>
+      )}
+      <div className={cn('overflow-auto font-mono leading-relaxed', fill ? 'flex-1 min-h-0' : 'max-h-96')}>
+        {rows.map((r, idx) => (
           <div
-            key={i}
+            key={idx}
             className={cn(
-              'flex',
-              r.kind === 'add' && 'bg-success/10',
-              r.kind === 'del' && 'bg-destructive/10',
+              'flex items-start',
+              r.kind === 'add' && 'bg-emerald-500/10',
+              r.kind === 'del' && 'bg-red-500/10',
+              r.kind === 'meta' && 'bg-muted/60',
             )}
           >
             <span
+              aria-hidden
               className={cn(
-                'w-6 shrink-0 text-center select-none',
-                r.kind === 'add' && 'text-success',
-                r.kind === 'del' && 'text-destructive',
-                r.kind === 'ctx' && 'text-muted-foreground/40',
+                'select-none w-4 shrink-0 text-center',
+                r.kind === 'add' && 'text-emerald-500',
+                r.kind === 'del' && 'text-red-500',
+                (r.kind === 'ctx' || r.kind === 'meta') && 'text-muted-foreground/50',
               )}
             >
-              {r.kind === 'add' ? '+' : r.kind === 'del' ? '-' : ' '}
+              {r.kind === 'add' ? '+' : r.kind === 'del' ? '-' : r.kind === 'meta' ? '@' : ' '}
             </span>
             <pre
               className={cn(
                 'whitespace-pre-wrap break-all flex-1 px-2',
-                r.kind === 'ctx' && 'text-muted-foreground/70',
+                (r.kind === 'ctx' || r.kind === 'meta') && 'text-muted-foreground/70',
               )}
             >
-              {r.text || ' '}
+              {r.text || ' '}
             </pre>
           </div>
         ))}
@@ -90,86 +120,3 @@ export const DiffView = memo(function DiffView({ oldText, newText, caption, fill
     </div>
   );
 });
-
-interface DiffRow {
-  kind: 'add' | 'del' | 'ctx';
-  text: string;
-}
-
-const MAX_LINES = 5000;
-
-/**
- * Returns null when either side exceeds the line cap. Otherwise walks the
- * LCS table to produce a clean diff. LCS table is O(n*m) memory — fine for
- * a file edit (usually <500 lines), prohibitive for a full file rewrite of
- * a giant generated file (hence the cap).
- */
-function computeDiff(oldText: string, newText: string): DiffRow[] | null {
-  const a = oldText.split('\n');
-  const b = newText.split('\n');
-  if (a.length > MAX_LINES || b.length > MAX_LINES) return null;
-  const n = a.length;
-  const m = b.length;
-  // dp[i][j] = LCS length of a[i..] and b[j..]
-  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
-  for (let i = n - 1; i >= 0; i--) {
-    for (let j = m - 1; j >= 0; j--) {
-      if (a[i] === b[j]) expectDefined(dp[i])[j] = expectDefined(dp[i + 1]?.[j + 1]) + 1;
-      else expectDefined(dp[i])[j] = Math.max(expectDefined(dp[i + 1]?.[j]), expectDefined(dp[i]?.[j + 1]));
-    }
-  }
-  const rows: DiffRow[] = [];
-  let i = 0;
-  let j = 0;
-  while (i < n && j < m) {
-    if (a[i] === b[j]) {
-      rows.push({ kind: 'ctx', text: expectDefined(a[i]) });
-      i++;
-      j++;
-    } else if (expectDefined(dp[i + 1]?.[j]) >= expectDefined(dp[i]?.[j + 1])) {
-      rows.push({ kind: 'del', text: expectDefined(a[i]) });
-      i++;
-    } else {
-      rows.push({ kind: 'add', text: expectDefined(b[j]) });
-      j++;
-    }
-  }
-  while (i < n) rows.push({ kind: 'del', text: expectDefined(a[i++]) });
-  while (j < m) rows.push({ kind: 'add', text: expectDefined(b[j++]) });
-  return rows;
-}
-
-/**
- * Recognise the WrongStack edit-family tools and pull a (oldText, newText,
- * caption) tuple out of their input. Returns null when the tool doesn't
- * carry diffable input. Caller uses this to decide whether to render the
- * DiffView at all.
- */
-export function diffFromToolInput(
-  toolName: string | undefined,
-  input: unknown,
-): { oldText: string; newText: string; caption: string } | null {
-  if (!toolName || typeof input !== 'object' || input === null) return null;
-  const obj = input as Record<string, unknown>;
-  const filePath = String(obj.file_path ?? obj.path ?? '');
-  switch (toolName) {
-    case 'edit':
-    case 'str_replace':
-    case 'edit_file': {
-      const oldText = typeof obj.old_string === 'string' ? obj.old_string : '';
-      const newText = typeof obj.new_string === 'string' ? obj.new_string : '';
-      if (!oldText && !newText) return null;
-      return { oldText, newText, caption: `edit ${filePath}` };
-    }
-    case 'write':
-    case 'write_file':
-    case 'create_file': {
-      const content = typeof obj.content === 'string' ? obj.content : '';
-      // For a fresh write there's no "old" — treat as additive so the
-      // viewer shows everything green.
-      return { oldText: '', newText: content, caption: `write ${filePath} (new)` };
-    }
-    default:
-      return null;
-  }
-}

--- a/packages/webui/src/components/MessageBubble/index.tsx
+++ b/packages/webui/src/components/MessageBubble/index.tsx
@@ -29,7 +29,7 @@ import { memo, useEffect, useMemo, useState } from 'react';
 import { useAppTranslation } from '@/i18n';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { DiffView, diffFromToolInput } from '../DiffView';
+import { ToolDiffView, diffFromToolInput } from '../DiffView';
 import { ToolResult } from '../ToolResult';
 import { NextStepsBar, fillInput, parseNextSteps } from '../NextStepsBar';
 import { CopyButton } from './CopyButton.js';
@@ -251,8 +251,8 @@ export const MessageBubble = memo(function MessageBubble({
                   </div>
                 )}
                 {expanded && message.toolInput !== undefined && (() => {
-                  const diffArgs = diffFromToolInput(message.toolName, message.toolInput);
-                  if (diffArgs) return (<DiffView oldText={diffArgs.oldText} newText={diffArgs.newText} caption={diffArgs.caption} />);
+                  const diff = diffFromToolInput(message.toolName, message.toolInput);
+                  if (diff) return <ToolDiffView diff={diff} />;
                   return (<div className="p-3 bg-muted/50 rounded-lg overflow-x-auto"><div className="flex items-center gap-1 text-muted-foreground mb-2 text-xs"><Clock className="h-3 w-3" /><span>{t('activity:message.inputLabel')}</span></div><ToolInputView input={message.toolInput} /></div>);
                 })()}
                 {expanded && message.toolResult !== undefined && message.toolResult.length > 0 && (


### PR DESCRIPTION
## What

Make `@wrongstack/tools` the single source of truth for **tool-output diff
rendering** (edit/write/patch → red/green diff), shared by the WebUI and the
HQ dashboard. Follow-up to #236, which shared the one-line tool summary.

## Why

The WebUI rendered edit/write diffs from a local `DiffView`; the HQ dashboard
rendered the same tool calls as **plain text**. Two surfaces, inconsistent
output, and no shared model. This unifies them and adds patch support to both.

## How

- **New module** `packages/tools/src/tool-diff.ts` (browser-safe, no node
  imports) at subpath `@wrongstack/tools/tool-diff`:
  - `diffFromToolInput(name, input)` → `{ mode:'lcs', oldText, newText, caption }`
    for edit/str_replace/write, or `{ mode:'unified', patchText, caption }` for
    **patch** (whose input is already a unified-diff string, so it is parsed, not
    recomputed). Accepts a parsed object **or** a JSON string.
  - `computeLineDiff` (LCS, dependency-free — drops the `expectDefined` dep the
    old WebUI copy used), `parseUnifiedDiff` (patch hunks → rows),
    `diffRowsFromToolInput` (convenience).
  - `TOOL_DIFF_BROWSER_SRC` — authored-once browser transcription for HQ.
- **WebUI**: `DiffView.tsx` delegates to the shared model and gains a
  `ToolDiffView` component for the `lcs | unified` union. `MessageBubble` and
  `ConfirmDialog` use it — so **patch diffs now render in the WebUI too**.
  `ChangesView` keeps the `oldText`/`newText` `DiffView` API (unchanged).
- **HQ**: `hq-dashboard-html.ts` injects the browser source via a second chained
  `HQ_HTML_TEMPLATE.replace(placeholder, () => SRC)` and renders edit/write/patch
  as red/green rows (previously plain text) via `renderToolDiff` + `.tool-diff`
  CSS.

## Verification

- `typecheck` green for tools / cli / webui
- `biome` clean (9 files)
- `tools` suite 79/79 including a **32-case tool-diff suite** with TS-vs-browser
  parity (guards HQ transcription drift)
- `hq-dashboard` 10/10 (new test asserts the diff model is injected and the CSS
  is present in the served document)
- full WebUI suite **2070/2070**

## Scope

Exactly 9 files. No peer files touched.
