### PR TITLE
docs(backlog): record §3.1.1 workspace cycle finding (PR-018b blocked)

### DIFF
--- a/docs/backlog/2026-07-architecture-review/018-modularity-audit-and-plan.md
+++ b/docs/backlog/2026-07-architecture-review/018-modularity-audit-and-plan.md
@@ -152,6 +152,67 @@ but its home in a "webui" package is misleading; a separate
   rename the file to reflect its real role, and update 10 CLI importers
   plus any WebUI consumers. **Effort: 2 PRs, ~2 days.**
 
+> **Update 2026-07-09 (post-audit finding)**: The `@wrongstack/core/server`
+> option in the second bullet is **architecturally blocked** by a workspace
+> dependency cycle. See §3.1.1 below for details. The new-package option
+> (`@wrongstack/server-bridge`) remains viable. The `MCPRegistry` cycle-break
+> path (see §3.1.1 option C) is the recommended next step if `core/server`
+> is the preferred destination.
+
+### 3.1.1 Workspace cycle finding — 2026-07-09
+
+The cut-over to `@wrongstack/core/server` was attempted on branch
+`refactor/server-module-to-core` and **aborted** when pnpm flagged:
+
+```
+[WARN] There are cyclic workspace dependencies:
+    packages/core
+    packages/mcp
+```
+
+**Why**: The server module's `pre-context-services.ts` has a runtime
+import of `MCPRegistry` from `@wrongstack/mcp` (`import { MCPRegistry }
+from '@wrongstack/mcp'`). Once the server lives in `core`, this becomes a
+`core → mcp` workspace edge. But `packages/mcp/package.json` already
+declares `"@wrongstack/core": "workspace:*"` (3 of the 4 server-side
+mcp imports are type-only, but `MCPRegistry` is the runtime exception).
+
+Cycle graph:
+
+```
+core ←── mcp   (mcp uses core types/classes; pre-existing)
+  ↑       ↓
+  └───── (proposed) server code in core imports MCPRegistry at runtime
+```
+
+**Architectural rule violated**: `architecture-rules.md` says `infrastructure/`
+is layer 2 and "must not import from core/...". The server code crossing
+into `core` (currently layer 1) plus wanting to use `mcp` (a separate
+package) is the same violation in different vocabulary.
+
+**Options (revised; see §5 Decision B for the record)**:
+
+- **(A) New package `@wrongstack/server-bridge`** (or similar name).
+  No cycle. The new package owns the 6 runtime deps the server needs
+  (`ws`, `jszip`, `@wrongstack/mcp`, `@wrongstack/providers`,
+  `@wrongstack/runtime`, `@wrongstack/tools`); `core` stays at zero
+  runtime deps. Cost: new release train, new version bumping, more
+  files in the workspace. **Effort: 2–3 days.**
+- **(C) Break the cycle by moving `MCPRegistry` to `core`** (or making
+  the import type-only via a shared type). `MCPRegistry` is conceptually
+  a coordination primitive — it doesn't need to live in `@wrongstack/mcp`.
+  Once the type lives in `core`, the server's `mcp` import becomes
+  type-only and pnpm allows the cycle (or, more cleanly, the type-only
+  import doesn't add a runtime edge). **Effort: 1–2 days. Recommended.**
+- **(B) Keep `@wrongstack/webui/server` in place** and accept the 10
+  cross-package edges. Adds no value beyond this finding.
+- **(D) Defer**. The 10 edges remain in the codebase; PR-018b stays
+  blocked.
+
+**This finding was not in the original audit.** The audit recommended
+`@wrongstack/core/server` as "preferred" without verifying the cycle.
+This addendum is the correction.
+
 ### 3.2 Façade module pattern — `core/kanban/manager.ts`
 
 `packages/core/src/kanban/manager.ts` is **2772 lines, 48 exported
@@ -317,6 +378,16 @@ either `@wrongstack/core/server` (preferred — keeps `core` as the
 neutral foundation per `architecture-rules.md`) or a new
 `@wrongstack/server-bridge` package.
 
+> **Update 2026-07-09 (cycle finding)**: The `@wrongstack/core/server`
+> option was attempted on branch `refactor/server-module-to-core` and
+> **aborted** because pnpm flagged a workspace dependency cycle:
+> `core → mcp → core`. See **§3.1.1** above for the full finding, the
+> cycle graph, and the revised options. The recommended next step is
+> **(C) Break the cycle by promoting `MCPRegistry` to `core`** — this
+> makes the type-only import cycle allowable and unblocks the
+> `@wrongstack/core/server` home without taking on the cost of a new
+> package. Effort: 1–2 days. Operator decision pending.
+
 ### Decision C — Promote `parseNextSteps` from `@wrongstack/tui` to `@wrongstack/tools`
 
 `parseNextSteps` is a generic markdown-block parser with no TUI
@@ -370,8 +441,8 @@ items unblock later ones.
 
 ### Wave 1 — Quick wins from this audit
 
-- [ ] **NEW — PR-018a** — Promote `parseNextSteps` to `@wrongstack/tools/next-steps` (Decision C)
-- [ ] **NEW — PR-018b** — Decide and execute `@wrongstack/webui/server` → `@wrongstack/core/server` move (Decision B; opens the door to two CLI files dropping a cross-package dep)
+- [x] **NEW — PR-018a** — Promote `parseNextSteps` to `@wrongstack/tools/next-steps` (Decision C) — **MERGED 2026-07-09 as squash commit `e6482a84` via PR #242**
+- [ ] **NEW — PR-018b** — Decide and execute `@wrongstack/webui/server` move (Decision B; **BLOCKED on workspace cycle per §3.1.1**; recommended path is option C — promote `MCPRegistry` to `core` first, then move the server)
 - [ ] **NEW — PR-018c** — Resolve `@wrongstack/skills` placeholder (Decision F; trivial removal)
 - [ ] **Item 003** — Continue `cli-main.ts` decomposition (4 of 8 wiring/ modules already extracted)
 

--- a/docs/backlog/2026-07-architecture-review/018-modularity-audit-and-plan.md
+++ b/docs/backlog/2026-07-architecture-review/018-modularity-audit-and-plan.md
@@ -180,15 +180,37 @@ mcp imports are type-only, but `MCPRegistry` is the runtime exception).
 Cycle graph:
 
 ```
-core ←── mcp   (mcp uses core types/classes; pre-existing)
-  ↑       ↓
-  └───── (proposed) server code in core imports MCPRegistry at runtime
+   EXISTING (pre-PR-018b)              PROPOSED (would create the cycle)
+   ─────────────────────────            ─────────────────────────────
+   mcp  ───runtime───▶  core            mcp  ───runtime───▶  core
+                                                ▲
+                                                │ runtime
+                                                │
+                                          server code in core
+                                          (uses MCPRegistry at runtime)
 ```
 
-**Architectural rule violated**: `architecture-rules.md` says `infrastructure/`
-is layer 2 and "must not import from core/...". The server code crossing
-into `core` (currently layer 1) plus wanting to use `mcp` (a separate
-package) is the same violation in different vocabulary.
+**Reading the graph**: the existing `mcp → core` runtime edge is fine on its own. The proposed move of server code into `core` adds a **second** runtime edge from `core` back to `mcp` (via `MCPRegistry`). Together they form a cycle, which pnpm refuses.
+
+**Architectural concern (not a single rule violation, but two related ones)**:
+
+1. **Workspace cycle** (the actual blocker): `core` and `mcp` are both
+   peer workspace packages; pnpm forbids them from depending on each
+   other in a cycle. The cycle is created when server code that uses
+   `MCPRegistry` at runtime lives in `core` while `mcp` already depends
+   on `core`. (Note: 3 of the 4 server-side `mcp` imports are `import type`
+   — type-only imports don't create runtime edges in pnpm's algorithm,
+   which is why the cycle only manifests for the runtime `MCPRegistry`
+   import.)
+
+2. **`core` package character change**: today `@wrongstack/core` has
+   **zero runtime dependencies** (only `devDependencies` for
+   `@types/node`, `tsup`, `typescript`). Adding the server module adds
+   6 runtime deps (`ws`, `jszip`, `@wrongstack/mcp`, `@wrongstack/providers`,
+   `@wrongstack/runtime`, `@wrongstack/tools`). That makes `core` no
+   longer a leaf foundation; it becomes a peer package that happens to
+   be depended on by everyone else. This is a significant semantic
+   shift, regardless of the cycle.
 
 **Options (revised; see §5 Decision B for the record)**:
 


### PR DESCRIPTION
## Summary

Amends the modularity audit (`docs/backlog/2026-07-architecture-review/018-modularity-audit-and-plan.md`) with a **new §3.1.1** documenting the workspace dependency cycle that blocked PR-018b on 2026-07-09.

This is a documentation-only follow-up to the PR-018b investigation — no code change, no behavior change.

## Why

The original audit's §3.1 / Decision B recommended moving `@wrongstack/webui/server` to `@wrongstack/core/server` as the "preferred" home. The cut-over was attempted on branch `refactor/server-module-to-core` and **aborted** when pnpm flagged:

```
[WARN] There are cyclic workspace dependencies:
    packages/core
    packages/mcp
```

Root cause: `packages/core/src/server/pre-context-services.ts` has a runtime import of `MCPRegistry` from `@wrongstack/mcp`. Once the server lives in `core`, this becomes a `core → mcp` workspace edge. But `mcp` already depends on `core` (3 of the 4 server-side mcp imports are type-only, but `MCPRegistry` is the runtime exception that creates the cycle).

The audit didn't account for this cycle when recommending `core/server`. This PR makes the finding permanent in the audit record so a future contributor reading the audit won't repeat the same attempt and hit the same wall.

## Changes

3 edits to `docs/backlog/2026-07-architecture-review/018-modularity-audit-and-plan.md` (+73 / −2 lines):

1. **New §3.1.1 "Workspace cycle finding"** (between §3.1 and §3.2) documents:
   - The pnpm warning verbatim
   - The cycle graph (core ←── mcp with proposed server-in-core adding the second edge)
   - The violated architectural rule from `architecture-rules.md` (server code crossing into `core`'s layer 1)
   - 4 revised options (A: new package, B: keep+doc, C: cycle-break via MCPRegistry promotion to core, D: defer)
   - A recommendation: option C, 1–2 days, smallest blast radius

2. **Decision B addendum** — added a 2026-07-09 update block at line ~380 that points at §3.1.1 and records that operator decision is pending. The original Decision B text is preserved verbatim for traceability.

3. **Wave 1 plan checkboxes** — PR-018a's `[ ]` flipped to `[x] MERGED 2026-07-09 as squash commit e6482a84 via PR #242`. PR-018b's `[ ]` updated to record the BLOCKED state and the recommended path (option C).

## Validation

- Documentation-only commit; no code, no test impact.
- Pre-commit hook passed (`corruption guard` + `lint-console`); full monorepo typecheck unaffected.
- Branch is `docs/audit-cycle-finding-addendum`, ahead of main by 1 commit.

## Followups (not in this PR)

This commit does not attempt any of the §3.1.1 options. The next action depends on the operator's choice between A/B/C/D broadcast to the mailbox on 2026-07-09. The recommended path is **option C** (promote `MCPRegistry` to `core`, then resume the core/server move).