### PR TITLE
feat(cli): auto-default startup prompts, --skip flag, and 4 cli-main.ts modular extractions

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "includes": [

--- a/packages/cli/src/arg-parser.ts
+++ b/packages/cli/src/arg-parser.ts
@@ -37,6 +37,7 @@ export const BOOLEAN_FLAGS = new Set([
   'no-hints',
   'hints',
   'no-hooks',
+  'skip',
   'skip-index',
   'mouse',
   'no-interactive',

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -313,7 +313,8 @@ export async function boot(argv: string[]): Promise<BootContext | number> {
         );
         const answer = (
           await reader.readLine(
-            `  ${color.amber('?')} Continue with these? ${color.dim('[Y/n/q]')} `,
+            `  ${color.amber('?')} Continue with these? ${color.dim('[Y/n/q]')} ${color.dim('(auto Y in 5s)')} `,
+            { timeoutMs: 5000, defaultAnswer: 'y' },
           )
         )
           .trim()

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -278,8 +278,10 @@ export async function boot(argv: string[]): Promise<BootContext | number> {
 
   const isSingleShot = positional.length > 0 || typeof flags['prompt'] === 'string';
   // Skip interactive TTY prompts when: single-shot, --webui, or --no-interactive
+  // --skip bypasses every interactive startup prompt (provider picker, launch
+  // mode, indexing question) and uses saved preferences or sensible defaults.
   const isInteractiveTTY =
-    isStdinTTY() && !isSingleShot && !flags['webui'] && !flags['no-interactive'];
+    isStdinTTY() && !isSingleShot && !flags['webui'] && !flags['no-interactive'] && !flags['skip'];
 
   if (isInteractiveTTY) {
     // If the current working directory has no .git repository, prompt the
@@ -468,9 +470,9 @@ export async function boot(argv: string[]): Promise<BootContext | number> {
     // Large codebases can take a while to index on first launch; let the
     // user skip it. The answer overrides config.indexing.onSessionStart
     // for this session only.
-    // --skip-index bypasses the question and skips indexing entirely.
+    // --skip-index / --skip bypasses the question and skips indexing entirely.
     let indexingAnswer: boolean | undefined;
-    if (flags['skip-index']) {
+    if (flags['skip-index'] || flags['skip']) {
       indexingAnswer = false;
     } else {
       indexingAnswer = await maybeAskAboutIndexing({

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -30,27 +30,17 @@ import {
   AgentError,
   allServers,
   attachDepWatcherBridge,
-  type BrainAutoRisk,
-  BrainDecisionQueue,
-  BrainMonitor,
   type Config,
   color,
-  createAutonomyBrain,
   type AuditLevel,
-  createDelegateTool,
-  createMcpControlTool,
-  createTieredBrainArbiter,
-  DefaultBrainArbiter,
   EternalAutonomyEngine,
   expectDefined,
   FLEET_ROSTER,
   gatedEnhancerReasoning,
   GlobalMailbox,
-  HumanEscalatingBrainArbiter,
   isStdinTTY,
   loadDirectorState,
   mailboxSessionTag,
-  ObservableBrainArbiter,
   ParallelEternalEngine,
   type LogLevel,
   SessionMemoryConsolidator,
@@ -72,12 +62,10 @@ import { registerBuiltinTools } from './boot/tool-registry.js';
 import { launchEternalFromFlag } from './cli-eternal-flag.js';
 import { promptRecovery } from './cli-recovery-prompt.js';
 import { bindSystemPromptBuilder } from './boot/system-prompt-builder.js';
-import { subscribeBrainDecisionLog } from './boot/brain-decision-log.js';
 import { refreshRuntimeModelCatalog } from './context-limit.js';
 import { type ExecutionDeps, execute } from './execution.js';
 import { createFallbackModelExtension } from './fallback-model.js';
 import { createCliHqPublisher } from './hq-publisher.js';
-import { MultiAgentHost } from './multi-agent.js';
 import { PLUGIN_AUDIT_ENTRIES, runPluginManagementCommand } from './plugin-management.js';
 import { buildPickableProviders } from './provider-helpers.js';
 import { SessionStats } from './session-stats.js';
@@ -104,6 +92,7 @@ import { setupDepWatcherConsumers } from './wiring/dep-watcher.js';
 import { setupHqTelemetry } from './wiring/hq-telemetry.js';
 import { setupDirectorAndAutonomy } from './wiring/director-setup.js';
 import { setupLifecycleAndPlugins } from './wiring/lifecycle-plugins.js';
+import { setupBrainAndOrchestration } from './wiring/brain-and-orchestration.js';
 import { setupMetrics } from './wiring/metrics.js';
 import { setupPipelines } from './wiring/pipeline.js';
 import {
@@ -715,47 +704,47 @@ export async function main(argv: string[]): Promise<number> {
     autonomyModeRef,
   });
 
-  // ── Global Brain chain — policy → LLM → human ──────────────────────────
-  // Positioning: the Brain is the authority layer above the leader/director
-  // and below the human. One instance serves every consumer (director,
-  // autophase, eternal engine, BrainMonitor, /brain) via TOKENS.BrainArbiter.
-  //   1. DefaultBrainArbiter — deterministic policy (low-risk fast path)
-  //   2. createAutonomyBrain — LLM decision support within the live risk
-  //      ceiling (adjust at runtime with /brain risk <level>)
-  //   3. HumanEscalating + Observable — escalation prompt + UI events
-  const brainSettings: { maxAutoRisk: BrainAutoRisk } = {
-    maxAutoRisk: 'medium',
-  };
-  const brainQueue = new BrainDecisionQueue(events);
-  // Lazy wrapper so the LLM layer always sees the LIVE provider/model —
-  // `provider` and `config` are reassigned when the user switches models.
-  const autonomousBrain: import('@wrongstack/core').BrainArbiter = {
-    decide: (request) =>
-      createAutonomyBrain({
-        provider,
-        model: config.model,
-        maxAutoRisk: 'all', // the tiered ceiling gates risk — keep inner permissive
-      }).decide(request),
-  };
-  const brain = new ObservableBrainArbiter(
-    new HumanEscalatingBrainArbiter(
-      createTieredBrainArbiter({
-        policy: new DefaultBrainArbiter(),
-        autonomous: autonomousBrain,
-        getMaxAutoRisk: () => brainSettings.maxAutoRisk,
-      }),
-      brainQueue,
-    ),
+  // ── Global Brain chain → BrainMonitor → shadow → MultiAgentHost → tools ──
+  // Extracted to wiring/brain-and-orchestration.ts. NOTE: setupHqTelemetry()
+  // is called between brain chain and brain monitor — the extracted function
+  // handles both halves around that call.
+  const {
+    brain,
+    brainLog,
+    brainSettings,
+    multiAgentHost,
+    shadowController,
+  } = setupBrainAndOrchestration({
     events,
-  );
-  container.bind(TOKENS.BrainArbiter, () => brain);
-
-  // Decision log for /brain status — last 20 decisions across all sources.
-  // Pulled out into a dedicated module as part of PR 8 / Stage 1 of the
-  // cli-main split refactor (see `next-1.md`). `brainLog` is captured by
-  // the closures produced later (see `getBrainLog: () => brainLog`).
-  const { brainLog, dispose: disposeBrainLog } = subscribeBrainDecisionLog(events);
-  teardownHandlers.push(disposeBrainLog);
+    config,
+    container,
+    provider,
+    session,
+    context,
+    toolRegistry,
+    providerRegistry,
+    configStore,
+    modelsRegistry,
+    promptBuilder,
+    tokenCounter,
+    projectRoot,
+    cwd,
+    wpaths,
+    teardownHandlers,
+    mailboxSessionTag,
+    brainMailbox,
+    agentMonitor,
+    directorMode,
+    manifestPath,
+    sharedScratchpadPath,
+    subagentSessionsRoot,
+    stateCheckpointPath,
+    fleetRootForPromotion,
+    maxConcurrent,
+    effectiveMaxContextRef,
+    mcpRegistry,
+    sessResult,
+  });
 
   // HQ command dispatch + telemetry bridges (WebSocket, session/fleet/brain/
   // worktree/tool/cost telemetry, agent-monitor forwarding) — extracted to
@@ -775,136 +764,6 @@ export async function main(argv: string[]): Promise<number> {
     mailboxSessionTag,
     hqPublisherRef,
   });
-
-  // brainMailbox is created earlier (before setupPlugins) so the
-  // `api.mailbox` PluginAPI field is populated for plugins like
-  // `todo-listener`. Reuse the same instance here.
-  const brainMonitor = new BrainMonitor({
-    events,
-    brain,
-    sessionId: () => context.session?.id ?? session.id,
-    intervene: async ({ subject, body }) => {
-      const leaderUniqueId = `leader@${mailboxSessionTag(session.id)}`;
-      await brainMailbox.send({
-        from: `brain@${mailboxSessionTag(session.id)}`,
-        to: leaderUniqueId,
-        type: 'steer',
-        subject,
-        body,
-        priority: 'high',
-      });
-    },
-  });
-  brainMonitor.start();
-
-  // ── AutonomousCoordinator is initialized inside execution.ts ──
-  // The execution phase owns its lifecycle (it has access to the Director and
-  // the LLM provider). See execution.ts:onDirectorReady.
-
-  // Shadow controller — tracks the active shadow agent so /shadow commands can
-  // reject duplicate starts and stop the real background monitor.
-  let shadowDefaults: { intervalMs?: number; provider?: string; model?: string } = {};
-  const shadowController: NonNullable<
-    Parameters<typeof buildBuiltinSlashCommands>[0]['shadowController']
-  > = {
-    activeId: null,
-    register(id) {
-      this.activeId = id;
-    },
-    clear() {
-      this.activeId = null;
-    },
-    getDefaults() {
-      return { ...shadowDefaults };
-    },
-    setDefaults(defaults) {
-      shadowDefaults = { ...shadowDefaults, ...defaults };
-    },
-  };
-
-  const multiAgentHost = new MultiAgentHost(
-    {
-      container,
-      toolRegistry,
-      providerRegistry,
-      configStore,
-      modelsRegistry,
-      events,
-      systemPromptBuilder: promptBuilder,
-      session,
-      tokenCounter,
-      projectRoot,
-      cwd,
-      secretScrubber: container.resolve(TOKENS.SecretScrubber),
-    },
-    {
-      directorMode,
-      manifestPath,
-      sharedScratchpadPath,
-      sessionsRoot: subagentSessionsRoot,
-      directorRunId: session.id,
-      fleetRoot: fleetRootForPromotion,
-      stateCheckpointPath,
-      sessionWriter: session,
-      maxConcurrent,
-      getLeaderMaxContext: () => effectiveMaxContextRef.current,
-      brain,
-      agentMonitor,
-      traceId: sessResult.traceId,
-      onShadowAgentStarted: (subagentId) => shadowController.register(subagentId),
-      onShadowAgentStopped: (subagentId) => {
-        if (shadowController.activeId === subagentId) shadowController.clear();
-      },
-    },
-  );
-  // ALWAYS register the `delegate` tool, even in non-director mode. It
-  // auto-promotes the host to director mode on first call so the LLM
-  // never has to know upfront whether multi-agent is "on" — it just
-  // calls `delegate({ role, task })` when it judges a subtask warrants
-  // a dedicated subagent. The system-prompt builder picks up this tool
-  // and surfaces a "Delegation" section teaching the model when to use
-  // it; without that block, the tool sits idle.
-  toolRegistry.register(
-    createDelegateTool({
-      host: multiAgentHost,
-      roster: FLEET_ROSTER,
-      // Wire the per-subagent transcript location so the tool can
-      // extract partial output on timeout / budget exhaustion. Without
-      // this, a subagent that hit its iteration cap returns an empty
-      // result and the host LLM has no idea what work was done.
-      sessionsRoot: subagentSessionsRoot,
-      directorRunId: session.id,
-      // Host bus so `delegate` can emit start/finish events that the TUI,
-      // plain CLI, and Telegram bridge render as readable lines.
-      events,
-    }),
-  );
-
-  // `mcp_control` — LLM-driven MCP server lifecycle.
-  // The model uses this to autonomously enable/disable MCP servers
-  // without requiring a slash command or manual intervention.
-  toolRegistry.register(
-    createMcpControlTool({
-      getConfig: () => configStore.get(),
-      configPath: wpaths.globalConfig,
-      registry: mcpRegistry,
-    }),
-  );
-
-  // `mcp_use` — meta-tool for calling MCP tools in token-saving mode.
-  // Registers only when lazy mode is active so the model has a single
-  // call to invoke any MCP tool without the manual activate→use→deactivate
-  // dance. When lazy mode is off, MCP tools are always registered and
-  // the meta-tool is unnecessary.
-  if (config.features.tokenSavingMode) {
-    const { createMcpUseTool } = await import('@wrongstack/core');
-    toolRegistry.register(
-      createMcpUseTool({
-        registry: mcpRegistry,
-        toolRegistry,
-      }),
-    );
-  }
 
   // Dep-watcher consumers (tech-stack + package-outdated) — extracted to wiring/dep-watcher.ts
   setupDepWatcherConsumers({
@@ -1820,8 +1679,6 @@ export async function main(argv: string[]): Promise<number> {
     onExit: () => {
       for (const teardown of teardownHandlers) teardown();
       teardownHandlers.length = 0;
-      brainMonitor.stop();
-      brainQueue.dispose();
       void mcpRegistry.stopAll();
       multiAgentHost
         .dispose()
@@ -2417,7 +2274,7 @@ export async function main(argv: string[]): Promise<number> {
     },
     onBrainRiskLevel: (level: 'off' | 'low' | 'medium' | 'high' | 'all') => {
       if (!brainSettings) return 'Brain settings not available.';
-      brainSettings.maxAutoRisk = level as BrainAutoRisk;
+      brainSettings.maxAutoRisk = level as import('@wrongstack/core').BrainAutoRisk;
       return undefined;
     },
     // Interactive /auth panel host — provider/key CRUD, catalog/local adds

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -44,7 +44,6 @@ import {
   type Director,
   EternalAutonomyEngine,
   expectDefined,
-  type FileAuthorTrackerOptions,
   FLEET_ROSTER,
   gatedEnhancerReasoning,
   GlobalMailbox,
@@ -57,21 +56,12 @@ import {
   loadDirectorState,
   mailboxSessionTag,
   ObservableBrainArbiter,
-  type PackageAuthorTrackerOptions,
   ParallelEternalEngine,
   type LogLevel,
   SessionMemoryConsolidator,
   SddRunRegistry,
   SlashCommandRegistry,
-  startSessionTelemetryBridge,
-  startFleetTelemetryBridge,
-  startBrainTelemetryBridge,
-  startWorktreeTelemetryBridge,
-  startToolTelemetryBridge,
-  startCostTelemetryBridge,
   type SystemPromptBuilder,
-  startPackageOutdatedWatcher,
-  startTechStackConsumer,
   TOKENS,
   ToolRegistry,
   watchProviderConfig,
@@ -95,8 +85,7 @@ import { subscribeBrainDecisionLog } from './boot/brain-decision-log.js';
 import { refreshRuntimeModelCatalog, resolveRuntimeMaxContext } from './context-limit.js';
 import { type ExecutionDeps, execute } from './execution.js';
 import { createFallbackModelExtension } from './fallback-model.js';
-import { createCliHqPublisher, startCliHqConnection } from './hq-publisher.js';
-import { createHqCommandDispatcher, type HqCommandController } from './hq-command-controller.js';
+import { createCliHqPublisher } from './hq-publisher.js';
 import { createLifecycleHooksExtension, createUserPromptSubmitMiddleware } from './hooks-wiring.js';
 import { MultiAgentHost } from './multi-agent.js';
 import { createAgentMonitorService } from '@wrongstack/core/coordination';
@@ -123,6 +112,8 @@ import { getSuggestions, setSuggestions } from './slash-commands/suggestion-stor
 import { fmtTaskResultLine, patchConfig } from './utils.js';
 import { CLI_VERSION } from './version.js';
 import { setupCodebaseIndexing } from './wiring/codebase-index.js';
+import { setupDepWatcherConsumers } from './wiring/dep-watcher.js';
+import { setupHqTelemetry } from './wiring/hq-telemetry.js';
 import { setupMetrics } from './wiring/metrics.js';
 import { createAgent, setupCompaction, setupPipelines } from './wiring/pipeline.js';
 import { installDesignStudio } from './wiring/design-studio.js';
@@ -695,7 +686,10 @@ export async function main(argv: string[]): Promise<number> {
   // `todo-listener` that publish cross-agent status updates.
   // (Constructor is side-effect-free; the instance is harmless until
   //  the first send/heartbeat call.)
-  const brainMailbox = new GlobalMailbox(wpaths.projectDir, events, () => hqPublisher);
+  // Mutable ref populated by setupHqTelemetry once the HQ connection
+  // establishes — brainMailbox reads it via closure for HQ publishing.
+  const hqPublisherRef: { current: any | undefined } = { current: undefined };
+  const brainMailbox = new GlobalMailbox(wpaths.projectDir, events, () => hqPublisherRef.current);
 
   // Plugins — extracted to wiring/plugins.ts
   await setupPlugins({
@@ -1081,161 +1075,24 @@ export async function main(argv: string[]): Promise<number> {
   const { brainLog, dispose: disposeBrainLog } = subscribeBrainDecisionLog(events);
   teardownHandlers.push(disposeBrainLog);
 
-  // ── Brain self-activation — watch the bus, intervene via mailbox steer ──
-  // Tool-failure streaks and error storms engage the Brain proactively; a
-  // "steer" decision lands in THIS session's leader inbox and is injected
-  // before the agent's next step.
-  let hqPublisher: ReturnType<typeof createCliHqPublisher>;
-  let stopHqSessionBridge: (() => void) | undefined;
-  const stopHqAuxBridges: Array<() => void> = [];
-
-  // ── Phase 4 control plane — HQ command dispatch holder ──────────────────
-  // Mutable holder (mirrors the `interruptController` pattern): populated
-  // lazily as `director` comes online and `interruptController.abortLeader`
-  // is rebound by the REPL/TUI. The `onCommand` handler reads these at
-  // dispatch time so a command arriving before the director exists is
-  // cleanly rejected instead of crashing.
-  const hqCommandController: HqCommandController = {
-    steerMailbox: brainMailbox,
-    interruptLeader: () => false, // rebound when the REPL/TUI mounts
-    sessionTag: () => mailboxSessionTag(session.id),
-    allowRunCommand: () => flags['hq-allow-exec'] === true,
-  };
-  const hqOnCommand = createHqCommandDispatcher(hqCommandController);
-
-  const hqConnection = startCliHqConnection({
-    clientKind: tuiOwnsScreen ? 'tui' : 'cli',
+  // HQ command dispatch + telemetry bridges (WebSocket, session/fleet/brain/
+  // worktree/tool/cost telemetry, agent-monitor forwarding) — extracted to
+  // wiring/hq-telemetry.ts.
+  const { hqCommandController } = setupHqTelemetry({
+    events,
+    session,
+    config,
+    flags,
+    tuiOwnsScreen,
     projectRoot,
-    projectName: path.basename(projectRoot),
-    appConfig: config,
-    onCommand: hqOnCommand,
-    capabilities: ['telemetry.publish', 'mailbox.summary', 'fleet.summary', 'session.summary', 'control.receive'],
-    onConnect: (publisher) => {
-      hqPublisher = publisher;
-      stopHqSessionBridge?.();
-      stopHqSessionBridge = undefined;
-      // Drain any auxiliary bridges from a previous connection before
-      // re-establishing them, so a reconnect never double-subscribes.
-      for (const stop of stopHqAuxBridges) {
-        try {
-          stop();
-        } catch {
-          /* best-effort */
-        }
-      }
-      stopHqAuxBridges.length = 0;
-      try {
-        stopHqSessionBridge = startSessionTelemetryBridge({
-          publisher,
-          events,
-          sessionId: session.id,
-          projectRoot,
-          projectName: path.basename(projectRoot),
-          globalRoot: wpaths.globalRoot,
-          initialAgents: tracker?.getAgents(),
-          startedAt: new Date().toISOString(),
-        });
-      } catch {
-        // HQ session telemetry is optional.
-      }
-      // ── Auxiliary telemetry bridges — forward richer signals (fleet
-      // stats, brain decisions, worktree lifecycle, tool activity, cost)
-      // to HQ so the command center dashboard is fully populated. All are
-      // best-effort and never break the host on failure. The session id is
-      // the canonical runId (namespace-stable per session), used by the
-      // fleet bridge to identify this coordinator instance.
-      try {
-        stopHqAuxBridges.push(
-          startFleetTelemetryBridge({
-            events,
-            publisher,
-            runId: session.id,
-            sessionId: session.id,
-          }),
-        );
-      } catch {
-        /* optional */
-      }
-      try {
-        stopHqAuxBridges.push(
-          startBrainTelemetryBridge({ events, publisher, sessionId: session.id }),
-        );
-      } catch {
-        /* optional */
-      }
-      try {
-        stopHqAuxBridges.push(
-          startWorktreeTelemetryBridge({ events, publisher, sessionId: session.id }),
-        );
-      } catch {
-        /* optional */
-      }
-      try {
-        stopHqAuxBridges.push(
-          startToolTelemetryBridge({
-            events,
-            publisher,
-            projectRoot,
-            sessionId: session.id,
-          }),
-        );
-      } catch {
-        /* optional */
-      }
-      try {
-        stopHqAuxBridges.push(
-          startCostTelemetryBridge({ events, publisher, sessionId: session.id }),
-        );
-      } catch {
-        /* optional */
-      }
-    },
+    globalRoot: wpaths.globalRoot,
+    tracker,
+    agentMonitor,
+    brainMailbox,
+    teardownHandlers,
+    mailboxSessionTag,
+    hqPublisherRef,
   });
-  hqPublisher = hqConnection.getPublisher();
-  teardownHandlers.push(() => stopHqSessionBridge?.());
-  teardownHandlers.push(() => {
-    for (const stop of stopHqAuxBridges) {
-      try {
-        stop();
-      } catch {
-        /* best-effort */
-      }
-    }
-  });
-  teardownHandlers.push(() => hqConnection.stop());
-
-  // ── Agent Monitor → HQ Bridge ───────────────────────────────────
-  // Forward agent.timeline.message and agent.status_changed events to
-  // the HQ publisher so the HQ browser dashboard sees real-time agent
-  // conversations.
-  if (agentMonitor) {
-    const offMsg = events.on('agent.timeline.message', (payload) => {
-      try {
-        hqPublisher?.publishEvent({
-          type: 'agent.message' as never,
-          payload,
-          timestamp: payload.ts,
-        });
-      } catch {
-        /* best-effort */
-      }
-    });
-    const offStatus = events.on('agent.status_changed', (payload) => {
-      try {
-        hqPublisher?.publishEvent({
-          type: 'agent.status' as never,
-          payload,
-          timestamp: payload.ts,
-        });
-      } catch {
-        /* best-effort */
-      }
-    });
-    teardownHandlers.push(() => {
-      offMsg();
-      offStatus();
-    });
-  }
 
   // brainMailbox is created earlier (before setupPlugins) so the
   // `api.mailbox` PluginAPI field is populated for plugins like
@@ -1367,93 +1224,18 @@ export async function main(argv: string[]): Promise<number> {
     );
   }
 
-  // ── Tech-stack mailbox consumer: auto-spawn agent on dep-watcher messages ──
-  // When dep-watcher posts assign messages to the mailbox, this consumer
-  // polls for them and spawns a tech-stack subagent to audit versions.
-  let techStackConsumerDispose: (() => void) | undefined;
-  if (dwCfg?.['enabled'] === true) {
-    try {
-      const projectDir = path.join(wpaths.globalRoot, 'projects', wpaths.projectSlug);
-      const tsMailbox = new GlobalMailbox(projectDir, events);
-      const fileAuthorOpts: FileAuthorTrackerOptions = {
-        storageDir: projectDir,
-        projectRoot,
-      };
-      techStackConsumerDispose = startTechStackConsumer({
-        mailbox: tsMailbox,
-        onSpawn: async (task, name) => {
-          return multiAgentHost.spawn(task, { name, tools: ['read', 'fetch', 'mailbox'] });
-        },
-        targetAgent: (dwCfg['targetAgent'] as string) ?? 'tech-stack',
-        consumerAgentId: 'tech-stack-consumer',
-        pollIntervalMs: (dwCfg['pollIntervalMs'] as number) ?? 5000,
-        fileAuthorOpts,
-        sessionId: session.id,
-        currentAgentId: 'leader',
-        currentAgentName: 'Leader',
-        onLog: (msg) => logger.debug(msg),
-        onError: (err) =>
-          logger.warn(
-            `Tech-stack consumer error: ${err instanceof Error ? err.message : String(err)}`,
-          ),
-      });
-      logger.info(
-        'Tech-stack mailbox consumer started — will auto-spawn agents on dependency changes',
-      );
-    } catch (err) {
-      logger.warn(`Failed to start tech-stack consumer: ${err}`);
-    }
-  }
-
-  // ── Package outdated watcher: notify original authors when packages are outdated ──
-  // When the tech-stack agent posts outdated-package results to the mailbox,
-  // this watcher looks up who originally added each package and notifies them.
-  let pkgOutdatedDispose: (() => void) | undefined;
-  if (dwCfg?.['enabled'] === true) {
-    try {
-      const projectDir = path.join(wpaths.globalRoot, 'projects', wpaths.projectSlug);
-      const pkgMailbox = new GlobalMailbox(projectDir, events);
-      const pkgTrackerOpts: Pick<PackageAuthorTrackerOptions, 'storageDir' | 'projectRoot'> = {
-        storageDir: projectDir,
-        projectRoot,
-      };
-      pkgOutdatedDispose = startPackageOutdatedWatcher({
-        mailbox: pkgMailbox,
-        packageTrackerOpts: pkgTrackerOpts,
-        pollIntervalMs: (dwCfg['pollIntervalMs'] as number) ?? 60 * 60 * 1000, // 1 hour default
-        watcherAgentId: 'pkg-outdated-watcher',
-        onNotify: async (msg) => {
-          await pkgMailbox.send({
-            from: msg.from,
-            to: msg.to,
-            type: 'note',
-            subject: msg.subject,
-            body: msg.body,
-            priority: msg.priority,
-          });
-        },
-        onLog: (m) => logger.debug(m),
-        onError: (err) =>
-          logger.warn(
-            `Pkg-outdated-watcher error: ${err instanceof Error ? err.message : String(err)}`,
-          ),
-      });
-      logger.info(
-        'Package outdated watcher started — will notify agents when their added packages are outdated',
-      );
-    } catch (err) {
-      logger.warn(`Failed to start package outdated watcher: ${err}`);
-    }
-  }
-
-  if (pkgOutdatedDispose) {
-    teardownHandlers.push(pkgOutdatedDispose);
-  }
-
-  // Clean up tech-stack consumer on teardown
-  if (techStackConsumerDispose) {
-    teardownHandlers.push(techStackConsumerDispose);
-  }
+  // Dep-watcher consumers (tech-stack + package-outdated) — extracted to wiring/dep-watcher.ts
+  setupDepWatcherConsumers({
+    dwCfg,
+    globalRoot: wpaths.globalRoot,
+    projectSlug: wpaths.projectSlug,
+    events,
+    multiAgentHost,
+    sessionId: session.id,
+    logger,
+    teardownHandlers,
+    projectRoot,
+  });
 
   if (directorMode) {
     // Eagerly build the director so its LLM-callable orchestration

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -541,7 +541,8 @@ export async function main(argv: string[]): Promise<number> {
     buildProviderForId,
     switchProviderAndModel,
   } = setupProviderRuntime({
-    config: { current: config },
+    config,
+    onConfigUpdate: (newConfig) => { config = newConfig; },
     configStore,
     providerRegistry,
     agent,

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -43,19 +43,16 @@ import {
   mailboxSessionTag,
   ParallelEternalEngine,
   type LogLevel,
-  SessionMemoryConsolidator,
   SddRunRegistry,
   type SystemPromptBuilder,
   TOKENS,
   ToolRegistry,
-  watchProviderConfig,
   writeErr,
   writeOut,
   getToolDescriptionMode,
 } from '@wrongstack/core';
 import { wireSessionEvents } from './session-event-wiring.js';
 import { initializeCli } from './cli-context.js';
-import { toErrorMessage } from '@wrongstack/core/utils/error';
 import { createAuthPanelHost } from './auth-menu/panel-service.js';
 import { createAutoPhaseHost } from './autophase-host.js';
 import { registerBuiltinTools } from './boot/tool-registry.js';
@@ -64,7 +61,6 @@ import { promptRecovery } from './cli-recovery-prompt.js';
 import { bindSystemPromptBuilder } from './boot/system-prompt-builder.js';
 import { refreshRuntimeModelCatalog } from './context-limit.js';
 import { type ExecutionDeps, execute } from './execution.js';
-import { createFallbackModelExtension } from './fallback-model.js';
 import { createCliHqPublisher } from './hq-publisher.js';
 import { PLUGIN_AUDIT_ENTRIES, runPluginManagementCommand } from './plugin-management.js';
 import { buildPickableProviders } from './provider-helpers.js';
@@ -93,6 +89,7 @@ import { setupHqTelemetry } from './wiring/hq-telemetry.js';
 import { setupDirectorAndAutonomy } from './wiring/director-setup.js';
 import { setupLifecycleAndPlugins } from './wiring/lifecycle-plugins.js';
 import { setupBrainAndOrchestration } from './wiring/brain-and-orchestration.js';
+import { setupProviderRuntime } from './wiring/provider-runtime-setup.js';
 import { setupMetrics } from './wiring/metrics.js';
 import { setupPipelines } from './wiring/pipeline.js';
 import {
@@ -538,140 +535,28 @@ export async function main(argv: string[]): Promise<number> {
     teardownHandlers.push(depWatcherDispose);
   }
 
-  // Resolve a provider id (alias-resolved via `providers[id].type`) to the
-  // concrete provider id + the runtime ProviderConfig used to build it and to
-  // refresh the context-window denominator. Single source of truth so the
-  // `/model` switch and the fallback extension can't drift apart.
-  //
-  // The actual logic lives in `./wiring/provider-runtime.js` so it can be
-  // unit-tested directly without spinning up the full CLI. Bug-fix history:
-  // prior to this refactor, `resolveProviderCfg` collapsed `savedCfg.type`
-  // into the returned id, so `buildProviderForId('minimax-coding-plan')`
-  // (where the saved config has `type: 'anthropic'`) produced a Provider
-  // with `id === 'anthropic'` instead of the user's chosen id. The startup
-  // path in `wiring/provider.ts` already does the right thing; this
-  // runtime path now mirrors it.
-  const resolveProviderCfg = (providerId: string) => resolveProviderCfgRuntime(config, providerId);
-
-  // Construct a credential-resolved Provider for a provider id, WITHOUT
-  // persisting anything. Shared by the `/model` switch and the fallback
-  // extension. The returned Provider's `id` is always the user-visible
-  // `providerId`.
-  const buildProviderForId = (providerId: string): import('@wrongstack/core').Provider =>
-    buildProviderForIdRuntime({ config, providerRegistry }, providerId);
-
-  // Refresh the auto-compaction / context-chip denominator for a (provider,
-  // model) pair. Used by both the `/model` switch and the fallback extension so
-  // a switch to a smaller-window model recomputes thresholds.
-  const refreshMaxContextFor = async (providerId: string, modelId: string): Promise<void> => {
-    const { cfg } = resolveProviderCfg(providerId);
-    await refreshMaxContext(providerId, modelId, cfg);
-  };
-  const refreshRuntimeModelStateFor = async (
-    providerId: string,
-    modelId: string,
-  ): Promise<void> => {
-    await refreshMaxContextFor(providerId, modelId);
-    await refreshActiveReasoningConfig(providerId, modelId);
-  };
-
-  // Cross-provider fallback: switch to the next configured model when the
-  // primary is overloaded (429/529/5xx). Registered unconditionally — the
-  // effective chain (explicit `fallbackModels` or the smart default) is
-  // recomputed every turn, so a chain populated at runtime via `/fallback`
-  // takes effect without a restart. An empty chain makes it a no-op.
-  agent.extensions.register(
-    createFallbackModelExtension({
-      getConfig: () => config,
-      buildProvider: buildProviderForId,
-      onModelSwitch: refreshRuntimeModelStateFor,
-      events,
-      logger,
-    }),
-  );
-
-  // Session-end memory consolidation — extracts key learnings from the
-  // completed session and persists them as memory entries.
-  if (config.features.memory && config.features.memoryConsolidation !== false) {
-    agent.extensions.register(
-      new SessionMemoryConsolidator({
-        memoryStore,
-      }),
-    );
-  }
-
-  // Build provider+model switch as a single callback. The TUI picker
-  // calls this after the user confirms a (provider, model) pair; we
-  // construct a fresh Provider instance, swap it onto the live context,
-  // and rebuild the frozen config so other consumers see the new ids.
-  const switchProviderAndModel = async (
-    providerId: string,
-    modelId: string,
-  ): Promise<string | null> => {
-    try {
-      context.provider = buildProviderForId(providerId);
-      context.model = modelId;
-      config = patchConfig(config, { provider: providerId, model: modelId });
-      // L1-B: propagate the change to the ConfigStore so any subsystem
-      // that subscribed via .watch() re-renders. Crucially, /diag now
-      // reads the live provider via the store.
-      configStore.update({ provider: providerId, model: modelId });
-      // Refresh AutoCompactionMiddleware denominator for the new model's
-      // maxContext so threshold triggers (warn/soft/hard) use the correct denominator.
-      await refreshMaxContextFor(providerId, modelId);
-      // Re-resolve the new model's reasoning capability so the model-runtime
-      // middleware stops gating on a stale (or missing) profile. Without this,
-      // a switch to a model that isn't in the registry leaves the warning
-      // "reasoning capabilities are unknown" firing on every subsequent
-      // request until restart.
-      await refreshActiveReasoningConfig(providerId, modelId);
-      return null;
-    } catch (err) {
-      return err instanceof Error ? err.message : String(err);
-    }
-  };
-
-  // Hot-reload provider credentials: when `config.json`'s providers/apiKey/
-  // baseUrl slice changes on disk (from another terminal's `wstack auth`, a
-  // WebUI provider panel, or a manual edit), re-read it and rebuild the active
-  // provider live so a running session picks up the new key without restart.
-  // The watcher's own no-op guard suppresses self-induced writes (our `/model`
-  // switch, key edits in this same process), so there is no rebuild storm.
-  // Escape hatch: WRONGSTACK_DISABLE_CONFIG_WATCH=1 (unreliable network FS).
-  if (process.env['WRONGSTACK_DISABLE_CONFIG_WATCH'] !== '1') {
-    const credentialWatcher = watchProviderConfig(
-      wpaths.globalConfig,
-      vault,
-      (snapshot) => {
-        // Capture the active provider's resolved cfg before the merge so we
-        // only rebuild when *its* credentials actually changed.
-        const activeId = config.provider;
-        const before = JSON.stringify(resolveProviderCfg(activeId).cfg);
-        config = patchConfig(config, {
-          providers: snapshot.providers,
-          ...(snapshot.apiKey !== undefined ? { apiKey: snapshot.apiKey } : {}),
-          ...(snapshot.baseUrl !== undefined ? { baseUrl: snapshot.baseUrl } : {}),
-        });
-        // Propagate to the ConfigStore so `.watch()` subscribers re-render.
-        configStore.update({
-          providers: snapshot.providers,
-          ...(snapshot.apiKey !== undefined ? { apiKey: snapshot.apiKey } : {}),
-          ...(snapshot.baseUrl !== undefined ? { baseUrl: snapshot.baseUrl } : {}),
-        });
-        const after = JSON.stringify(resolveProviderCfg(activeId).cfg);
-        if (after === before) return; // active provider's creds unchanged
-        try {
-          context.provider = buildProviderForId(activeId);
-          logger.info(`Provider credentials reloaded from config.json (${activeId})`);
-        } catch (err) {
-          // Keep the existing provider on a bad rebuild (e.g. removed family).
-          logger.warn(`Credential hot-reload failed for ${activeId}: ${toErrorMessage(err)}`);
-        }
-      },
-      { warn: (msg) => logger.warn(`Config watcher: ${msg}`) },
-    );
-    teardownHandlers.push(() => credentialWatcher.close());
-  }
+  // ── Provider runtime helpers + fallback + switch + credential watcher ──
+  // Extracted to wiring/provider-runtime-setup.ts.
+  const {
+    buildProviderForId,
+    switchProviderAndModel,
+  } = setupProviderRuntime({
+    config: { current: config },
+    configStore,
+    providerRegistry,
+    agent,
+    memoryStore,
+    refreshMaxContext,
+    refreshActiveReasoningConfig,
+    wpaths,
+    vault,
+    logger,
+    teardownHandlers,
+    context,
+    events,
+    resolveProviderCfgRuntime,
+    buildProviderForIdRuntime,
+  });
 
   // Director / autonomy mode, fleet paths, eternal-engine scaffolding,
   // Agent Monitor — extracted to wiring/director-setup.ts.

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -46,10 +46,6 @@ import {
   FLEET_ROSTER,
   gatedEnhancerReasoning,
   GlobalMailbox,
-  HookRegistry,
-  HookRunner,
-  countShellHooks,
-  shellHooksEqual,
   HumanEscalatingBrainArbiter,
   isStdinTTY,
   loadDirectorState,
@@ -59,19 +55,16 @@ import {
   type LogLevel,
   SessionMemoryConsolidator,
   SddRunRegistry,
-  SlashCommandRegistry,
   type SystemPromptBuilder,
   TOKENS,
   ToolRegistry,
   watchProviderConfig,
   writeErr,
   writeOut,
-  normalizeTokenSavingTier,
   getToolDescriptionMode,
 } from '@wrongstack/core';
 import { wireSessionEvents } from './session-event-wiring.js';
 import { initializeCli } from './cli-context.js';
-import { MCPRegistry } from '@wrongstack/mcp';
 import { toErrorMessage } from '@wrongstack/core/utils/error';
 import { createAuthPanelHost } from './auth-menu/panel-service.js';
 import { createAutoPhaseHost } from './autophase-host.js';
@@ -80,13 +73,11 @@ import { launchEternalFromFlag } from './cli-eternal-flag.js';
 import { promptRecovery } from './cli-recovery-prompt.js';
 import { bindSystemPromptBuilder } from './boot/system-prompt-builder.js';
 import { subscribeBrainDecisionLog } from './boot/brain-decision-log.js';
-import { refreshRuntimeModelCatalog, resolveRuntimeMaxContext } from './context-limit.js';
+import { refreshRuntimeModelCatalog } from './context-limit.js';
 import { type ExecutionDeps, execute } from './execution.js';
 import { createFallbackModelExtension } from './fallback-model.js';
 import { createCliHqPublisher } from './hq-publisher.js';
-import { createLifecycleHooksExtension, createUserPromptSubmitMiddleware } from './hooks-wiring.js';
 import { MultiAgentHost } from './multi-agent.js';
-import { makeConfirmAwaiter } from './permission-prompt.js';
 import { PLUGIN_AUDIT_ENTRIES, runPluginManagementCommand } from './plugin-management.js';
 import { buildPickableProviders } from './provider-helpers.js';
 import { SessionStats } from './session-stats.js';
@@ -112,14 +103,13 @@ import { setupCodebaseIndexing } from './wiring/codebase-index.js';
 import { setupDepWatcherConsumers } from './wiring/dep-watcher.js';
 import { setupHqTelemetry } from './wiring/hq-telemetry.js';
 import { setupDirectorAndAutonomy } from './wiring/director-setup.js';
+import { setupLifecycleAndPlugins } from './wiring/lifecycle-plugins.js';
 import { setupMetrics } from './wiring/metrics.js';
-import { createAgent, setupCompaction, setupPipelines } from './wiring/pipeline.js';
-import { installDesignStudio } from './wiring/design-studio.js';
+import { setupPipelines } from './wiring/pipeline.js';
 import {
   buildProviderForId as buildProviderForIdRuntime,
   resolveProviderCfg as resolveProviderCfgRuntime,
 } from './wiring/provider-runtime.js';
-import { setupPlugins } from './wiring/plugins.js';
 import { setupSession } from './wiring/session.js';
 import { resolveModeAndCapabilities } from './boot/system-prompt.js';
 import { wireEventWiring } from './boot/event-wiring.js';
@@ -487,251 +477,44 @@ export async function main(argv: string[]): Promise<number> {
     },
   });
 
-  // ── Lifecycle hooks ──────────────────────────────────────────────────────
-  // `--no-hooks` disables everything (shell + in-process). Otherwise shell
-  // hooks are loaded from `config.hooks`; plugins add in-process hooks via
-  // `api.registerHook`. The runner is wired into the tool executor
-  // (PreToolUse/PostToolUse), the userInput pipeline (UserPromptSubmit), and an
-  // agent extension (SessionStart/Stop, registered after the agent is built).
-  const hooksEnabled = flags['no-hooks'] !== true;
-  const hookRegistry = new HookRegistry();
-  if (hooksEnabled) hookRegistry.loadShellHooks(config.hooks);
-  container.bind(TOKENS.HookRegistry, () => hookRegistry);
-  const hookRunner = new HookRunner({
-    registry: hookRegistry,
+  // ── Lifecycle hooks → compaction → agent → MCP → plugins ─────────────
+  // Extracted to wiring/lifecycle-plugins.ts.
+  const {
+    autoCompactor,
+    effectiveMaxContextRef,
+    applyMaxContext,
+    refreshMaxContext,
+    agent,
+    mcpRegistry,
+    slashRegistry,
+    hqPublisherRef,
+    brainMailbox,
+  } = await setupLifecycleAndPlugins({
+    flags,
+    config,
+    container,
+    pipelines,
     logger,
-    allowShell: hooksEnabled,
-    sessionId: () => session.id,
-  });
-  if (hooksEnabled) {
-    pipelines.userInput.use(createUserPromptSubmitMiddleware(hookRunner));
-
-    // Hot-reload shell hooks when `config.hooks` changes at runtime
-    // (via `/config` slash command, programmatic `configStore.update`,
-    // or external file edits that the config store picks up). We compare
-    // shallowly per event — `ShellHook[]` is reference-stable and its
-    // fields (command, matcher, timeoutMs) are primitives, so a per-event
-    // array comparison is sufficient and avoids re-running on unrelated
-    // config changes (model, log level, etc.).
-    configStore.watch((next, prev) => {
-      if (!shellHooksEqual(next.hooks, prev.hooks)) {
-        try {
-          hookRegistry.replaceShellHooks(next.hooks);
-          logger.info(
-            `Shell hooks reloaded (${countShellHooks(next.hooks)} entries across ${
-              Object.keys(next.hooks ?? {}).length
-            } events)`,
-          );
-        } catch (err) {
-          // A failed reload must not crash the config watcher — keep the
-          // existing hook set in place and log so the operator can see it.
-          logger.warn(`Hook hot-reload failed: ${toErrorMessage(err)}`);
-        }
-      }
-    });
-  }
-
-  // Design Studio — per-turn UI-intent detection + kit-menu injection. Installed
-  // after the live Context + pipelines exist; the `design` tool itself ships in
-  // the builtin pack independently of this.
-  installDesignStudio({ pipelines, context });
-
-  const compactor = container.resolve(TOKENS.Compactor);
-  const compactionSetup = await setupCompaction({
-    compactor,
+    session,
     events,
     modelsRegistry,
     context,
-    config,
     provider,
-    pipelines,
-    fullConfig: config as never as Parameters<typeof setupCompaction>[0]['fullConfig'],
-    sessionBridge, // share the same bridge for consistent audit logging (compaction + errors + future)
-  });
-  let effectiveMaxContext = compactionSetup.effectiveMaxContext;
-  context.provider.capabilities.maxContext = effectiveMaxContext;
-  modelCapabilitiesRef.current =
-    effectiveMaxContext > 0
-      ? {
-          maxContextTokens: effectiveMaxContext,
-          supportsTools: !!context.provider.capabilities.tools,
-          supportsVision: !!context.provider.capabilities.vision,
-          supportsReasoning: !!context.provider.capabilities.reasoning,
-        }
-      : undefined;
-  const { autoCompactor } = compactionSetup;
-
-  // Refresh the active model's context denominator when provider/model changes.
-  // This feeds auto-compaction, the leader context chip, and Director spawn guards.
-  let maxContextRefreshSeq = 0;
-  const applyMaxContext = (
-    providerId: string,
-    modelId: string,
-    mc: number,
-    seq?: number | undefined,
-  ): void => {
-    if (seq !== undefined && seq !== maxContextRefreshSeq) return;
-    effectiveMaxContext = mc;
-    context.provider.capabilities.maxContext = effectiveMaxContext; // may be 0 (unknown)
-    modelCapabilitiesRef.current =
-      effectiveMaxContext > 0
-        ? {
-            maxContextTokens: effectiveMaxContext,
-            supportsTools: !!context.provider.capabilities.tools,
-            supportsVision: !!context.provider.capabilities.vision,
-            supportsReasoning: !!context.provider.capabilities.reasoning,
-          }
-        : undefined;
-    if (effectiveMaxContext > 0) {
-      context.meta['effectiveMaxContext'] = effectiveMaxContext;
-      autoCompactor?.setMaxContext(effectiveMaxContext);
-      autoCompactor?.setEnabled(config.context.autoCompact !== false);
-    } else {
-      delete context.meta['effectiveMaxContext'];
-      autoCompactor?.setEnabled(false);
-    }
-    events.emit('ctx.max_context', {
-      sessionId: context.session.id,
-      providerId,
-      modelId,
-      maxContext: effectiveMaxContext,
-    });
-    eventWiring.setEffectiveMaxContext(effectiveMaxContext);
-  };
-
-  const refreshMaxContext = async (
-    providerId: string,
-    modelId: string,
-    runtimeProviderConfig?: import('@wrongstack/core').ProviderConfig | undefined,
-  ) => {
-    const seq = ++maxContextRefreshSeq;
-    const resolveAndApply = async (): Promise<void> => {
-      const mc = await resolveRuntimeMaxContext({
-        modelsRegistry,
-        config,
-        provider: context.provider,
-        runtimeProviderConfig,
-        providerId,
-        modelId,
-      });
-      applyMaxContext(providerId, modelId, mc, seq);
-    };
-
-    // Apply the best-known cached value immediately, then refresh the catalog
-    // and re-apply. Model metadata (especially context windows) changes after
-    // release; model switches should converge to current catalog data without
-    // blocking the TUI picker or fallback path.
-    await resolveAndApply();
-    const refreshed = await refreshRuntimeModelCatalog({
-      modelsRegistry,
-      logger,
-      reason: `${providerId}/${modelId}`,
-    });
-    if (refreshed) await resolveAndApply();
-  };
-
-  const agent = createAgent({
-    container,
-    tools: toolRegistry,
-    providers: providerRegistry,
-    events,
-    pipelines,
-    context,
-    config,
-    confirmAwaiter: makeConfirmAwaiter(reader),
-    hookRunner,
-    fullConfig: config,
-    source: 'cli',
-  });
-
-  // SessionStart / Stop lifecycle hooks (PreToolUse/PostToolUse live in the
-  // tool executor; UserPromptSubmit in the userInput pipeline above).
-  if (hooksEnabled) {
-    agent.extensions.register(createLifecycleHooksExtension(hookRunner));
-  }
-
-  // MCP servers — lazy mode in token-saving mode (connect but don't register tools)
-  const mcpRegistry = new MCPRegistry({
-    toolRegistry,
-    events,
-    log: logger,
-    lazyMode: normalizeTokenSavingTier(config.features.tokenSavingMode) !== 'off',
-    // Lazy-connect (per-server `lazy`) needs a manifest cache to register tools
-    // cold; idle auto-sleep uses the default timeout.
-    cacheDir: wpaths.cacheDir,
-  });
-  if (config.features.mcp) {
-    const presets = allServers();
-    for (const cfg of Object.values(config.mcpServers ?? {})) {
-      // Merge stored config with built-in preset so new fields (e.g.
-      // `passthroughEnv`) added to presets after the config was last saved
-      // are picked up automatically without requiring a manual config update.
-      const preset = presets[cfg.name];
-      const merged = preset ? { ...preset, ...cfg } : cfg;
-      try {
-        await mcpRegistry.start(merged);
-      } catch (err) {
-        logger.warn(`MCP server "${cfg.name}" failed to start`, err);
-      }
-    }
-  }
-
-  // Slash registry — created before plugins so plugins can register commands.
-  const slashRegistry = new SlashCommandRegistry();
-
-  // Project mailbox — created before setupPlugins so the new
-  // `api.mailbox` PluginAPI field is populated for plugins like
-  // `todo-listener` that publish cross-agent status updates.
-  // (Constructor is side-effect-free; the instance is harmless until
-  //  the first send/heartbeat call.)
-  // Mutable ref populated by setupHqTelemetry once the HQ connection
-  // establishes — brainMailbox reads it via closure for HQ publishing.
-  const hqPublisherRef: { current: any | undefined } = { current: undefined };
-  const brainMailbox = new GlobalMailbox(wpaths.projectDir, events, () => hqPublisherRef.current);
-
-  // Plugins — extracted to wiring/plugins.ts
-  await setupPlugins({
-    config,
-    container,
-    events,
-    pipelines,
+    modelCapabilitiesRef,
+    reader,
+    wpaths,
     toolRegistry,
     providerRegistry,
-    slashCommandRegistry: slashRegistry,
-    mcpRegistry,
-    log: logger,
-    agent: agent,
-    sessionWriter: context.session,
-    metricsSink,
-    modelsRegistry,
-    healthRegistry,
-    skillLoader: config.features.skills ? skillLoader : undefined,
-    promptLoader: config.features.prompts === false ? undefined : promptLoader,
     configStore,
+    sessionBridge,
+    eventWiring,
+    healthRegistry: healthRegistry as any,
+    skillLoader,
+    promptLoader,
     vault,
-    paths: {
-      globalRoot: wpaths.globalRoot,
-      globalConfig: wpaths.globalConfig,
-      globalSkills: wpaths.globalSkills,
-      globalPrompts: wpaths.globalPrompts,
-      globalMemory: wpaths.globalMemory,
-      historyFile: wpaths.historyFile,
-      syncConfig: wpaths.syncConfig,
-      projectDir: wpaths.projectDir,
-      projectGoal: wpaths.projectGoal,
-    },
-    hookRegistry,
-    mailbox: brainMailbox,
-    // api.llm — plugins get LLM access through the host's provider layer.
-    // Default = the session's live provider/model; a named override goes
-    // through buildProviderForId (same alias-safe path as /model switch).
-    // The model itself travels in each Request, so the factory ignores it.
-    llm: {
-      provider,
-      model: config.model,
-      createProvider: (name: string) =>
-        buildProviderForIdRuntime({ config, providerRegistry }, name),
-    },
+    metricsSink,
+    renderer,
+    buildProviderForIdRuntime,
   });
 
   // ── Dep-watcher bridge: wire file-watcher events into the mailbox ────
@@ -1064,7 +847,7 @@ export async function main(argv: string[]): Promise<number> {
       stateCheckpointPath,
       sessionWriter: session,
       maxConcurrent,
-      getLeaderMaxContext: () => effectiveMaxContext,
+      getLeaderMaxContext: () => effectiveMaxContextRef.current,
       brain,
       agentMonitor,
       traceId: sessResult.traceId,
@@ -1929,7 +1712,7 @@ export async function main(argv: string[]): Promise<number> {
     },
     onContextLimit: (tokens?: number) => {
       if (typeof tokens === 'number' && Number.isFinite(tokens) && tokens > 0) {
-        effectiveMaxContext = tokens;
+        effectiveMaxContextRef.current = tokens;
         context.provider.capabilities.maxContext = tokens;
         context.meta['effectiveMaxContext'] = tokens;
         autoCompactor?.setMaxContext(tokens);
@@ -1941,7 +1724,7 @@ export async function main(argv: string[]): Promise<number> {
         });
         eventWiring.setEffectiveMaxContext(tokens);
       }
-      return effectiveMaxContext;
+      return effectiveMaxContextRef.current;
     },
     onMcp: async (args) => {
       const parsed = parseMcpArgs(args);
@@ -2002,7 +1785,7 @@ export async function main(argv: string[]): Promise<number> {
             agent,
             projectRoot,
             compactor: container.resolve(TOKENS.Compactor) as import('@wrongstack/core').Compactor,
-            maxContextTokens: effectiveMaxContext > 0 ? effectiveMaxContext : undefined,
+            maxContextTokens: effectiveMaxContextRef.current > 0 ? effectiveMaxContextRef.current : undefined,
             onIteration: broadcastEternalIteration,
             onStage: broadcastAutonomyStage,
             // Real per-role factory: each dispatched slot runs as a fresh,
@@ -2020,7 +1803,7 @@ export async function main(argv: string[]): Promise<number> {
             agent,
             projectRoot,
             compactor: container.resolve(TOKENS.Compactor) as import('@wrongstack/core').Compactor,
-            maxContextTokens: effectiveMaxContext > 0 ? effectiveMaxContext : undefined,
+            maxContextTokens: effectiveMaxContextRef.current > 0 ? effectiveMaxContextRef.current : undefined,
             onIteration: broadcastEternalIteration,
             onStage: broadcastAutonomyStage,
             brain,
@@ -2409,7 +2192,7 @@ export async function main(argv: string[]): Promise<number> {
     container,
     renderer,
     broadcastEternalIteration,
-    effectiveMaxContext,
+    effectiveMaxContext: effectiveMaxContextRef.current,
     configRef,
     autonomyModeRef,
   });
@@ -2518,8 +2301,8 @@ export async function main(argv: string[]): Promise<number> {
     projectRoot,
     flags,
     positional,
-    effectiveMaxContext,
-    getEffectiveMaxContext: () => effectiveMaxContext,
+    effectiveMaxContext: effectiveMaxContextRef.current,
+    getEffectiveMaxContext: () => effectiveMaxContextRef.current,
     queueStore,
     context,
     stats,

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -41,7 +41,6 @@ import {
   createMcpControlTool,
   createTieredBrainArbiter,
   DefaultBrainArbiter,
-  type Director,
   EternalAutonomyEngine,
   expectDefined,
   FLEET_ROSTER,
@@ -73,7 +72,6 @@ import {
 import { wireSessionEvents } from './session-event-wiring.js';
 import { initializeCli } from './cli-context.js';
 import { MCPRegistry } from '@wrongstack/mcp';
-import { sessionScopedPath } from '@wrongstack/core/utils';
 import { toErrorMessage } from '@wrongstack/core/utils/error';
 import { createAuthPanelHost } from './auth-menu/panel-service.js';
 import { createAutoPhaseHost } from './autophase-host.js';
@@ -88,7 +86,6 @@ import { createFallbackModelExtension } from './fallback-model.js';
 import { createCliHqPublisher } from './hq-publisher.js';
 import { createLifecycleHooksExtension, createUserPromptSubmitMiddleware } from './hooks-wiring.js';
 import { MultiAgentHost } from './multi-agent.js';
-import { createAgentMonitorService } from '@wrongstack/core/coordination';
 import { makeConfirmAwaiter } from './permission-prompt.js';
 import { PLUGIN_AUDIT_ENTRIES, runPluginManagementCommand } from './plugin-management.js';
 import { buildPickableProviders } from './provider-helpers.js';
@@ -114,6 +111,7 @@ import { CLI_VERSION } from './version.js';
 import { setupCodebaseIndexing } from './wiring/codebase-index.js';
 import { setupDepWatcherConsumers } from './wiring/dep-watcher.js';
 import { setupHqTelemetry } from './wiring/hq-telemetry.js';
+import { setupDirectorAndAutonomy } from './wiring/director-setup.js';
 import { setupMetrics } from './wiring/metrics.js';
 import { createAgent, setupCompaction, setupPipelines } from './wiring/pipeline.js';
 import { installDesignStudio } from './wiring/design-studio.js';
@@ -903,134 +901,35 @@ export async function main(argv: string[]): Promise<number> {
     teardownHandlers.push(() => credentialWatcher.close());
   }
 
-  // L1-E: lazily-instantiated multi-agent host. Wired into /spawn and
-  // /agents slash commands; constructed on first invocation so users
-  // who never spawn subagents pay nothing.
-  //
-  // `--director` upgrades the host to Director mode — same external API,
-  // but task lifecycle flows through a `Director` so manifest writing
-  // works and the FleetBus is available for observability hooks. Manifest
-  // path defaults to `<projectSessions>/<date>/sess_<ULID>/fleet.json`; users can
-  // override via `WRONGSTACK_FLEET_MANIFEST` if they want a fixed path.
-  const directorMode = flags['director'] === true || typeof flags['resume'] === 'string';
-  // Concurrent subagent ceiling. Priority: CLI flag → env var → config → default (4).
-  // Caps how many delegated tasks the coordinator dispatches at once;
-  // extra tasks queue. Keeps the leader from spawning enough parallel
-  // subagents to trip provider rate limits. Persist a default in config.json
-  // via `maxConcurrent` or change live with /fleet concurrency <n>.
-  const maxConcurrentFromFlag =
-    typeof flags['max-concurrent'] === 'string'
-      ? Number.parseInt(flags['max-concurrent'], 10)
-      : undefined;
-  const maxConcurrentFromEnv =
-    typeof process.env['WRONGSTACK_MAX_CONCURRENT'] === 'string'
-      ? Number.parseInt(process.env['WRONGSTACK_MAX_CONCURRENT'], 10)
-      : undefined;
-  const maxConcurrentFromConfig =
-    typeof config.maxConcurrent === 'number' && config.maxConcurrent > 0
-      ? config.maxConcurrent
-      : undefined;
-  const maxConcurrent =
-    Number.isFinite(maxConcurrentFromFlag) && (maxConcurrentFromFlag as number) > 0
-      ? (maxConcurrentFromFlag as number)
-      : Number.isFinite(maxConcurrentFromEnv) && (maxConcurrentFromEnv as number) > 0
-        ? (maxConcurrentFromEnv as number)
-        : Number.isFinite(maxConcurrentFromConfig) && (maxConcurrentFromConfig as number) > 0
-          ? (maxConcurrentFromConfig as number)
-          : undefined;
-  let director: Director | null = null;
-  // Autonomy mode: 'off' (default), 'suggest' (show next steps), 'auto' (self-driving)
-  // Initial value can be pinned via the launch prompt (or `--autonomy <mode>`),
-  // which sets `flags['autonomy']` before we wire up. Keep the ref in sync
-  // so the autonomy prompt contributor sees the same value from turn 1.
-  let autonomyMode: import('./slash-commands/autonomy.js').AutonomyMode = (() => {
-    const v = flags['autonomy'];
-    if (v === 'auto' || v === 'suggest' || v === 'eternal' || v === 'eternal-parallel') return v;
-    // An explicit 'off' (e.g. --no-autonomy, or the non-interactive guard in
-    // boot.ts) is honored as a user/system opt-out. Only when the flag is
-    // genuinely unset do we fall back to the configured default mode (now
-    // 'auto'), so launches that don't pin a mode self-drive by default.
-    if (v === 'off') return 'off';
-    return (config.autonomy?.defaultMode ??
-      'off') as import('./slash-commands/autonomy.js').AutonomyMode;
-  })();
-  autonomyModeRef.current = autonomyMode;
-  // Next-task prediction toggle — persisted in config so it survives restarts.
-  // Read/written via `onNextPredict`, read by the REPL via `getNextPredict`.
-  let nextPredictEnabled = config.nextPrediction === true;
-  // Suggestion list for /next selection — ephemeral, cleared each cycle.
-  // Read/written via `onSuggestions`.
-  let currentSuggestions: string[] = [];
-  // Eternal-autonomy engine instance — lazy, created when /autonomy eternal is invoked.
-  // Lives at function scope so /autonomy stop and SIGINT handlers can reach it.
-  let eternalEngine: import('@wrongstack/core').EternalAutonomyEngine | null = null;
-  // Parallel-eternal engine instance — lazy, created when /autonomy parallel is invoked.
-  let parallelEngine: import('@wrongstack/core').ParallelEternalEngine | null = null;
-  // Listeners installed by the TUI / REPL to receive per-iteration events
-  // from the engine. We support a list (not a single callback) so both
-  // surfaces can subscribe without overwriting each other — TUI installs
-  // one on mount, but the underlying engine is owned at CLI scope.
-  const eternalListeners = new Set<(entry: import('@wrongstack/core').JournalEntry) => void>();
-  const broadcastEternalIteration = (entry: import('@wrongstack/core').JournalEntry): void => {
-    for (const fn of eternalListeners) {
-      try {
-        fn(entry);
-      } catch {
-        // listener failures must never break the engine — swallow
-      }
-    }
-  };
-  const stageListeners = new Set<(stage: AutonomyStage) => void>();
-  const broadcastAutonomyStage = (stage: AutonomyStage): void => {
-    for (const fn of stageListeners) {
-      try {
-        fn(stage);
-      } catch {
-        // listener failures must never break the engine — swallow
-      }
-    }
-  };
-  // Convention: director artifacts all live under the same fleet root —
-  //   <projectSessions>/<date>/sess_<ULID>/
-  //     ├─ fleet.json              (manifest)
-  //     ├─ shared/                 (cross-agent scratchpad)
-  //     └─ subagents/              (per-subagent JSONL transcripts)
-  // The user can override the manifest path with WRONGSTACK_FLEET_MANIFEST
-  // but the scratchpad + transcripts always sit relative to the session.
-  const fleetRoot = directorMode
-    ? sessionScopedPath(wpaths.projectSessions, session.id, '')
-    : undefined;
-  const manifestPath = directorMode
-    ? typeof process.env['WRONGSTACK_FLEET_MANIFEST'] === 'string'
-      ? process.env['WRONGSTACK_FLEET_MANIFEST']
-      : path.join(expectDefined(fleetRoot), 'fleet.json')
-    : undefined;
-  const sharedScratchpadPath = directorMode
-    ? path.join(expectDefined(fleetRoot), 'shared')
-    : undefined;
-  const subagentSessionsRoot = directorMode
-    ? path.join(expectDefined(fleetRoot), 'subagents')
-    : undefined;
-  // Live director state checkpoint — written incrementally to disk on
-  // every spawn/assign/complete event so a crashed director leaves a
-  // recoverable snapshot. Distinct from manifestPath (final record).
-  const stateCheckpointPath = directorMode
-    ? path.join(expectDefined(fleetRoot), 'director-state.json')
-    : undefined;
-  // Always derive a fleetRoot for runtime promotion — /director needs
-  // a base dir to write manifest + scratchpad + per-subagent JSONLs into.
-  const fleetRootForPromotion = sessionScopedPath(wpaths.projectSessions, session.id, '');
-
-  // ── Agent Monitor — subagent conversation tracking ─────────────────────
-  // Creates the AgentMonitorService that listens to FleetBus events and
-  // maintains per-subagent virtual chat history + JSONL transcripts.
-  // The transcripts dir sits alongside the director's subagent sessions.
-  const agentMonitor = createAgentMonitorService({
+  // Director / autonomy mode, fleet paths, eternal-engine scaffolding,
+  // Agent Monitor — extracted to wiring/director-setup.ts.
+  let {
+    director,
+    directorMode,
+    maxConcurrent,
+    autonomyMode,
+    nextPredictEnabled,
+    currentSuggestions,
+    eternalEngine,
+    parallelEngine,
+    eternalListeners,
+    broadcastEternalIteration,
+    stageListeners,
+    broadcastAutonomyStage,
+    fleetRoot,
+    manifestPath,
+    sharedScratchpadPath,
+    subagentSessionsRoot,
+    stateCheckpointPath,
+    fleetRootForPromotion,
+    agentMonitor,
+  } = setupDirectorAndAutonomy({
+    flags,
+    config,
+    wpaths,
+    session,
     events,
-    sessionId: session.id,
-    transcriptsDir: path.join(fleetRootForPromotion, 'subagents', 'transcripts'),
-    maxEntriesPerAgent: 500,
-    streamEnabled: false,
+    autonomyModeRef,
   });
 
   // ── Global Brain chain — policy → LLM → human ──────────────────────────

--- a/packages/cli/src/input-reader.ts
+++ b/packages/cli/src/input-reader.ts
@@ -55,7 +55,10 @@ export class ReadlineInputReader implements InputReader {
     return this.rl;
   }
 
-  async readLine(prompt?: string): Promise<string> {
+  async readLine(
+    prompt?: string,
+    timeoutOpts?: { timeoutMs: number; defaultAnswer: string } | undefined,
+  ): Promise<string> {
     if (this.history.length === 0) await this.loadHistory();
     while (this.pending) {
       // Wait for the current read to settle before accepting another.
@@ -90,12 +93,29 @@ export class ReadlineInputReader implements InputReader {
       this.installPromptGuard(fresh);
       return new Promise<string>((resolve) => {
         let settled = false;
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
         const settle = (line: string): void => {
           if (settled) return;
           settled = true;
+          if (timeoutHandle) clearTimeout(timeoutHandle);
           setOutputLineGuard(null);
           resolve(line);
         };
+
+        // When a timeout is configured, auto-feed the default answer
+        // after `timeoutMs` milliseconds.  `fresh.write()` programmatically
+        // feeds the readline parser as if the user typed it — the question
+        // callback fires naturally and the default text appears on screen
+        // so the user sees what happened.
+        if (timeoutOpts) {
+          timeoutHandle = setTimeout(() => {
+            if (!settled) {
+              fresh.write(`${timeoutOpts.defaultAnswer}\n`);
+            }
+          }, timeoutOpts.timeoutMs);
+        }
+
         fresh.question(prompt ?? '> ', (line) => {
           if (line.trim()) {
             this.history.push(line);

--- a/packages/cli/src/pre-launch.ts
+++ b/packages/cli/src/pre-launch.ts
@@ -252,7 +252,10 @@ export async function runLaunchPrompts(opts: {
     );
 
     const answer = (
-      await reader.readLine(`  ${color.amber('?')} Continue with these? ${color.dim('[Y/n/q]')} `)
+      await reader.readLine(
+        `  ${color.amber('?')} Continue with these? ${color.dim('[Y/n/q]')} ${color.dim('(auto Y in 5s)')} `,
+        { timeoutMs: 5000, defaultAnswer: 'y' },
+      )
     )
       .trim()
       .toLowerCase();
@@ -526,10 +529,14 @@ export async function maybeAskAboutIndexing(opts: {
   renderer.write(
     `\n  ${color.dim('○')} Large codebase detected ${color.dim(`(~${fileCount}+ indexable files)`)}\n`,
   );
+  renderer.write(
+    `  ${color.amber('⚠')} ${color.dim('Codebase search requires indexing — skipped by default.')}\n`,
+  );
 
   const answer = (
     await reader.readLine(
-      `  ${color.amber('?')} Run codebase indexing now? ${color.dim('(needed for codebase-search) [Y/n/q]')} `,
+      `  ${color.amber('?')} Run codebase indexing now? ${color.dim('[n/Y/q]')} ${color.dim('(auto n in 5s)')} `,
+      { timeoutMs: 5000, defaultAnswer: 'n' },
     )
   )
     .trim()
@@ -541,11 +548,12 @@ export async function maybeAskAboutIndexing(opts: {
     return false;
   }
 
-  if (answer === 'n' || answer === 'no') {
+  // Default on timeout or explicit 'n': skip.
+  if (answer === 'n' || answer === 'no' || answer === '') {
     renderer.write(color.dim('  Skipping indexing for this session.\n'));
     return false;
   }
 
-  // Default: yes (empty input, 'y', 'yes', or anything else).
+  // 'y' or 'yes' means yes.
   return true;
 }

--- a/packages/cli/src/wiring/brain-and-orchestration.ts
+++ b/packages/cli/src/wiring/brain-and-orchestration.ts
@@ -35,15 +35,10 @@ export interface BrainOrchestrationDeps {
   session: SessionWriter;
   context: AnyObj;
   toolRegistry: ToolRegistry;
-  // biome-ignore lint/suspicious/noExplicitAny: many providers/registries
   providerRegistry: AnyObj;
-  // biome-ignore lint/suspicious/noExplicitAny: config store
   configStore: AnyObj;
-  // biome-ignore lint/suspicious/noExplicitAny: models registry
   modelsRegistry: AnyObj;
-  // biome-ignore lint/suspicious/noExplicitAny: prompt builder
   promptBuilder: AnyObj;
-  // biome-ignore lint/suspicious/noExplicitAny: token counter
   tokenCounter: AnyObj;
   projectRoot: string;
   cwd: string;
@@ -61,7 +56,6 @@ export interface BrainOrchestrationDeps {
   maxConcurrent: number | undefined;
   effectiveMaxContextRef: { current: number };
   mcpRegistry: AnyObj;
-  // biome-ignore lint/suspicious/noExplicitAny: session result
   sessResult: AnyObj;
 }
 

--- a/packages/cli/src/wiring/brain-and-orchestration.ts
+++ b/packages/cli/src/wiring/brain-and-orchestration.ts
@@ -1,0 +1,270 @@
+import {
+  type BrainAutoRisk,
+  BrainDecisionQueue,
+  BrainMonitor,
+  type Config,
+  createAutonomyBrain,
+  createDelegateTool,
+  createMcpControlTool,
+  createMcpUseTool,
+  createTieredBrainArbiter,
+  DefaultBrainArbiter,
+  FLEET_ROSTER,
+  HumanEscalatingBrainArbiter,
+  ObservableBrainArbiter,
+  type Provider,
+  type SessionWriter,
+  TOKENS,
+  type ToolRegistry,
+} from '@wrongstack/core';
+import { MultiAgentHost } from '../multi-agent.js';
+import { subscribeBrainDecisionLog } from '../boot/brain-decision-log.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// biome-ignore lint/suspicious/noExplicitAny: large dep bag
+type AnyObj = any;
+
+export interface BrainOrchestrationDeps {
+  events: AnyObj;
+  config: Config;
+  container: AnyObj;
+  provider: Provider;
+  session: SessionWriter;
+  context: AnyObj;
+  toolRegistry: ToolRegistry;
+  // biome-ignore lint/suspicious/noExplicitAny: many providers/registries
+  providerRegistry: AnyObj;
+  // biome-ignore lint/suspicious/noExplicitAny: config store
+  configStore: AnyObj;
+  // biome-ignore lint/suspicious/noExplicitAny: models registry
+  modelsRegistry: AnyObj;
+  // biome-ignore lint/suspicious/noExplicitAny: prompt builder
+  promptBuilder: AnyObj;
+  // biome-ignore lint/suspicious/noExplicitAny: token counter
+  tokenCounter: AnyObj;
+  projectRoot: string;
+  cwd: string;
+  wpaths: AnyObj;
+  teardownHandlers: (() => void)[];
+  mailboxSessionTag: (id: string) => string;
+  brainMailbox: AnyObj;
+  agentMonitor: AnyObj;
+  directorMode: boolean;
+  manifestPath: string | undefined;
+  sharedScratchpadPath: string | undefined;
+  subagentSessionsRoot: string | undefined;
+  stateCheckpointPath: string | undefined;
+  fleetRootForPromotion: string;
+  maxConcurrent: number | undefined;
+  effectiveMaxContextRef: { current: number };
+  mcpRegistry: AnyObj;
+  // biome-ignore lint/suspicious/noExplicitAny: session result
+  sessResult: AnyObj;
+}
+
+export interface BrainOrchestrationResult {
+  brain: ObservableBrainArbiter;
+  brainLog: AnyObj[];
+  brainSettings: { maxAutoRisk: BrainAutoRisk };
+  brainQueue: BrainDecisionQueue;
+  multiAgentHost: MultiAgentHost;
+  shadowController: AnyObj;
+  shadowDefaults: { intervalMs?: number; provider?: string; model?: string };
+}
+
+/**
+ * Wire the global Brain chain (policy → LLM → human), BrainMonitor,
+ * shadow controller, MultiAgentHost (subagent orchestration), and
+ * delegate/mcp_control/mcp_use tool registration.
+ *
+ * The HQ telemetry bridges (setupHqTelemetry) are called separately
+ * between brain chain setup and brain monitor creation in cli-main.ts,
+ * which is why this function has two logical halves stitched together.
+ */
+export function setupBrainAndOrchestration(
+  deps: BrainOrchestrationDeps,
+): BrainOrchestrationResult {
+  const {
+    events,
+    config,
+    container,
+    provider,
+    session,
+    context,
+    toolRegistry,
+    providerRegistry,
+    configStore,
+    modelsRegistry,
+    promptBuilder,
+    tokenCounter,
+    projectRoot,
+    cwd,
+    wpaths,
+    teardownHandlers,
+    mailboxSessionTag,
+    brainMailbox,
+    agentMonitor,
+    directorMode,
+    manifestPath,
+    sharedScratchpadPath,
+    subagentSessionsRoot,
+    stateCheckpointPath,
+    fleetRootForPromotion,
+    maxConcurrent,
+    effectiveMaxContextRef,
+    mcpRegistry,
+    sessResult,
+  } = deps;
+
+  // ── Global Brain chain — policy → LLM → human ──────────────────────────
+  const brainSettings: { maxAutoRisk: BrainAutoRisk } = {
+    maxAutoRisk: 'medium',
+  };
+  const brainQueue = new BrainDecisionQueue(events);
+  const autonomousBrain = {
+    decide: (request: AnyObj) =>
+      createAutonomyBrain({
+        provider,
+        model: config.model,
+        maxAutoRisk: 'all',
+      }).decide(request),
+  };
+  const brain = new ObservableBrainArbiter(
+    new HumanEscalatingBrainArbiter(
+      createTieredBrainArbiter({
+        policy: new DefaultBrainArbiter(),
+        autonomous: autonomousBrain,
+        getMaxAutoRisk: () => brainSettings.maxAutoRisk,
+      }),
+      brainQueue,
+    ),
+    events,
+  );
+  container.bind(TOKENS.BrainArbiter, () => brain);
+
+  // Decision log for /brain status
+  const { brainLog, dispose: disposeBrainLog } = subscribeBrainDecisionLog(events);
+  teardownHandlers.push(disposeBrainLog);
+
+  // NOTE: setupHqTelemetry() is called here in cli-main.ts between
+  // brain chain and brain monitor. The function continues below.
+
+  // ── Brain Monitor ────────────────────────────────────────────────────────
+  const brainMonitor = new BrainMonitor({
+    events,
+    brain,
+    sessionId: () => context.session?.id ?? session.id,
+    intervene: async ({ subject, body }: { subject: string; body: string }) => {
+      const leaderUniqueId = `leader@${mailboxSessionTag(session.id)}`;
+      await brainMailbox.send({
+        from: `brain@${mailboxSessionTag(session.id)}`,
+        to: leaderUniqueId,
+        type: 'steer',
+        subject,
+        body,
+        priority: 'high',
+      });
+    },
+  });
+  brainMonitor.start();
+  teardownHandlers.push(() => brainMonitor.stop());
+  teardownHandlers.push(() => brainQueue.dispose());
+
+  // ── Shadow controller ────────────────────────────────────────────────────
+  let shadowDefaults: { intervalMs?: number; provider?: string; model?: string } = {};
+  const shadowController = {
+    activeId: null as string | null,
+    register(id: string) {
+      this.activeId = id;
+    },
+    clear() {
+      this.activeId = null;
+    },
+    getDefaults() {
+      return { ...shadowDefaults };
+    },
+    setDefaults(defaults: { intervalMs?: number; provider?: string; model?: string }) {
+      shadowDefaults = { ...shadowDefaults, ...defaults };
+    },
+  };
+
+  // ── MultiAgentHost ───────────────────────────────────────────────────────
+  const multiAgentHost = new MultiAgentHost(
+    {
+      container,
+      toolRegistry,
+      providerRegistry,
+      configStore,
+      modelsRegistry,
+      events,
+      systemPromptBuilder: promptBuilder,
+      session,
+      tokenCounter,
+      projectRoot,
+      cwd,
+      secretScrubber: container.resolve(TOKENS.SecretScrubber),
+    },
+    {
+      directorMode,
+      manifestPath,
+      sharedScratchpadPath,
+      sessionsRoot: subagentSessionsRoot,
+      directorRunId: session.id,
+      fleetRoot: fleetRootForPromotion,
+      stateCheckpointPath,
+      sessionWriter: session,
+      maxConcurrent,
+      getLeaderMaxContext: () => effectiveMaxContextRef.current,
+      brain,
+      agentMonitor,
+      traceId: sessResult.traceId,
+      onShadowAgentStarted: (subagentId: string) => shadowController.register(subagentId),
+      onShadowAgentStopped: (subagentId: string) => {
+        if (shadowController.activeId === subagentId) shadowController.clear();
+      },
+    },
+  );
+
+  // Delegate tool
+  toolRegistry.register(
+    createDelegateTool({
+      host: multiAgentHost,
+      roster: FLEET_ROSTER,
+      sessionsRoot: subagentSessionsRoot,
+      directorRunId: session.id,
+      events,
+    }),
+  );
+
+  // mcp_control tool
+  toolRegistry.register(
+    createMcpControlTool({
+      getConfig: () => configStore.get(),
+      configPath: wpaths.globalConfig,
+      registry: mcpRegistry,
+    }),
+  );
+
+  // mcp_use tool — meta-tool for token-saving mode
+  if (config.features.tokenSavingMode) {
+    toolRegistry.register(
+      createMcpUseTool({
+        registry: mcpRegistry,
+        toolRegistry,
+      }),
+    );
+  }
+
+  return {
+    brain,
+    brainLog,
+    brainSettings,
+    brainQueue,
+    multiAgentHost,
+    shadowController,
+    shadowDefaults,
+  };
+}

--- a/packages/cli/src/wiring/dep-watcher.ts
+++ b/packages/cli/src/wiring/dep-watcher.ts
@@ -1,0 +1,117 @@
+import * as path from 'node:path';
+import {
+  type EventBus,
+  type FileAuthorTrackerOptions,
+  GlobalMailbox,
+  type PackageAuthorTrackerOptions,
+  startPackageOutdatedWatcher,
+  startTechStackConsumer,
+} from '@wrongstack/core';
+import type { DefaultLogger } from '@wrongstack/core';
+import type { MultiAgentHost } from '../multi-agent.js';
+
+export interface SetupDepWatcherConsumersDeps {
+  dwCfg: Record<string, unknown> | undefined;
+  globalRoot: string;
+  projectSlug: string;
+  events: EventBus;
+  multiAgentHost: MultiAgentHost;
+  sessionId: string;
+  logger: DefaultLogger;
+  teardownHandlers: (() => void)[];
+  projectRoot: string;
+}
+
+/**
+ * Wire the tech-stack mailbox consumer and the package-outdated watcher.
+ * Both are gated on `dwCfg?.enabled` (the file-watcher plugin's depWatcher
+ * config). When enabled, the tech-stack consumer polls for dep-watcher
+ * messages and spawns a subagent; the package-outdated watcher notifies
+ * original authors when their added packages become outdated.
+ */
+export function setupDepWatcherConsumers(deps: SetupDepWatcherConsumersDeps): void {
+  const { dwCfg, globalRoot, projectSlug, events, multiAgentHost, sessionId, logger, teardownHandlers, projectRoot } =
+    deps;
+
+  // ── Tech-stack mailbox consumer: auto-spawn agent on dep-watcher messages ──
+  let techStackConsumerDispose: (() => void) | undefined;
+  if (dwCfg?.['enabled'] === true) {
+    try {
+      const projectDir = path.join(globalRoot, 'projects', projectSlug);
+      const tsMailbox = new GlobalMailbox(projectDir, events);
+      const fileAuthorOpts: FileAuthorTrackerOptions = {
+        storageDir: projectDir,
+        projectRoot,
+      };
+      techStackConsumerDispose = startTechStackConsumer({
+        mailbox: tsMailbox,
+        onSpawn: async (task, name) => {
+          return multiAgentHost.spawn(task, { name, tools: ['read', 'fetch', 'mailbox'] });
+        },
+        targetAgent: (dwCfg['targetAgent'] as string) ?? 'tech-stack',
+        consumerAgentId: 'tech-stack-consumer',
+        pollIntervalMs: (dwCfg['pollIntervalMs'] as number) ?? 5000,
+        fileAuthorOpts,
+        sessionId,
+        currentAgentId: 'leader',
+        currentAgentName: 'Leader',
+        onLog: (msg) => logger.debug(msg),
+        onError: (err) =>
+          logger.warn(
+            `Tech-stack consumer error: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+      });
+      logger.info(
+        'Tech-stack mailbox consumer started — will auto-spawn agents on dependency changes',
+      );
+    } catch (err) {
+      logger.warn(`Failed to start tech-stack consumer: ${err}`);
+    }
+  }
+
+  // ── Package outdated watcher: notify original authors when packages are outdated ──
+  let pkgOutdatedDispose: (() => void) | undefined;
+  if (dwCfg?.['enabled'] === true) {
+    try {
+      const projectDir = path.join(globalRoot, 'projects', projectSlug);
+      const pkgMailbox = new GlobalMailbox(projectDir, events);
+      const pkgTrackerOpts: Pick<PackageAuthorTrackerOptions, 'storageDir' | 'projectRoot'> = {
+        storageDir: projectDir,
+        projectRoot,
+      };
+      pkgOutdatedDispose = startPackageOutdatedWatcher({
+        mailbox: pkgMailbox,
+        packageTrackerOpts: pkgTrackerOpts,
+        pollIntervalMs: (dwCfg['pollIntervalMs'] as number) ?? 60 * 60 * 1000, // 1 hour default
+        watcherAgentId: 'pkg-outdated-watcher',
+        onNotify: async (msg) => {
+          await pkgMailbox.send({
+            from: msg.from,
+            to: msg.to,
+            type: 'note',
+            subject: msg.subject,
+            body: msg.body,
+            priority: msg.priority,
+          });
+        },
+        onLog: (m) => logger.debug(m),
+        onError: (err) =>
+          logger.warn(
+            `Pkg-outdated-watcher error: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+      });
+      logger.info(
+        'Package outdated watcher started — will notify agents when their added packages are outdated',
+      );
+    } catch (err) {
+      logger.warn(`Failed to start package outdated watcher: ${err}`);
+    }
+  }
+
+  if (pkgOutdatedDispose) {
+    teardownHandlers.push(pkgOutdatedDispose);
+  }
+  if (techStackConsumerDispose) {
+    teardownHandlers.push(techStackConsumerDispose);
+  }
+}

--- a/packages/cli/src/wiring/director-setup.ts
+++ b/packages/cli/src/wiring/director-setup.ts
@@ -1,0 +1,187 @@
+import * as path from 'node:path';
+import {
+  type AutonomyStage,
+  type Config,
+  type Director,
+  type EventBus,
+  type EternalAutonomyEngine,
+  type ParallelEternalEngine,
+  expectDefined,
+  type SessionWriter,
+} from '@wrongstack/core';
+import { type AgentMonitorService, createAgentMonitorService } from '@wrongstack/core/coordination';
+import { sessionScopedPath } from '@wrongstack/core/utils';
+import type { WstackPaths } from '@wrongstack/core';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Persistent ref for autonomy mode — set once here, read elsewhere via
+ * `autonomyModeRef.current`. Matches the shape created in cli-main.ts.
+ */
+export interface AutonomyModeRef {
+  current: import('../slash-commands/autonomy.js').AutonomyMode;
+}
+
+export interface DirectorAutonomyDeps {
+  flags: Record<string, string | boolean>;
+  config: Config;
+  wpaths: WstackPaths;
+  session: SessionWriter;
+  events: EventBus;
+  autonomyModeRef: AutonomyModeRef;
+}
+
+export interface DirectorAutonomyResult {
+  director: Director | null;
+  directorMode: boolean;
+  maxConcurrent: number | undefined;
+  autonomyMode: import('../slash-commands/autonomy.js').AutonomyMode;
+  nextPredictEnabled: boolean;
+  currentSuggestions: string[];
+  eternalEngine: EternalAutonomyEngine | null;
+  parallelEngine: ParallelEternalEngine | null;
+  eternalListeners: Set<(entry: import('@wrongstack/core').JournalEntry) => void>;
+  broadcastEternalIteration: (entry: import('@wrongstack/core').JournalEntry) => void;
+  stageListeners: Set<(stage: AutonomyStage) => void>;
+  broadcastAutonomyStage: (stage: AutonomyStage) => void;
+  fleetRoot: string | undefined;
+  manifestPath: string | undefined;
+  sharedScratchpadPath: string | undefined;
+  subagentSessionsRoot: string | undefined;
+  stateCheckpointPath: string | undefined;
+  fleetRootForPromotion: string;
+  agentMonitor: AgentMonitorService;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire director / autonomy mode, fleet paths, eternal-engine scaffolding,
+ * and the Agent Monitor service. Returns everything the caller needs to
+ * reference later in the launch flow.
+ *
+ * The `director`, `eternalEngine`, `parallelEngine`, `autonomyMode`,
+ * `nextPredictEnabled`, and `currentSuggestions` fields are returned at
+ * their initial value — the caller may reassign `director` (from
+ * `multiAgentHost.ensureDirector()`) and the other mutable fields later.
+ */
+export function setupDirectorAndAutonomy(deps: DirectorAutonomyDeps): DirectorAutonomyResult {
+  const { flags, config, wpaths, session, events, autonomyModeRef } = deps;
+
+  // ── Director mode ──────────────────────────────────────────────────────
+  const directorMode = flags['director'] === true || typeof flags['resume'] === 'string';
+
+  // Concurrent subagent ceiling. Priority: CLI flag → env var → config → default (4).
+  const maxConcurrentFromFlag =
+    typeof flags['max-concurrent'] === 'string'
+      ? Number.parseInt(flags['max-concurrent'], 10)
+      : undefined;
+  const maxConcurrentFromEnv =
+    typeof process.env['WRONGSTACK_MAX_CONCURRENT'] === 'string'
+      ? Number.parseInt(process.env['WRONGSTACK_MAX_CONCURRENT'], 10)
+      : undefined;
+  const maxConcurrentFromConfig =
+    typeof config.maxConcurrent === 'number' && config.maxConcurrent > 0
+      ? config.maxConcurrent
+      : undefined;
+  const maxConcurrent =
+    Number.isFinite(maxConcurrentFromFlag) && (maxConcurrentFromFlag as number) > 0
+      ? (maxConcurrentFromFlag as number)
+      : Number.isFinite(maxConcurrentFromEnv) && (maxConcurrentFromEnv as number) > 0
+        ? (maxConcurrentFromEnv as number)
+        : Number.isFinite(maxConcurrentFromConfig) && (maxConcurrentFromConfig as number) > 0
+          ? (maxConcurrentFromConfig as number)
+          : undefined;
+
+  // ── Autonomy mode ──────────────────────────────────────────────────────
+  const autonomyMode: import('../slash-commands/autonomy.js').AutonomyMode = (() => {
+    const v = flags['autonomy'];
+    if (v === 'auto' || v === 'suggest' || v === 'eternal' || v === 'eternal-parallel') return v;
+    if (v === 'off') return 'off';
+    return (config.autonomy?.defaultMode ?? 'off') as import('../slash-commands/autonomy.js').AutonomyMode;
+  })();
+  autonomyModeRef.current = autonomyMode;
+
+  const nextPredictEnabled = config.nextPrediction === true;
+  const currentSuggestions: string[] = [];
+
+  // ── Eternal / parallel engine scaffolding ──────────────────────────────
+  const eternalEngine: EternalAutonomyEngine | null = null;
+  const parallelEngine: ParallelEternalEngine | null = null;
+  const eternalListeners = new Set<(entry: import('@wrongstack/core').JournalEntry) => void>();
+  const broadcastEternalIteration = (entry: import('@wrongstack/core').JournalEntry): void => {
+    for (const fn of eternalListeners) {
+      try {
+        fn(entry);
+      } catch {
+        // listener failures must never break the engine — swallow
+      }
+    }
+  };
+  const stageListeners = new Set<(stage: AutonomyStage) => void>();
+  const broadcastAutonomyStage = (stage: AutonomyStage): void => {
+    for (const fn of stageListeners) {
+      try {
+        fn(stage);
+      } catch {
+        // listener failures must never break the engine — swallow
+      }
+    }
+  };
+
+  // ── Fleet root paths ───────────────────────────────────────────────────
+  const fleetRoot = directorMode
+    ? sessionScopedPath(wpaths.projectSessions, session.id, '')
+    : undefined;
+  const manifestPath = directorMode
+    ? typeof process.env['WRONGSTACK_FLEET_MANIFEST'] === 'string'
+      ? process.env['WRONGSTACK_FLEET_MANIFEST']
+      : path.join(expectDefined(fleetRoot), 'fleet.json')
+    : undefined;
+  const sharedScratchpadPath = directorMode
+    ? path.join(expectDefined(fleetRoot), 'shared')
+    : undefined;
+  const subagentSessionsRoot = directorMode
+    ? path.join(expectDefined(fleetRoot), 'subagents')
+    : undefined;
+  const stateCheckpointPath = directorMode
+    ? path.join(expectDefined(fleetRoot), 'director-state.json')
+    : undefined;
+  const fleetRootForPromotion = sessionScopedPath(wpaths.projectSessions, session.id, '');
+
+  // ── Agent Monitor — subagent conversation tracking ─────────────────────
+  const agentMonitor = createAgentMonitorService({
+    events,
+    sessionId: session.id,
+    transcriptsDir: path.join(fleetRootForPromotion, 'subagents', 'transcripts'),
+    maxEntriesPerAgent: 500,
+    streamEnabled: false,
+  });
+
+  return {
+    director: null,
+    directorMode,
+    maxConcurrent,
+    autonomyMode,
+    nextPredictEnabled,
+    currentSuggestions,
+    eternalEngine,
+    parallelEngine,
+    eternalListeners,
+    broadcastEternalIteration,
+    stageListeners,
+    broadcastAutonomyStage,
+    fleetRoot,
+    manifestPath,
+    sharedScratchpadPath,
+    subagentSessionsRoot,
+    stateCheckpointPath,
+    fleetRootForPromotion,
+    agentMonitor,
+  };
+}

--- a/packages/cli/src/wiring/hq-telemetry.ts
+++ b/packages/cli/src/wiring/hq-telemetry.ts
@@ -1,0 +1,230 @@
+import * as path from 'node:path';
+import {
+  type Config,
+  type EventBus,
+  GlobalMailbox,
+  type SessionWriter,
+  startCostTelemetryBridge,
+  startSessionTelemetryBridge,
+  startFleetTelemetryBridge,
+  startBrainTelemetryBridge,
+  startWorktreeTelemetryBridge,
+  startToolTelemetryBridge,
+} from '@wrongstack/core';
+import type { AgentMonitorService } from '@wrongstack/core/coordination';
+import { startCliHqConnection } from '../hq-publisher.js';
+import { createHqCommandDispatcher, type HqCommandController } from '../hq-command-controller.js';
+
+/**
+ * Mutable holder for the HQ publisher reference. The ref is created in
+ * cli-main.ts before `brainMailbox` (which captures it via closure) and
+ * populated by `setupHqTelemetry` once the HQ connection establishes.
+ */
+export interface HqPublisherRef {
+  // biome-ignore lint/suspicious/noExplicitAny: publisher shape from hq-publisher.ts
+  current: any | undefined;
+}
+
+export interface SetupHqTelemetryDeps {
+  events: EventBus;
+  session: SessionWriter;
+  config: Config;
+  // biome-ignore lint/suspicious/noExplicitAny: flags bag from arg-parser
+  flags: Record<string, string | boolean>;
+  tuiOwnsScreen: boolean;
+  projectRoot: string;
+  globalRoot: string;
+  // biome-ignore lint/suspicious/noExplicitAny: tracker type from AgentStatusTracker
+  tracker: any | undefined;
+  agentMonitor: AgentMonitorService | undefined;
+  brainMailbox: GlobalMailbox;
+  teardownHandlers: (() => void)[];
+  mailboxSessionTag: (sessionId: string) => string;
+  hqPublisherRef: HqPublisherRef;
+}
+
+export interface HqTelemetryResult {
+  hqCommandController: HqCommandController;
+  hqOnCommand: ReturnType<typeof createHqCommandDispatcher>;
+}
+
+/**
+ * Wire the HQ command dispatch controller and the HQ WebSocket connection
+ * with its auxiliary telemetry bridges (session, fleet, brain, worktree,
+ * tool, cost). Also forwards agent-monitor events to HQ.
+ *
+ * The `hqPublisherRef` is populated once the connection establishes so
+ * the `brainMailbox` (which captured the ref earlier) can publish to HQ.
+ *
+ * Teardown handlers are pushed into `deps.teardownHandlers` internally.
+ */
+export function setupHqTelemetry(deps: SetupHqTelemetryDeps): HqTelemetryResult {
+  const {
+    events,
+    session,
+    config,
+    flags,
+    tuiOwnsScreen,
+    projectRoot,
+    globalRoot,
+    tracker,
+    agentMonitor,
+    brainMailbox,
+    teardownHandlers,
+    mailboxSessionTag,
+    hqPublisherRef,
+  } = deps;
+
+  // Mutable state owned entirely within this function — no references
+  // escape to the caller's scope except through the hqPublisherRef.
+  let stopHqSessionBridge: (() => void) | undefined;
+  const stopHqAuxBridges: Array<() => void> = [];
+
+  // ── Phase 4 control plane — HQ command dispatch holder ──────────────────
+  const hqCommandController: HqCommandController = {
+    steerMailbox: brainMailbox as never,
+    interruptLeader: () => false,
+    sessionTag: () => mailboxSessionTag(session.id),
+    allowRunCommand: () => flags['hq-allow-exec'] === true,
+  };
+  const hqOnCommand = createHqCommandDispatcher(hqCommandController);
+
+  const hqConnection = startCliHqConnection({
+    clientKind: tuiOwnsScreen ? 'tui' : 'cli',
+    projectRoot,
+    projectName: path.basename(projectRoot),
+    appConfig: config,
+    onCommand: hqOnCommand,
+    capabilities: [
+      'telemetry.publish',
+      'mailbox.summary',
+      'fleet.summary',
+      'session.summary',
+      'control.receive',
+    ],
+    onConnect: (publisher) => {
+      hqPublisherRef.current = publisher;
+      stopHqSessionBridge?.();
+      stopHqSessionBridge = undefined;
+      // Drain any auxiliary bridges from a previous connection before
+      // re-establishing, so a reconnect never double-subscribes.
+      for (const stop of stopHqAuxBridges) {
+        try {
+          stop();
+        } catch {
+          /* best-effort */
+        }
+      }
+      stopHqAuxBridges.length = 0;
+      try {
+        stopHqSessionBridge = startSessionTelemetryBridge({
+          publisher,
+          events,
+          sessionId: session.id,
+          projectRoot,
+          projectName: path.basename(projectRoot),
+          globalRoot,
+          // biome-ignore lint/suspicious/noExplicitAny: initialAgents shape
+          initialAgents: (tracker as any)?.getAgents?.() as any,
+          startedAt: new Date().toISOString(),
+        });
+      } catch {
+        // HQ session telemetry is optional.
+      }
+      // ── Auxiliary telemetry bridges ──
+      try {
+        stopHqAuxBridges.push(
+          startFleetTelemetryBridge({
+            events,
+            publisher,
+            runId: session.id,
+            sessionId: session.id,
+          }),
+        );
+      } catch {
+        /* optional */
+      }
+      try {
+        stopHqAuxBridges.push(
+          startBrainTelemetryBridge({ events, publisher, sessionId: session.id }),
+        );
+      } catch {
+        /* optional */
+      }
+      try {
+        stopHqAuxBridges.push(
+          startWorktreeTelemetryBridge({ events, publisher, sessionId: session.id }),
+        );
+      } catch {
+        /* optional */
+      }
+      try {
+        stopHqAuxBridges.push(
+          startToolTelemetryBridge({
+            events,
+            publisher,
+            projectRoot,
+            sessionId: session.id,
+          }),
+        );
+      } catch {
+        /* optional */
+      }
+      try {
+        stopHqAuxBridges.push(
+          startCostTelemetryBridge({ events, publisher, sessionId: session.id }),
+        );
+      } catch {
+        /* optional */
+      }
+    },
+  });
+
+  // Populate the publisher ref from the connection so the brainMailbox
+  // closure (which captured hqPublisherRef) can publish immediately.
+  hqPublisherRef.current = hqConnection.getPublisher();
+
+  teardownHandlers.push(() => stopHqSessionBridge?.());
+  teardownHandlers.push(() => {
+    for (const stop of stopHqAuxBridges) {
+      try {
+        stop();
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+  teardownHandlers.push(() => hqConnection.stop());
+
+  // ── Agent Monitor → HQ Bridge ───────────────────────────────────
+  if (agentMonitor) {
+    const offMsg = events.on('agent.timeline.message', (payload) => {
+      try {
+        (hqPublisherRef.current as any)?.publishEvent?.({
+          type: 'agent.message',
+          payload,
+          timestamp: (payload as any).ts,
+        });
+      } catch {
+        /* best-effort */
+      }
+    });
+    const offStatus = events.on('agent.status_changed', (payload) => {
+      try {
+        (hqPublisherRef.current as any)?.publishEvent?.({
+          type: 'agent.status',
+          payload,
+          timestamp: (payload as any).ts,
+        });
+      } catch {
+        /* best-effort */
+      }
+    });
+    teardownHandlers.push(() => {
+      offMsg();
+      offStatus();
+    });
+  }
+
+  return { hqCommandController, hqOnCommand };
+}

--- a/packages/cli/src/wiring/hq-telemetry.ts
+++ b/packages/cli/src/wiring/hq-telemetry.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 import {
   type Config,
   type EventBus,
-  GlobalMailbox,
+  type GlobalMailbox,
   type SessionWriter,
   startCostTelemetryBridge,
   startSessionTelemetryBridge,
@@ -29,7 +29,6 @@ export interface SetupHqTelemetryDeps {
   events: EventBus;
   session: SessionWriter;
   config: Config;
-  // biome-ignore lint/suspicious/noExplicitAny: flags bag from arg-parser
   flags: Record<string, string | boolean>;
   tuiOwnsScreen: boolean;
   projectRoot: string;

--- a/packages/cli/src/wiring/lifecycle-plugins.ts
+++ b/packages/cli/src/wiring/lifecycle-plugins.ts
@@ -1,0 +1,352 @@
+import {
+  type Config,
+  GlobalMailbox,
+  type HealthRegistry,
+  HookRegistry,
+  HookRunner,
+  countShellHooks,
+  shellHooksEqual,
+  type Logger,
+  type ModelsRegistry,
+  normalizeTokenSavingTier,
+  type Provider,
+  type ProviderConfig,
+  type ProviderRegistry,
+  type SecretVault,
+  type SessionWriter,
+  SlashCommandRegistry,
+  TOKENS,
+  type ToolRegistry,
+  type WstackPaths,
+  allServers,
+} from '@wrongstack/core';
+import { MCPRegistry } from '@wrongstack/mcp';
+import { createAgent, setupCompaction } from './pipeline.js';
+import { installDesignStudio } from './design-studio.js';
+import { createLifecycleHooksExtension, createUserPromptSubmitMiddleware } from '../hooks-wiring.js';
+import { makeConfirmAwaiter } from '../permission-prompt.js';
+import { refreshRuntimeModelCatalog, resolveRuntimeMaxContext } from '../context-limit.js';
+import { setupPlugins } from './plugins.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// biome-ignore lint/suspicious/noExplicitAny: large dependency bag — exact types add no safety here
+type AnyRecord = Record<string, any>;
+
+export interface LifecyclePluginsDeps {
+  flags: Record<string, string | boolean>;
+  config: Config;
+  // biome-ignore lint/suspicious/noExplicitAny: DI container shape
+  container: any;
+  // biome-ignore lint/suspicious/noExplicitAny: pipeline shape
+  pipelines: any;
+  logger: Logger;
+  session: SessionWriter;
+  sessionBridge: any;
+  // biome-ignore lint/suspicious/noExplicitAny: event bus
+  events: any;
+  modelsRegistry: ModelsRegistry;
+  // biome-ignore lint/suspicious/noExplicitAny: context shape
+  context: any;
+  provider: Provider;
+  // biome-ignore lint/suspicious/noExplicitAny: ref
+  modelCapabilitiesRef: AnyRecord;
+  // biome-ignore lint/suspicious/noExplicitAny: reader
+  reader: any;
+  wpaths: WstackPaths;
+  toolRegistry: ToolRegistry;
+  providerRegistry: ProviderRegistry;
+  // biome-ignore lint/suspicious/noExplicitAny: config store
+  configStore: any;
+  eventWiring: any;
+  healthRegistry: HealthRegistry;
+  // biome-ignore lint/suspicious/noExplicitAny: optional loaders
+  skillLoader: any;
+  promptLoader: any;
+  vault: SecretVault;
+  // biome-ignore lint/suspicious/noExplicitAny: metrics sink
+  metricsSink: any;
+  // biome-ignore lint/suspicious/noExplicitAny: renderer
+  renderer: any;
+  // biome-ignore lint/suspicious/noExplicitAny: import
+  buildProviderForIdRuntime: any;
+}
+
+export interface LifecyclePluginsResult {
+  hookRegistry: HookRegistry;
+  hookRunner: HookRunner;
+  // biome-ignore lint/suspicious/noExplicitAny: auto-compactor
+  autoCompactor: any;
+  effectiveMaxContextRef: { current: number };
+  applyMaxContext: (providerId: string, modelId: string, mc: number, seq?: number) => void;
+  refreshMaxContext: (providerId: string, modelId: string, runtimeProviderConfig?: ProviderConfig) => Promise<void>;
+  // biome-ignore lint/suspicious/noExplicitAny: agent
+  agent: any;
+  mcpRegistry: MCPRegistry;
+  slashRegistry: SlashCommandRegistry;
+  hqPublisherRef: { current: any };
+  brainMailbox: GlobalMailbox;
+}
+
+/**
+ * Wire lifecycle hooks, compaction + max-context management, agent creation,
+ * MCP servers, slash-registry, project mailbox, and plugins setup.
+ *
+ * Returns a result bag; the returned closures capture `effectiveMaxContext`
+ * and `autoCompactor` internally so the caller can invoke `applyMaxContext`
+ * / `refreshMaxContext` without needing those internals.
+ */
+export async function setupLifecycleAndPlugins(
+  deps: LifecyclePluginsDeps,
+): Promise<LifecyclePluginsResult> {
+  const {
+    flags,
+    config,
+    container,
+    pipelines,
+    logger,
+    session,
+    events,
+    modelsRegistry,
+    context,
+    provider,
+    modelCapabilitiesRef,
+    reader,
+    wpaths,
+    toolRegistry,
+    providerRegistry,
+    configStore,
+    sessionBridge,
+    eventWiring,
+    healthRegistry,
+    skillLoader,
+    promptLoader,
+    vault,
+    metricsSink,
+    buildProviderForIdRuntime: buildProviderForIdRuntimeFn,
+  } = deps;
+
+  // ── Lifecycle hooks ──────────────────────────────────────────────────────
+  const hooksEnabled = flags['no-hooks'] !== true;
+  const hookRegistry = new HookRegistry();
+  if (hooksEnabled) hookRegistry.loadShellHooks(config.hooks);
+  container.bind(TOKENS.HookRegistry, () => hookRegistry);
+  const hookRunner = new HookRunner({
+    registry: hookRegistry,
+    logger,
+    allowShell: hooksEnabled,
+    sessionId: () => session.id,
+  });
+  if (hooksEnabled) {
+    pipelines.userInput.use(createUserPromptSubmitMiddleware(hookRunner));
+
+    // Hot-reload shell hooks when config.hooks changes at runtime
+    configStore.watch((next: Config, prev: Config) => {
+      if (!shellHooksEqual(next.hooks, prev.hooks)) {
+        try {
+          hookRegistry.replaceShellHooks(next.hooks);
+          logger.info(
+            `Shell hooks reloaded (${countShellHooks(next.hooks)} entries across ${
+              Object.keys(next.hooks ?? {}).length
+            } events)`,
+          );
+        } catch (err) {
+          logger.warn(`Hook hot-reload failed: ${(err as Error).message ?? String(err)}`);
+        }
+      }
+    });
+  }
+
+  // Design Studio — per-turn UI-intent detection + kit-menu injection.
+  installDesignStudio({ pipelines, context });
+
+  // ── Compaction + max context ─────────────────────────────────────────────
+  const compactor = container.resolve(TOKENS.Compactor);
+  const compactionSetup = await setupCompaction({
+    compactor,
+    events,
+    modelsRegistry,
+    context,
+    config,
+    provider,
+    pipelines,
+    fullConfig: config as never,
+    sessionBridge,
+  });
+  const effectiveMaxContextRef = { current: compactionSetup.effectiveMaxContext };
+  context.provider.capabilities.maxContext = effectiveMaxContextRef.current;
+  modelCapabilitiesRef.current =
+    effectiveMaxContextRef.current > 0
+      ? {
+          maxContextTokens: effectiveMaxContextRef.current,
+          supportsTools: !!context.provider.capabilities.tools,
+          supportsVision: !!context.provider.capabilities.vision,
+          supportsReasoning: !!context.provider.capabilities.reasoning,
+        }
+      : undefined;
+  const { autoCompactor } = compactionSetup;
+
+  let maxContextRefreshSeq = 0;
+  const applyMaxContext = (
+    providerId: string,
+    modelId: string,
+    mc: number,
+    seq?: number | undefined,
+  ): void => {
+    if (seq !== undefined && seq !== maxContextRefreshSeq) return;
+    effectiveMaxContextRef.current = mc;
+    context.provider.capabilities.maxContext = effectiveMaxContextRef.current;
+    modelCapabilitiesRef.current =
+      effectiveMaxContextRef.current > 0
+        ? {
+            maxContextTokens: effectiveMaxContextRef.current,
+            supportsTools: !!context.provider.capabilities.tools,
+            supportsVision: !!context.provider.capabilities.vision,
+            supportsReasoning: !!context.provider.capabilities.reasoning,
+          }
+        : undefined;
+    if (effectiveMaxContextRef.current > 0) {
+      context.meta['effectiveMaxContext'] = effectiveMaxContextRef.current;
+      autoCompactor?.setMaxContext(effectiveMaxContextRef.current);
+      autoCompactor?.setEnabled(config.context.autoCompact !== false);
+    } else {
+      // biome-ignore lint/performance/noDelete: intentional property removal
+      delete context.meta['effectiveMaxContext'];
+      autoCompactor?.setEnabled(false);
+    }
+    events.emit('ctx.max_context', {
+      sessionId: context.session.id,
+      providerId,
+      modelId,
+      maxContext: effectiveMaxContextRef.current,
+    });
+    eventWiring.setEffectiveMaxContext(effectiveMaxContextRef.current);
+  };
+
+  const refreshMaxContext = async (
+    providerId: string,
+    modelId: string,
+    runtimeProviderConfig?: ProviderConfig | undefined,
+  ): Promise<void> => {
+    const seq = ++maxContextRefreshSeq;
+    const resolveAndApply = async (): Promise<void> => {
+      const mc = await resolveRuntimeMaxContext({
+        modelsRegistry,
+        config,
+        provider: context.provider,
+        runtimeProviderConfig,
+        providerId,
+        modelId,
+      });
+      applyMaxContext(providerId, modelId, mc, seq);
+    };
+    await resolveAndApply();
+    const refreshed = await refreshRuntimeModelCatalog({
+      modelsRegistry,
+      logger,
+      reason: `${providerId}/${modelId}`,
+    });
+    if (refreshed) await resolveAndApply();
+  };
+
+  // ── Agent ────────────────────────────────────────────────────────────────
+  const agent = createAgent({
+    container,
+    tools: toolRegistry,
+    providers: providerRegistry,
+    events,
+    pipelines,
+    context,
+    config,
+    confirmAwaiter: makeConfirmAwaiter(reader),
+    hookRunner,
+    fullConfig: config,
+    source: 'cli',
+  });
+
+  if (hooksEnabled) {
+    agent.extensions.register(createLifecycleHooksExtension(hookRunner));
+  }
+
+  // ── MCP servers ──────────────────────────────────────────────────────────
+  const mcpRegistry = new MCPRegistry({
+    toolRegistry,
+    events,
+    log: logger,
+    lazyMode: normalizeTokenSavingTier(config.features.tokenSavingMode) !== 'off',
+    cacheDir: wpaths.cacheDir,
+  });
+  if (config.features.mcp) {
+    const presets = allServers();
+    for (const cfg of Object.values(config.mcpServers ?? {})) {
+      const preset = (presets as any)[(cfg as any).name];
+      const merged = preset ? { ...preset, ...(cfg as any) } : cfg;
+      try {
+        await (mcpRegistry as any).start(merged);
+      } catch (err) {
+        logger.warn(`MCP server "${(cfg as any).name}" failed to start`, err);
+      }
+    }
+  }
+
+  // ── Slash registry + mailbox + plugins ───────────────────────────────────
+  const slashRegistry = new SlashCommandRegistry();
+  const hqPublisherRef: { current: any } = { current: undefined };
+  const brainMailbox = new GlobalMailbox(wpaths.projectDir, events, () => hqPublisherRef.current);
+
+  await setupPlugins({
+    config,
+    container,
+    events,
+    pipelines,
+    toolRegistry,
+    providerRegistry,
+    slashCommandRegistry: slashRegistry,
+    mcpRegistry,
+    log: logger,
+    agent,
+    sessionWriter: context.session,
+    metricsSink,
+    modelsRegistry,
+    healthRegistry,
+    skillLoader: config.features.skills ? skillLoader : undefined,
+    promptLoader: config.features.prompts === false ? undefined : promptLoader,
+    configStore,
+    vault,
+    paths: {
+      globalRoot: wpaths.globalRoot,
+      globalConfig: wpaths.globalConfig,
+      globalSkills: wpaths.globalSkills,
+      globalPrompts: wpaths.globalPrompts,
+      globalMemory: wpaths.globalMemory,
+      historyFile: wpaths.historyFile,
+      syncConfig: wpaths.syncConfig,
+      projectDir: wpaths.projectDir,
+      projectGoal: wpaths.projectGoal,
+    },
+    hookRegistry,
+    mailbox: brainMailbox,
+    llm: {
+      provider,
+      model: config.model,
+      createProvider: (name: string) =>
+        buildProviderForIdRuntimeFn({ config, providerRegistry }, name),
+    },
+  });
+
+  return {
+    hookRegistry,
+    hookRunner,
+    autoCompactor,
+    effectiveMaxContextRef,
+    applyMaxContext,
+    refreshMaxContext,
+    agent,
+    mcpRegistry,
+    slashRegistry,
+    hqPublisherRef,
+    brainMailbox,
+  };
+}

--- a/packages/cli/src/wiring/provider-runtime-setup.ts
+++ b/packages/cli/src/wiring/provider-runtime-setup.ts
@@ -21,7 +21,9 @@ import { patchConfig } from '../utils.js';
 type AnyObj = any;
 
 export interface ProviderRuntimeDeps {
-  config: { current: Config };
+  config: Config;
+  /** Called whenever the function patches config, so the caller stays in sync. */
+  onConfigUpdate: (config: Config) => void;
   configStore: AnyObj;
   providerRegistry: ProviderRegistry;
   agent: AnyObj;
@@ -50,10 +52,15 @@ export interface ProviderRuntimeResult {
  * Wire runtime provider-config helpers, fallback model extension,
  * memory consolidation, the provider/model switch callback, and
  * the credential hot-reload watcher.
+ *
+ * Uses `onConfigUpdate` to propagate config patches back to the caller,
+ * avoiding the desync that a bare `{ current: Config }` ref would cause
+ * when the caller also mutates `config` directly.
  */
 export function setupProviderRuntime(deps: ProviderRuntimeDeps): ProviderRuntimeResult {
   const {
-    config,
+    config: initialConfig,
+    onConfigUpdate,
     configStore,
     providerRegistry,
     agent,
@@ -70,20 +77,26 @@ export function setupProviderRuntime(deps: ProviderRuntimeDeps): ProviderRuntime
     buildProviderForIdRuntime,
   } = deps;
 
+  // Local mutable config — seeded from deps, kept in sync via onConfigUpdate.
+  let cfg = initialConfig;
+  const sync = (next: Config): void => {
+    cfg = next;
+    onConfigUpdate(next);
+  };
+
   // ── Provider config helpers ────────────────────────────────────────────
-  const cfgRef = config;
   const resolveProviderCfg = (providerId: string) =>
-    resolveProviderCfgRuntime(cfgRef.current, providerId);
+    resolveProviderCfgRuntime(cfg, providerId);
 
   const buildProviderForId = (providerId: string): Provider =>
-    buildProviderForIdRuntime({ config: cfgRef.current, providerRegistry }, providerId);
+    buildProviderForIdRuntime({ config: cfg, providerRegistry }, providerId);
 
   const refreshMaxContextFor = async (
     providerId: string,
     modelId: string,
   ): Promise<void> => {
-    const { cfg } = resolveProviderCfg(providerId);
-    await refreshMaxContext(providerId, modelId, cfg);
+    const { cfg: resolvedCfg } = resolveProviderCfg(providerId);
+    await refreshMaxContext(providerId, modelId, resolvedCfg);
   };
 
   const refreshRuntimeModelStateFor = async (
@@ -97,7 +110,7 @@ export function setupProviderRuntime(deps: ProviderRuntimeDeps): ProviderRuntime
   // ── Fallback extension ─────────────────────────────────────────────────
   agent.extensions.register(
     createFallbackModelExtension({
-      getConfig: () => cfgRef.current,
+      getConfig: () => cfg,
       buildProvider: buildProviderForId,
       onModelSwitch: refreshRuntimeModelStateFor,
       events,
@@ -106,7 +119,7 @@ export function setupProviderRuntime(deps: ProviderRuntimeDeps): ProviderRuntime
   );
 
   // ── Session-end memory consolidation ───────────────────────────────────
-  if (cfgRef.current.features.memory && cfgRef.current.features.memoryConsolidation !== false) {
+  if (cfg.features.memory && cfg.features.memoryConsolidation !== false) {
     agent.extensions.register(
       new SessionMemoryConsolidator({
         memoryStore,
@@ -122,7 +135,7 @@ export function setupProviderRuntime(deps: ProviderRuntimeDeps): ProviderRuntime
     try {
       context.provider = buildProviderForId(providerId);
       context.model = modelId;
-      cfgRef.current = patchConfig(cfgRef.current, { provider: providerId, model: modelId });
+      sync(patchConfig(cfg, { provider: providerId, model: modelId }));
       configStore.update({ provider: providerId, model: modelId });
       await refreshMaxContextFor(providerId, modelId);
       await refreshActiveReasoningConfig(providerId, modelId);
@@ -138,13 +151,13 @@ export function setupProviderRuntime(deps: ProviderRuntimeDeps): ProviderRuntime
       wpaths.globalConfig,
       vault,
       (snapshot: AnyObj) => {
-        const activeId = cfgRef.current.provider;
+        const activeId = cfg.provider;
         const before = JSON.stringify(resolveProviderCfg(activeId).cfg);
-        cfgRef.current = patchConfig(cfgRef.current, {
+        sync(patchConfig(cfg, {
           providers: snapshot.providers,
           ...(snapshot.apiKey !== undefined ? { apiKey: snapshot.apiKey } : {}),
           ...(snapshot.baseUrl !== undefined ? { baseUrl: snapshot.baseUrl } : {}),
-        });
+        }));
         configStore.update({
           providers: snapshot.providers,
           ...(snapshot.apiKey !== undefined ? { apiKey: snapshot.apiKey } : {}),

--- a/packages/cli/src/wiring/provider-runtime-setup.ts
+++ b/packages/cli/src/wiring/provider-runtime-setup.ts
@@ -1,0 +1,174 @@
+import {
+  type Config,
+  createFallbackModelExtension,
+  type EventBus,
+  type Logger,
+  type Provider,
+  type ProviderConfig,
+  type ProviderRegistry,
+  type SecretVault,
+  SessionMemoryConsolidator,
+  type WstackPaths,
+  watchProviderConfig,
+} from '@wrongstack/core';
+import { patchConfig } from '../utils.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// biome-ignore lint/suspicious/noExplicitAny: large dep bag
+type AnyObj = any;
+
+export interface ProviderRuntimeDeps {
+  config: { current: Config };
+  configStore: AnyObj;
+  providerRegistry: ProviderRegistry;
+  agent: AnyObj;
+  memoryStore: AnyObj;
+  refreshMaxContext: (providerId: string, modelId: string, cfg?: ProviderConfig) => Promise<void>;
+  refreshActiveReasoningConfig: (providerId: string, modelId: string) => Promise<void>;
+  wpaths: WstackPaths;
+  vault: SecretVault;
+  logger: Logger;
+  teardownHandlers: (() => void)[];
+  context: AnyObj;
+  events: EventBus;
+  resolveProviderCfgRuntime: (config: Config, providerId: string) => { cfg: ProviderConfig };
+  buildProviderForIdRuntime: (opts: { config: Config; providerRegistry: ProviderRegistry }, providerId: string) => Provider;
+}
+
+export interface ProviderRuntimeResult {
+  resolveProviderCfg: (providerId: string) => { cfg: ProviderConfig };
+  buildProviderForId: (providerId: string) => Provider;
+  refreshMaxContextFor: (providerId: string, modelId: string) => Promise<void>;
+  refreshRuntimeModelStateFor: (providerId: string, modelId: string) => Promise<void>;
+  switchProviderAndModel: (providerId: string, modelId: string) => Promise<string | null>;
+}
+
+/**
+ * Wire runtime provider-config helpers, fallback model extension,
+ * memory consolidation, the provider/model switch callback, and
+ * the credential hot-reload watcher.
+ */
+export function setupProviderRuntime(deps: ProviderRuntimeDeps): ProviderRuntimeResult {
+  const {
+    config,
+    configStore,
+    providerRegistry,
+    agent,
+    memoryStore,
+    refreshMaxContext,
+    refreshActiveReasoningConfig,
+    wpaths,
+    vault,
+    logger,
+    teardownHandlers,
+    context,
+    events,
+    resolveProviderCfgRuntime,
+    buildProviderForIdRuntime,
+  } = deps;
+
+  // ── Provider config helpers ────────────────────────────────────────────
+  const cfgRef = config;
+  const resolveProviderCfg = (providerId: string) =>
+    resolveProviderCfgRuntime(cfgRef.current, providerId);
+
+  const buildProviderForId = (providerId: string): Provider =>
+    buildProviderForIdRuntime({ config: cfgRef.current, providerRegistry }, providerId);
+
+  const refreshMaxContextFor = async (
+    providerId: string,
+    modelId: string,
+  ): Promise<void> => {
+    const { cfg } = resolveProviderCfg(providerId);
+    await refreshMaxContext(providerId, modelId, cfg);
+  };
+
+  const refreshRuntimeModelStateFor = async (
+    providerId: string,
+    modelId: string,
+  ): Promise<void> => {
+    await refreshMaxContextFor(providerId, modelId);
+    await refreshActiveReasoningConfig(providerId, modelId);
+  };
+
+  // ── Fallback extension ─────────────────────────────────────────────────
+  agent.extensions.register(
+    createFallbackModelExtension({
+      getConfig: () => cfgRef.current,
+      buildProvider: buildProviderForId,
+      onModelSwitch: refreshRuntimeModelStateFor,
+      events,
+      logger,
+    }),
+  );
+
+  // ── Session-end memory consolidation ───────────────────────────────────
+  if (cfgRef.current.features.memory && cfgRef.current.features.memoryConsolidation !== false) {
+    agent.extensions.register(
+      new SessionMemoryConsolidator({
+        memoryStore,
+      }),
+    );
+  }
+
+  // ── Provider/model switch callback ─────────────────────────────────────
+  const switchProviderAndModel = async (
+    providerId: string,
+    modelId: string,
+  ): Promise<string | null> => {
+    try {
+      context.provider = buildProviderForId(providerId);
+      context.model = modelId;
+      cfgRef.current = patchConfig(cfgRef.current, { provider: providerId, model: modelId });
+      configStore.update({ provider: providerId, model: modelId });
+      await refreshMaxContextFor(providerId, modelId);
+      await refreshActiveReasoningConfig(providerId, modelId);
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  };
+
+  // ── Credential hot-reload watcher ──────────────────────────────────────
+  if (process.env['WRONGSTACK_DISABLE_CONFIG_WATCH'] !== '1') {
+    const credentialWatcher = watchProviderConfig(
+      wpaths.globalConfig,
+      vault,
+      (snapshot: AnyObj) => {
+        const activeId = cfgRef.current.provider;
+        const before = JSON.stringify(resolveProviderCfg(activeId).cfg);
+        cfgRef.current = patchConfig(cfgRef.current, {
+          providers: snapshot.providers,
+          ...(snapshot.apiKey !== undefined ? { apiKey: snapshot.apiKey } : {}),
+          ...(snapshot.baseUrl !== undefined ? { baseUrl: snapshot.baseUrl } : {}),
+        });
+        configStore.update({
+          providers: snapshot.providers,
+          ...(snapshot.apiKey !== undefined ? { apiKey: snapshot.apiKey } : {}),
+          ...(snapshot.baseUrl !== undefined ? { baseUrl: snapshot.baseUrl } : {}),
+        });
+        const after = JSON.stringify(resolveProviderCfg(activeId).cfg);
+        if (after === before) return;
+        try {
+          context.provider = buildProviderForId(activeId);
+          logger.info(`Provider credentials reloaded from config.json (${activeId})`);
+        } catch (err) {
+          logger.warn(`Credential hot-reload failed for ${activeId}: ${(err as Error).message ?? String(err)}`);
+        }
+      },
+      { warn: (msg) => logger.warn(`Config watcher: ${msg}`) },
+    );
+    teardownHandlers.push(() => credentialWatcher.close());
+  }
+
+  return {
+    resolveProviderCfg,
+    buildProviderForId,
+    refreshMaxContextFor,
+    refreshRuntimeModelStateFor,
+    switchProviderAndModel,
+  };
+}

--- a/packages/cli/tests/pre-launch.test.ts
+++ b/packages/cli/tests/pre-launch.test.ts
@@ -646,7 +646,7 @@ describe('maybeAskAboutIndexing', () => {
     expect(reader.readLine).toHaveBeenCalledTimes(1);
   });
 
-  it('returns true on empty input (defaults to yes)', async () => {
+  it('returns false on empty input (defaults to skip)', async () => {
     const root = '/proj';
     const reader = makeReader(['']);
 
@@ -662,7 +662,7 @@ describe('maybeAskAboutIndexing', () => {
       indexingConfigured: true,
     });
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   it('counts recursively across nested directories', async () => {


### PR DESCRIPTION
## Summary

Six commits on `feat/startup-prompt-timeout` that improve startup UX and continue the cli-main.ts modularization.

## Changes

### 1. Startup prompt auto-default after 5s timeout

- `ReadlineInputReader.readLine()` gains optional `{ timeoutMs, defaultAnswer }`
- Provider/model "Continue with these?" → 5s auto-Y
- Launch mode "Continue with these?" → 5s auto-Y
- Codebase indexing question → 5s auto-N (warning-only)

### 2. `--skip` flag

- `--skip` bypasses all three startup prompts (provider picker, launch mode, indexing)
- Uses saved preferences or sensible defaults
- Also acts as `--skip-index` for the indexing question

### 3–6. cli-main.ts modular extractions (4 new modules, −743 lines)

| Module | Lines | Responsibility |
|---|---|---|
| `wiring/hq-telemetry.ts` | 230 | HQ WebSocket + 6 telemetry bridges + Agent Monitor forwarding |
| `wiring/dep-watcher.ts` | 117 | Tech-stack consumer + package-outdated watcher |
| `wiring/director-setup.ts` | 188 | Director/autonomy mode, fleet paths, Agent Monitor |
| `wiring/lifecycle-plugins.ts` | 352 | Lifecycle hooks, compaction, agent, MCP, plugins |

cli-main.ts: **3492 → 2484 lines** (−1008 total including prior peer work).

## Key design decisions

- **Mutable ref pattern** — `effectiveMaxContext` returned as `{ current: number }` so both the extracted function's `applyMaxContext` closure and the caller's `onContextLimit` mutate the same value
- **`hqPublisherRef`** — brainMailbox captures a ref instead of a `let` variable, populated when the HQ WebSocket connection establishes
- **`let` destructuring** — mutable vars (`director`, `eternalEngine`, `autonomyMode`) are `let`-destructured for later reassignment by the caller

## Verification

- Monorepo typecheck: ✅ all 17 packages
- CLI tests: 188/188 ✅
- Pre-commit pipeline: tsup build + tsc --noEmit across all workspace packages