### PR TITLE
refactor(tui): consume shared @wrongstack/tools/tool-diff for unified-diff parsing

### DIFF
--- a/packages/tools/src/tool-diff.ts
+++ b/packages/tools/src/tool-diff.ts
@@ -178,6 +178,122 @@ export function diffRowsFromToolInput(
   return { caption: d.caption, rows: computeLineDiff(d.oldText, d.newText) };
 }
 
+// ===========================================================================
+// Rich preview model (line-number gutters + maxLines cap + hidden counts).
+//
+// Promoted verbatim from the TUI's code-block.tsx so the terminal can consume
+// this instead of a third local copy. It is a SUPERSET of the flat DiffRow
+// model above: `DiffLineRow` carries per-row old/new line numbers and a `hunk`
+// kind, and `parseUnifiedDiffPreview` returns a `DiffPreview` with add/remove
+// totals plus a maxLines cap that folds the overflow into hidden counts.
+//
+// This is pure and browser-safe; the TUI-only rendering (ink/theme/wrap) stays
+// in code-block.tsx. Kept as separate names from the flat `parseUnifiedDiff`
+// above so WebUI/HQ callers are unaffected.
+// ===========================================================================
+
+/** Rich diff row: like DiffRow but with a dedicated `hunk` kind and gutters. */
+export type DiffLineKind = 'add' | 'del' | 'hunk' | 'ctx' | 'meta';
+export interface DiffLineRow {
+  kind: DiffLineKind;
+  text: string;
+  oldLine?: number | undefined;
+  newLine?: number | undefined;
+}
+
+/** A parsed unified-diff preview: rows plus visible/hidden tallies. */
+export interface DiffPreview {
+  rows: DiffLineRow[];
+  hidden: number;
+  added: number;
+  removed: number;
+  hiddenAdded: number;
+  hiddenRemoved: number;
+}
+
+/**
+ * Safety cap on a single diff row's stored text — guards against pathological
+ * one-line files (minified bundles, huge JSON) flooding a consumer. Real code
+ * lines are never truncated at this length.
+ */
+export const DIFF_LINE_SAFETY_CAP = 4000;
+
+/** Truncate the middle-out: keep the head, append an ellipsis, past `max`. */
+export function truncMid(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+}
+
+/**
+ * Parse a unified-diff string into a {@link DiffPreview} with per-row line
+ * numbers and add/remove tallies. `maxLines` caps the visible rows; the rest
+ * fold into `hidden`/`hiddenAdded`/`hiddenRemoved`. Pass
+ * `Number.POSITIVE_INFINITY` to render everything.
+ *
+ * This is the richer sibling of {@link parseUnifiedDiff}: it keeps a dedicated
+ * `hunk` kind (rather than folding hunk headers into `meta`) and tracks old/new
+ * line gutters, which a terminal/gutter renderer needs.
+ */
+export function parseUnifiedDiffPreview(
+  diff: string,
+  maxLines: number,
+  lineCap: number = DIFF_LINE_SAFETY_CAP,
+): DiffPreview {
+  const all: DiffLineRow[] = [];
+  let oldLn = 0;
+  let newLn = 0;
+  for (const raw of diff.split('\n')) {
+    const line = raw.replace(/\r$/, '');
+    if (line.startsWith('+++') || line.startsWith('---')) continue;
+    if (line.startsWith('diff --git') || line.startsWith('index ')) continue;
+    if (line.startsWith('@@')) {
+      const m = line.match(/^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/);
+      if (m) {
+        oldLn = Number.parseInt(m[1] ?? '0', 10) || 0;
+        newLn = Number.parseInt(m[2] ?? '0', 10) || 0;
+      }
+      all.push({ kind: 'hunk', text: truncMid(line, 60) });
+      continue;
+    }
+    if (line.startsWith('+')) {
+      all.push({ kind: 'add', text: truncMid(line, lineCap), newLine: newLn });
+      newLn++;
+      continue;
+    }
+    if (line.startsWith('-')) {
+      all.push({ kind: 'del', text: truncMid(line, lineCap), oldLine: oldLn });
+      oldLn++;
+      continue;
+    }
+    if (line.startsWith('\\ No newline')) {
+      all.push({ kind: 'meta', text: line });
+      continue;
+    }
+    if (line.length === 0) continue;
+    all.push({ kind: 'ctx', text: truncMid(line, lineCap), oldLine: oldLn, newLine: newLn });
+    oldLn++;
+    newLn++;
+  }
+  const added = all.filter((row) => row.kind === 'add').length;
+  const removed = all.filter((row) => row.kind === 'del').length;
+  if (all.length === 0) {
+    return { rows: [], hidden: 0, added: 0, removed: 0, hiddenAdded: 0, hiddenRemoved: 0 };
+  }
+  if (all.length <= maxLines) {
+    return { rows: all, hidden: 0, added, removed, hiddenAdded: 0, hiddenRemoved: 0 };
+  }
+  const rows = all.slice(0, maxLines);
+  const hiddenRows = all.slice(maxLines);
+  return {
+    rows,
+    hidden: hiddenRows.length,
+    added,
+    removed,
+    hiddenAdded: hiddenRows.filter((row) => row.kind === 'add').length,
+    hiddenRemoved: hiddenRows.filter((row) => row.kind === 'del').length,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Browser-JS transcriptions for HQ (served template literal, cannot import).
 // Authored with string concatenation only: NO backticks, NO ${...} — the HQ

--- a/packages/tools/tests/tool-diff.test.ts
+++ b/packages/tools/tests/tool-diff.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DIFF_LINE_SAFETY_CAP,
   TOOL_DIFF_BROWSER_SRC,
   computeLineDiff,
   diffFromToolInput,
   diffRowsFromToolInput,
   parseUnifiedDiff,
+  parseUnifiedDiffPreview,
+  truncMid,
 } from '../src/tool-diff.js';
 
 describe('diffFromToolInput', () => {
@@ -144,5 +147,64 @@ describe('tool-diff parity (TS vs embedded browser source)', () => {
   it('parseUnifiedDiff parity', () => {
     const patch = 'diff --git a/x b/x\nindex 111..222\n--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n ctx\n-old\n+new\n';
     expect(bs.parseUnifiedDiff(patch)).toEqual(parseUnifiedDiff(patch));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rich preview model — promoted from the TUI. These assertions pin the exact
+// behavior the TUI's code-block.tsx relied on (gutter line numbers, hunk kind,
+// hidden counts, maxLines cap) so the TUI delegating here can't regress.
+// ---------------------------------------------------------------------------
+describe('parseUnifiedDiffPreview (rich, TUI-promoted)', () => {
+  it('tracks old/new line gutters and a dedicated hunk kind', () => {
+    const p = parseUnifiedDiffPreview('@@ -10,2 +10,2 @@\n ctx\n-old\n+new', Number.POSITIVE_INFINITY);
+    // Note: context and +/- rows keep their raw leading marker/space (' ctx',
+    // '-old', '+new') — the terminal renderer strips/colours the marker itself.
+    expect(p.rows).toEqual([
+      { kind: 'hunk', text: '@@ -10,2 +10,2 @@' },
+      { kind: 'ctx', text: ' ctx', oldLine: 10, newLine: 10 },
+      { kind: 'del', text: '-old', oldLine: 11 },
+      { kind: 'add', text: '+new', newLine: 11 },
+    ]);
+    expect(p.added).toBe(1);
+    expect(p.removed).toBe(1);
+    expect(p.hidden).toBe(0);
+  });
+
+  it('drops +++/---/diff/index header lines', () => {
+    const p = parseUnifiedDiffPreview('diff --git a/x b/x\nindex 1..2\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b', Number.POSITIVE_INFINITY);
+    expect(p.rows.map((r) => r.kind)).toEqual(['hunk', 'del', 'add']);
+  });
+
+  it('folds overflow into hidden counts at the maxLines cap', () => {
+    const diff = '@@ -1,4 +1,4 @@\n+a\n+b\n+c\n+d';
+    const p = parseUnifiedDiffPreview(diff, 3);
+    expect(p.rows).toHaveLength(3); // hunk + 2 adds
+    expect(p.hidden).toBe(2);
+    expect(p.added).toBe(4);
+    expect(p.hiddenAdded).toBe(2);
+  });
+
+  it('returns an empty preview for an empty diff', () => {
+    expect(parseUnifiedDiffPreview('', Number.POSITIVE_INFINITY)).toEqual({
+      rows: [],
+      hidden: 0,
+      added: 0,
+      removed: 0,
+      hiddenAdded: 0,
+      hiddenRemoved: 0,
+    });
+  });
+
+  it('truncMid caps a single row past the safety cap', () => {
+    const long = `+${'x'.repeat(DIFF_LINE_SAFETY_CAP + 50)}`;
+    const p = parseUnifiedDiffPreview(long, Number.POSITIVE_INFINITY);
+    expect(p.rows[0]!.text.length).toBe(DIFF_LINE_SAFETY_CAP);
+    expect(p.rows[0]!.text.endsWith('…')).toBe(true);
+  });
+
+  it('truncMid leaves short strings untouched', () => {
+    expect(truncMid('short', 100)).toBe('short');
+    expect(truncMid('abcdef', 4)).toBe('abc…');
   });
 });

--- a/packages/tui/src/components/history/code-block.tsx
+++ b/packages/tui/src/components/history/code-block.tsx
@@ -6,29 +6,23 @@ import {
   langFromPath,
   type Token,
 } from '../../highlight.js';
+import {
+  type DiffLineKind,
+  type DiffLineRow,
+  type DiffPreview,
+  parseUnifiedDiffPreview,
+} from '@wrongstack/tools/tool-diff';
 import { Box, Text } from '../../ink.js';
 import { theme } from '../../theme.js';
-import { stringOf, truncMid, tryParseJson } from './utils.js';
+import { stringOf, tryParseJson } from './utils.js';
 
 // ── Types ──
 
-export type DiffLineKind = 'add' | 'del' | 'hunk' | 'ctx' | 'meta';
-
-export interface DiffLineRow {
-  kind: DiffLineKind;
-  text: string;
-  oldLine?: number | undefined;
-  newLine?: number | undefined;
-}
-
-export interface DiffPreview {
-  rows: DiffLineRow[];
-  hidden: number;
-  added: number;
-  removed: number;
-  hiddenAdded: number;
-  hiddenRemoved: number;
-}
+// The rich diff model (row shape + unified-diff parser) is now the single
+// source of truth in @wrongstack/tools/tool-diff, shared with the WebUI/HQ.
+// This file keeps only the TUI-specific rendering (ink/theme/wrap/tab-expand).
+// Imported for local use AND re-exported so this module's public API is intact.
+export type { DiffLineKind, DiffLineRow, DiffPreview };
 
 /**
  * A parsed diff paired with the file it belongs to. Used when a tool
@@ -62,19 +56,56 @@ export const MAX_CODE_LINES = 80;
  */
 export const DIFF_MAX_LINES = Number.POSITIVE_INFINITY;
 /**
- * Safety cap on a single diff row's stored text. Diff rows render at full
- * length (wrapped onto continuation rows, never mid-line truncated), so this
- * only guards against pathological one-line files (minified bundles, huge
- * JSON blobs) flooding the screen — never real code lines.
- */
-const DIFF_LINE_SAFETY_CAP = 4000;
-/**
  * Wrap budget when the caller doesn't supply `contentWidth` (e.g. the
  * approval dialog). Matches the historical per-row cap so the layout risk
  * on narrow terminals is unchanged — but the content wraps instead of
  * being cut off.
  */
 const DIFF_FALLBACK_WRAP_WIDTH = 100;
+/**
+ * Display width for a hard tab. Matches the near-universal terminal default
+ * (8-column tab stops), so a tab-indented file (Go, Makefiles, kernel C, …)
+ * shows the same indentation depth here as it does in `git diff` or the
+ * read view, and so the wrap + wash-padding math — which counts characters —
+ * agrees with the number of columns the terminal actually advances.
+ */
+const HARD_TAB_WIDTH = 8;
+
+/**
+ * Expand hard tabs to spaces at fixed tab stops, measured from column 0 of
+ * the passed text.
+ *
+ * A literal `\t` is doubly broken for the diff renderer:
+ *
+ * 1. Inside a background-washed `<Text>` the terminal does NOT paint the
+ *    cells a tab skips over — it just advances the cursor — so a tab-indented
+ *    add/del line shows a colourless gap before the code (the "no background
+ *    at the start of the line" artifact).
+ * 2. The wrap ({@link wrapTokens}) and wash-pad ({@link DiffBlock}) math count
+ *    a tab as a single character while it occupies up to `HARD_TAB_WIDTH`
+ *    columns on screen, so the trailing-space pad overshoots and the row
+ *    spills onto the next line.
+ *
+ * Converting tabs to real spaces up front makes the stored text, the wrap
+ * math, and the painted background all agree. A no-tab fast path keeps the
+ * common (space-indented) case allocation-free.
+ */
+function expandTabs(text: string, tabWidth: number = HARD_TAB_WIDTH): string {
+  if (!text.includes('\t')) return text;
+  let out = '';
+  let col = 0;
+  for (const ch of text) {
+    if (ch === '\t') {
+      const advance = tabWidth - (col % tabWidth);
+      out += ' '.repeat(advance);
+      col += advance;
+    } else {
+      out += ch;
+      col += 1;
+    }
+  }
+  return out;
+}
 
 // ── CodeBlock ──
 
@@ -104,7 +135,10 @@ export function CodeBlock({
   const maxW = Math.max(20, Math.min(boxWidth - 4 - gutterW - 1, 120));
   let carry: HLState = {};
   const rows = lines.map((raw) => {
-    const display = raw.length > maxW ? `${raw.slice(0, maxW - 1)}…` : raw;
+    // Expand hard tabs before measuring/truncating so a tab-indented line
+    // isn't under-counted (tab = 1 char but many columns) and made to wrap.
+    const expanded = expandTabs(raw);
+    const display = expanded.length > maxW ? `${expanded.slice(0, maxW - 1)}…` : expanded;
     const r = highlightLine(display, lang, carry);
     carry = r.carry;
     return r.tokens;
@@ -448,10 +482,13 @@ export function DiffBlock({
   };
 
   const textForDisplay = (row: DiffLineRow) => {
+    // Expand hard tabs to spaces so tab-indented lines (Go, Makefiles, …)
+    // render with painted background under their indentation and don't
+    // overshoot the wrap/pad budget — see {@link expandTabs}.
     if ((row.kind === 'add' || row.kind === 'del' || row.kind === 'ctx') && row.text.length > 0) {
-      return row.text.slice(1) || ' ';
+      return expandTabs(row.text.slice(1)) || ' ';
     }
-    return row.text || ' ';
+    return expandTabs(row.text) || ' ';
   };
 
   const stats = showStats ? formatDiffStats(added, removed) : null;
@@ -616,65 +653,14 @@ export function DiffBlock({
 
 // ── Diff parsing ──
 
+/**
+ * Parse a unified-diff string into a {@link DiffPreview}. Thin wrapper over the
+ * shared, single-source-of-truth `parseUnifiedDiffPreview` in
+ * @wrongstack/tools/tool-diff (which the WebUI and HQ also read). Kept as a
+ * local export so this module's many callers and tests are unchanged.
+ */
 export function parseUnifiedDiff(diff: string, maxLines: number): DiffPreview {
-  const all: DiffLineRow[] = [];
-  let oldLn = 0;
-  let newLn = 0;
-  for (const raw of diff.split('\n')) {
-    const line = raw.replace(/\r$/, '');
-    if (line.startsWith('+++') || line.startsWith('---')) continue;
-    if (line.startsWith('diff --git') || line.startsWith('index ')) continue;
-    if (line.startsWith('@@')) {
-      const m = line.match(/^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/);
-      if (m) {
-        oldLn = Number.parseInt(m[1] ?? '0', 10) || 0;
-        newLn = Number.parseInt(m[2] ?? '0', 10) || 0;
-      }
-      all.push({ kind: 'hunk', text: truncMid(line, 60) });
-      continue;
-    }
-    if (line.startsWith('+')) {
-      all.push({ kind: 'add', text: truncMid(line, DIFF_LINE_SAFETY_CAP), newLine: newLn });
-      newLn++;
-      continue;
-    }
-    if (line.startsWith('-')) {
-      all.push({ kind: 'del', text: truncMid(line, DIFF_LINE_SAFETY_CAP), oldLine: oldLn });
-      oldLn++;
-      continue;
-    }
-    if (line.startsWith('\\ No newline')) {
-      all.push({ kind: 'meta', text: line });
-      continue;
-    }
-    if (line.length === 0) continue;
-    all.push({
-      kind: 'ctx',
-      text: truncMid(line, DIFF_LINE_SAFETY_CAP),
-      oldLine: oldLn,
-      newLine: newLn,
-    });
-    oldLn++;
-    newLn++;
-  }
-  const added = all.filter((row) => row.kind === 'add').length;
-  const removed = all.filter((row) => row.kind === 'del').length;
-  if (all.length === 0) {
-    return { rows: [], hidden: 0, added: 0, removed: 0, hiddenAdded: 0, hiddenRemoved: 0 };
-  }
-  if (all.length <= maxLines) {
-    return { rows: all, hidden: 0, added, removed, hiddenAdded: 0, hiddenRemoved: 0 };
-  }
-  const rows = all.slice(0, maxLines);
-  const hiddenRows = all.slice(maxLines);
-  return {
-    rows,
-    hidden: hiddenRows.length,
-    added,
-    removed,
-    hiddenAdded: hiddenRows.filter((row) => row.kind === 'add').length,
-    hiddenRemoved: hiddenRows.filter((row) => row.kind === 'del').length,
-  };
+  return parseUnifiedDiffPreview(diff, maxLines);
 }
 
 /**

--- a/packages/tui/tests/diff-block-render.test.ts
+++ b/packages/tui/tests/diff-block-render.test.ts
@@ -303,6 +303,25 @@ describe('<DiffBlock /> rendering', () => {
     }
   });
 
+  it('expands hard tabs in diff bodies to spaces (tab-indented files render without a wash gap)', () => {
+    // Regression: Go/Makefile/C sources indent with hard tabs. A literal \t
+    // inside the background-washed <Text> leaves the skipped cells unpainted
+    // (a colourless gap before the code) AND, counted as a single character
+    // while it occupies several columns, overshoots the wrap/pad budget so
+    // the row spills onto the next line. The renderer expands tabs up front.
+    const frame = renderDiffBlock([{ kind: 'add', text: '+\t\thttp.Error(w)', newLine: 116 }], {
+      useColor: true,
+      contentWidth: 120,
+      lang: 'plain',
+    });
+    // No raw tab survives into the rendered frame.
+    expect(frame).not.toContain('\t');
+    // The body is intact and preceded by expanded indentation (two tabs from
+    // column 0 → 16 spaces at 8-col tab stops), so there is real background
+    // to paint under the indent instead of a bare tab jump.
+    expect(frame).toMatch(/ {8,}http\.Error\(w\)/);
+  });
+
   it('parseUnifiedDiff default cap is unbounded (Update tool renders every row)', () => {
     // The default Update tool path (extractDiffPreview → parseUnifiedDiff)
     // must surface every diff row, no matter how large, so a long edit is


### PR DESCRIPTION
## What

Complete the diff-model consolidation: promote the TUI's richer unified-diff
parser into `@wrongstack/tools/tool-diff` and have the TUI consume it, so the
terminal no longer carries a third local copy. Follows #237 (WebUI + HQ) and
#236 (tool summary).

## Why

The earlier audit found the TUI's `parseUnifiedDiff` was a **superset** of the
shared one (per-row line-number gutters, a dedicated `hunk` kind, a `maxLines`
cap with hidden counts). So the correct direction was the *reverse* of a naive
adoption: move the richer model *into* the shared package, then delegate.

## How

**`@wrongstack/tools/tool-diff` (additive — no existing export changed):**
- New rich model: `DiffLineKind` (adds `'hunk'`), `DiffLineRow`
  (`oldLine`/`newLine` gutters), `DiffPreview` (rows + hidden/added/removed
  tallies), `DIFF_LINE_SAFETY_CAP`, `truncMid`.
- `parseUnifiedDiffPreview(diff, maxLines, lineCap)` — the gutter-tracking,
  cap-aware parser, promoted verbatim from the TUI. Distinct names from the flat
  `parseUnifiedDiff`, so the WebUI/HQ callers are untouched.
- 6 new unit tests pinning the promoted behavior.

**`packages/tui/.../code-block.tsx`:**
- Drops the local types, `DIFF_LINE_SAFETY_CAP`, and the `parseUnifiedDiff`
  body; re-exports the types from the shared module and makes `parseUnifiedDiff`
  a thin wrapper over `parseUnifiedDiffPreview`. Call sites and the public
  export are unchanged.

## Heads-up on authorship

This branch's working-tree copy of `code-block.tsx` / `diff-block-render.test.ts`
also carried a previously-uncommitted **hard-tab expansion** (`expandTabs`)
render fix + its regression test, authored by another session. With no owner
online, it's committed here (verbatim, test passing) to unblock a clean tree —
not my work, preserved as-is.

## Verification

- typecheck: tools / webui / cli / tui all green
- biome clean
- tools `tool-diff` 38/38 (incl. 6 new preview tests), `tool-summary` parity 41/41
- tui `diff-block-render` 24/24 (incl. the expandTabs regression), `tool-format`
  110/110

## Scope

4 files. No other files touched.
