### PR TITLE
feat(cli): /tuneup (alias /checkup) — health, context-cost & performance checkup

### DIFF
--- a/docs/slash/tuneup.md
+++ b/docs/slash/tuneup.md
@@ -2,60 +2,80 @@
 
 ## What It Does
 
-`/tuneup` runs a broad **health + context-cost checkup** of your WrongStack
-setup and prints a findings list. `/tuneup fix` applies the safe, deterministic
-subset and hands the judgement-heavy items to the agent as a follow-up turn.
+`/tuneup` runs a broad **health + context-cost + performance checkup** of your
+WrongStack setup and prints a findings list. `/tuneup fix` applies the safe,
+deterministic subset; `/tuneup fix --power` also flips the autonomy profile; and
+`/tuneup deep` hands the findings to the agent for a project-specific plan.
 
 Where [`/doctor`](./doctor.md) repairs the config JSON, `/tuneup` sweeps the
-wider setup — skills, MCP servers, plugins, instruction files, hooks, version,
-autonomy, and the permission allowlist. Bare `/tuneup` is strictly read-only.
-
-`/checkup` is a registered alias.
+wider setup and recommends the knobs that make a session faster and more
+resilient. Bare `/tuneup` is strictly read-only. `/checkup` is a registered alias.
 
 ## Checks
 
-| # | Group | What it flags | `/tuneup fix` |
-|---|---|---|---|
-| 1 | Skills | Eager skill bodies exceeding `skills.eagerMaxChars`; foreign (`.claude`/other-tool) skills injected into every prompt | Advisory (switch to `skills.mode: progressive` / trim sources) |
-| 1 | MCP servers | Configured-but-disabled servers; live servers stuck in `failed` | Advisory (`/mcp remove`/`restart`) |
-| 1 | Plugins | Plugins listed in config but disabled | Advisory (remove the entry) |
-| 2 | Instruction files | The same significant line duplicated across user memory / project `AGENTS.md` / root `CLAUDE.md` | Agent hand-off (dedup, keeping the committed copy) |
-| 3 | Instruction files | Oversized root instruction file (> 12k chars or > 400 lines) | Agent hand-off (split into skills / nested files) |
-| 4 | Hooks | Shell hooks with a ≥ 10s timeout; many hooks on one event | **Clamps** the timeout to 10s |
-| 5 | Version | A newer WrongStack on npm (cached, best-effort) | Advisory (`wrongstack update`) |
-| 6 | Autonomy | `autonomy.defaultMode` is not `auto` | **Sets** `autonomy.defaultMode: "auto"` |
-| 7 | Permissions | Read-only bash/exec commands that keep getting denied (trust file `deny[]` + session history) | **Adds** the safe command names to `tools.exec.allow` |
+| Group | What it flags | `/tuneup fix` |
+|---|---|---|
+| Version | A newer WrongStack on npm (cached, best-effort) | Advisory (`wrongstack update`) |
+| Autonomy | `autonomy.defaultMode` is not `auto` | **`--power` only** |
+| Performance | Auto-fallback off with no chain; adaptive concurrency off; circuit-breaker off; session-start indexing off; oversubscribed `maxConcurrent` | **Writes** `fallbackAuto`, `adaptiveConcurrency.enabled`; rest advisory |
+| Reliability | `session.auditLevel: minimal`; vault key not passphrase-hardened; large session logs | Advisory (`/prune`, `WRONGSTACK_VAULT_PASSPHRASE`) |
+| Config | `/doctor`-style config issues | Advisory (`/doctor fix`) |
+| Skills | Eager bodies over `skills.eagerMaxChars`; foreign skills injected every prompt | **Writes** `skills.mode: progressive` |
+| MCP | Configured-but-disabled servers; live `failed` servers | Advisory |
+| Plugins | Listed but disabled | Advisory |
+| Instruction files | Duplicated lines across memory/AGENTS.md/CLAUDE.md; oversized root file | Agent hand-off |
+| Hooks | Shell hooks ≥ 10s timeout; many hooks on one event | **Clamps** the timeout |
+| Permissions | Read-only bash/exec commands that keep getting denied | **Adds** to `tools.exec.allow` |
 
 ## Usage
 
 | Usage | Effect |
 |---|---|
 | `/tuneup` | Run all checks, read-only report |
-| `/tuneup fix` | Apply deterministic fixes + hand fuzzy items to the agent |
-| `/checkup` | Alias for `/tuneup` |
+| `/tuneup fix` | Apply safe deterministic fixes (never touches autonomy) |
+| `/tuneup fix --power` | …and enable the autonomy + YOLO + director profile |
+| `/tuneup fix --pick` | Confirm each fix before applying |
+| `/tuneup fix --profile power` | Alias for `fix --power` |
+| `/tuneup deep` | Hand the findings to the agent for a tailored optimization plan |
+| `/checkup …` | Alias for `/tuneup` |
+
+## The power profile
+
+A plain `/tuneup fix` **never** flips autonomy, YOLO, or director — that respects
+the "autonomy is user-owned" invariant. Only the explicit `--power` opt-in writes
+`autonomy.defaultMode: "auto"`, `yolo: true`, and `launch.director: true`, and
+live-applies YOLO + auto mode through the same runtime controllers `/yolo` and
+`/autonomy` use, so it takes effect immediately.
+
+## Deep mode
+
+`/tuneup deep` is the non-mechanical tier: it runs the report, then hands the
+agent a prompt with the live findings and asks for a prioritized, project-aware
+optimization plan (which knob, why it helps here, how to apply). It changes
+nothing itself — the plan is for you to approve.
 
 ## Fix Safety
 
-- Only three change kinds are ever written mechanically: `autonomy.defaultMode`,
+- Deterministic changes only: `autonomy.defaultMode` / `yolo` / `launch.director`
+  (power), `fallbackAuto`, `adaptiveConcurrency.enabled`, `skills.mode`,
   `tools.exec.allow`, and slow-hook `timeoutMs`. Everything else is advisory or
   handed to the agent.
 - Writes target the **global** `~/.wrongstack/config.json` (never the untrusted
-  in-project config — `tools.exec.allow` is a trusted-source-only field), and
-  are preceded by a backup using the config-history convention (`config.json.last`
-  plus a timestamped `.bak`). The change is mirrored into the in-memory config
-  store and `/config-history`, so it takes effect without a restart.
+  in-project config — `tools.exec.allow` is a trusted-source-only field), and are
+  preceded by a backup (`config.json.last` + a timestamped `.bak`). The change is
+  mirrored into the in-memory config store and `/config-history`, so it takes
+  effect without a restart.
 - A corrupt global config is left untouched — `/tuneup fix` tells you to run
   `/doctor fix` first.
-- The permission check uses a **conservative** read-only heuristic (a small
-  allowlist of verbs like `ls`/`cat`/`grep`/`git status`, rejecting anything
-  with redirection, pipes, or a write subcommand). An explicit `deny[]` entry is
-  never overridden.
+- The permission check uses a conservative read-only heuristic (verbs like
+  `ls`/`cat`/`grep`/`git status`; rejects redirection, pipes, write subcommands).
 - Instruction-file cleanups are handed to the agent with an explicit "ask before
   deleting anything" instruction — nothing is auto-deleted.
 
 ## Code Reference
 
-- `packages/cli/src/tuneup.ts` — pure check engine (`runTuneup` + per-item checks)
-- `packages/cli/src/slash-commands/tuneup.ts` — the command (IO, backups, fixes)
-- `packages/cli/src/update-check.ts` — reused `checkForUpdate()` (item 5)
+- `packages/cli/src/tuneup.ts` — pure check engine (`runTuneup`, per-item checks, `buildDeepPrompt`)
+- `packages/cli/src/slash-commands/tuneup.ts` — the command (IO, backups, fixes, arg parsing)
+- `packages/cli/src/update-check.ts` — reused `checkForUpdate()` (version check)
+- `packages/cli/src/config-doctor.ts` — reused `diagnoseConfig()` (config category)
 - `packages/cli/src/config-history.ts` — backup/persist convention reused here

--- a/docs/slash/tuneup.md
+++ b/docs/slash/tuneup.md
@@ -1,0 +1,61 @@
+# /tuneup - Session tune-up (alias: /checkup)
+
+## What It Does
+
+`/tuneup` runs a broad **health + context-cost checkup** of your WrongStack
+setup and prints a findings list. `/tuneup fix` applies the safe, deterministic
+subset and hands the judgement-heavy items to the agent as a follow-up turn.
+
+Where [`/doctor`](./doctor.md) repairs the config JSON, `/tuneup` sweeps the
+wider setup — skills, MCP servers, plugins, instruction files, hooks, version,
+autonomy, and the permission allowlist. Bare `/tuneup` is strictly read-only.
+
+`/checkup` is a registered alias.
+
+## Checks
+
+| # | Group | What it flags | `/tuneup fix` |
+|---|---|---|---|
+| 1 | Skills | Eager skill bodies exceeding `skills.eagerMaxChars`; foreign (`.claude`/other-tool) skills injected into every prompt | Advisory (switch to `skills.mode: progressive` / trim sources) |
+| 1 | MCP servers | Configured-but-disabled servers; live servers stuck in `failed` | Advisory (`/mcp remove`/`restart`) |
+| 1 | Plugins | Plugins listed in config but disabled | Advisory (remove the entry) |
+| 2 | Instruction files | The same significant line duplicated across user memory / project `AGENTS.md` / root `CLAUDE.md` | Agent hand-off (dedup, keeping the committed copy) |
+| 3 | Instruction files | Oversized root instruction file (> 12k chars or > 400 lines) | Agent hand-off (split into skills / nested files) |
+| 4 | Hooks | Shell hooks with a ≥ 10s timeout; many hooks on one event | **Clamps** the timeout to 10s |
+| 5 | Version | A newer WrongStack on npm (cached, best-effort) | Advisory (`wrongstack update`) |
+| 6 | Autonomy | `autonomy.defaultMode` is not `auto` | **Sets** `autonomy.defaultMode: "auto"` |
+| 7 | Permissions | Read-only bash/exec commands that keep getting denied (trust file `deny[]` + session history) | **Adds** the safe command names to `tools.exec.allow` |
+
+## Usage
+
+| Usage | Effect |
+|---|---|
+| `/tuneup` | Run all checks, read-only report |
+| `/tuneup fix` | Apply deterministic fixes + hand fuzzy items to the agent |
+| `/checkup` | Alias for `/tuneup` |
+
+## Fix Safety
+
+- Only three change kinds are ever written mechanically: `autonomy.defaultMode`,
+  `tools.exec.allow`, and slow-hook `timeoutMs`. Everything else is advisory or
+  handed to the agent.
+- Writes target the **global** `~/.wrongstack/config.json` (never the untrusted
+  in-project config — `tools.exec.allow` is a trusted-source-only field), and
+  are preceded by a backup using the config-history convention (`config.json.last`
+  plus a timestamped `.bak`). The change is mirrored into the in-memory config
+  store and `/config-history`, so it takes effect without a restart.
+- A corrupt global config is left untouched — `/tuneup fix` tells you to run
+  `/doctor fix` first.
+- The permission check uses a **conservative** read-only heuristic (a small
+  allowlist of verbs like `ls`/`cat`/`grep`/`git status`, rejecting anything
+  with redirection, pipes, or a write subcommand). An explicit `deny[]` entry is
+  never overridden.
+- Instruction-file cleanups are handed to the agent with an explicit "ask before
+  deleting anything" instruction — nothing is auto-deleted.
+
+## Code Reference
+
+- `packages/cli/src/tuneup.ts` — pure check engine (`runTuneup` + per-item checks)
+- `packages/cli/src/slash-commands/tuneup.ts` — the command (IO, backups, fixes)
+- `packages/cli/src/update-check.ts` — reused `checkForUpdate()` (item 5)
+- `packages/cli/src/config-history.ts` — backup/persist convention reused here

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -1486,6 +1486,13 @@ export async function main(argv: string[]): Promise<number> {
         allServerPresets: allServers(),
       });
     },
+    mcpStatus: () =>
+      mcpRegistry.describe().map((s) => ({
+        name: s.name,
+        state: s.state,
+        enabled: s.enabled,
+        toolCount: s.toolCount,
+      })),
     onYolo: setYoloMode,
     onNextPredict: (setTo?: boolean) => {
       if (setTo !== undefined) {

--- a/packages/cli/src/slash-commands/index.ts
+++ b/packages/cli/src/slash-commands/index.ts
@@ -352,6 +352,14 @@ export interface SlashCommandContext {
   /** Manage MCP servers: add, remove, enable, disable, restart. */
   onMcp?: ((args: string) => Promise<string>) | undefined;
   /**
+   * Structured MCP server status for diagnostics (e.g. /tuneup). Backed by
+   * `mcpRegistry.describe()` — includes disabled + failed servers, unlike the
+   * rendered string `onMcp` returns. Undefined when no registry is wired.
+   */
+  mcpStatus?:
+    | (() => Array<{ name: string; state: string; enabled: boolean; toolCount: number }>)
+    | undefined;
+  /**
    * Fix a reported error or bug. Pass the error message or problem description.
    * Returns a structured diagnosis + fix plan, and sets up the next agent turn
    * with the appropriate skill (bug-hunter, typescript-strict, security-scanner).
@@ -575,6 +583,7 @@ import { buildTasksCommand } from './tasks.js';
 import { buildTechStackCommand } from './techstack.js';
 import { buildTelegramSettingsCommand } from './telegram-settings.js';
 import { buildTelegramSetupCommand } from './telegram-setup.js';
+import { buildTuneupCommand } from './tuneup.js';
 import { buildTodosCommand } from './todos.js';
 import { buildToolCommand } from './tool.js';
 import { buildToolsCommand } from './tools.js';
@@ -596,6 +605,7 @@ export function buildBuiltinSlashCommands(opts: SlashCommandContext): SlashComma
     buildDelegateCommand(opts),
     buildDevCommand(opts),
     buildDoctorCommand(opts),
+    buildTuneupCommand(opts),
     buildCodebaseReindexCommand(opts),
     buildTechStackCommand(opts),
     buildToolCommand(opts),

--- a/packages/cli/src/slash-commands/tuneup.ts
+++ b/packages/cli/src/slash-commands/tuneup.ts
@@ -1,0 +1,505 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { SlashCommand } from '@wrongstack/core';
+import { atomicWrite, color } from '@wrongstack/core';
+import { diagnoseConfig } from '../config-doctor.js';
+import { appendHistory } from '../config-history.js';
+import {
+  buildDeepPrompt,
+  DEFAULT_EAGER_MAX_CHARS,
+  runTuneup,
+  type TuneupAction,
+  type TuneupCategory,
+  type TuneupFinding,
+  type TuneupInput,
+  type TuneupMemoryFile,
+  type TuneupSkill,
+  type TuneupTrustPolicy,
+} from '../tuneup.js';
+import { checkForUpdate } from '../update-check.js';
+import { parseSubcommand } from './helpers.js';
+import type { SlashCommandContext } from './index.js';
+
+/**
+ * `/tuneup` (alias `/checkup`) — broad session health, context-cost, and
+ * performance checkup.
+ *
+ * Where `/doctor` repairs the config JSON, `/tuneup` sweeps the wider setup and
+ * suggests the config knobs that make a session faster and more resilient.
+ * Report-only by default; `/tuneup fix` applies the safe deterministic subset,
+ * `/tuneup fix --power` also enables the autonomy/yolo/director profile (explicit
+ * opt-in so a plain tune-up never flips those), and `/tuneup deep` hands the
+ * findings to the agent for a project-specific optimization plan.
+ */
+export function buildTuneupCommand(opts: SlashCommandContext): SlashCommand {
+  const help = [
+    'Usage:',
+    '  /tuneup                Run all health checks (read-only report)',
+    '  /tuneup fix            Apply safe deterministic fixes',
+    '  /tuneup fix --power    …and enable the autonomy/yolo/director profile',
+    '  /tuneup fix --pick     Confirm each fix before applying',
+    '  /tuneup deep           Hand the findings to the agent for a tailored plan',
+    '',
+    'Checks: skill/MCP/plugin context cost, duplicated & oversized instruction',
+    'files, slow shell hooks, updates, auto-mode default, denied read-only',
+    'commands, performance knobs (fallback, adaptive concurrency, indexing), and',
+    'reliability (audit level, vault, disk).',
+    '',
+    'Fix safety: only deterministic config changes are written; the global config',
+    'is backed up first (like /doctor). --power is the ONLY path that touches',
+    'autonomy/yolo/director. Instruction-file cleanups are handed to the agent,',
+    'never auto-deleted.',
+  ].join('\n');
+
+  return {
+    name: 'tuneup',
+    aliases: ['checkup'],
+    category: 'Config',
+    description: 'Health + performance checkup; /tuneup fix applies safe fixes.',
+    argsHint: '[fix [--power] [--pick] | deep]',
+    help,
+    async run(args) {
+      const parsed = parseArgs(args);
+      if (parsed.mode === 'help') return { message: help };
+      if (parsed.mode === 'usage') {
+        return { message: `${color.amber('Usage:')} /tuneup [fix [--power] [--pick] | deep]` };
+      }
+      if (!opts.paths) {
+        return { message: `${color.red('Error')} config paths not available.` };
+      }
+
+      const input = await gatherInput(opts, parsed.power);
+      const report = runTuneup(input);
+
+      const lines: string[] = [`${color.bold('WrongStack')} ${color.dim('— Tune-up')}`];
+      renderFindings(lines, report.findings);
+
+      // Deep mode: read-only report + hand the findings to the agent.
+      if (parsed.mode === 'deep') {
+        lines.push('', color.dim('  → asking the agent for a project-specific optimization plan…'));
+        return { message: lines.join('\n'), runText: buildDeepPrompt(report) };
+      }
+
+      if (parsed.mode === 'report') {
+        const fixable = report.findings.filter((f) => f.action).length;
+        const handoffs = report.findings.filter((f) => f.handoff).length;
+        lines.push('', summaryLine(report.findings, fixable, handoffs, parsed.power));
+        return { message: lines.join('\n') };
+      }
+
+      // Fix mode: collect actions (optionally confirm each), apply, hand off fuzzy items.
+      let actions = report.findings
+        .map((f) => f.action)
+        .filter((a): a is TuneupAction => !!a);
+
+      if (parsed.pick && opts.confirm) {
+        const chosen: TuneupAction[] = [];
+        for (const f of report.findings) {
+          if (!f.action) continue;
+          const ok = await opts.confirm(`Apply: ${f.fix ?? f.problem}?`, true);
+          if (ok) chosen.push(f.action);
+        }
+        actions = chosen;
+      }
+
+      const applied = await applyActions(actions, opts);
+
+      lines.push('');
+      if (applied.messages.length === 0) {
+        lines.push(color.dim('  no deterministic fixes to apply'));
+      } else {
+        for (const m of applied.messages) lines.push(`  ${color.green('✓')} ${m}`);
+        if (applied.changed) {
+          lines.push(
+            `  ${color.green('✓')} written ${color.dim('(backup: config.json.last + timestamped .bak)')}`,
+          );
+        }
+      }
+
+      const runText = report.agentHandoff || undefined;
+      if (runText) {
+        lines.push('', color.dim('  → handing instruction-file cleanups to the agent…'));
+      }
+      return { message: lines.join('\n'), ...(runText ? { runText } : {}) };
+    },
+  };
+}
+
+// ── Argument parsing ─────────────────────────────────────────────────────────
+
+interface ParsedArgs {
+  mode: 'report' | 'fix' | 'deep' | 'help' | 'usage';
+  power: boolean;
+  pick: boolean;
+}
+
+function parseArgs(args: string): ParsedArgs {
+  const { cmd, rest } = parseSubcommand(args);
+  const flags = [cmd, ...rest].filter((t) => t.startsWith('--'));
+  const profileIdx = rest.indexOf('--profile');
+  const profileVal = profileIdx >= 0 ? rest[profileIdx + 1] : undefined;
+  const power = flags.includes('--power') || profileVal === 'power';
+  const pick = flags.includes('--pick');
+
+  const sub = cmd.startsWith('--') || cmd === '' ? '' : cmd;
+  if (sub === 'help' || sub === '--help') return { mode: 'help', power, pick };
+  if (sub === 'deep') return { mode: 'deep', power, pick };
+  if (sub === 'fix') return { mode: 'fix', power, pick };
+  if (sub === '') return { mode: 'report', power, pick };
+  return { mode: 'usage', power, pick };
+}
+
+// ── Input gathering (all IO lives here) ──────────────────────────────────────
+
+async function gatherInput(opts: SlashCommandContext, power: boolean): Promise<TuneupInput> {
+  const config = opts.configStore.get();
+  const skillMode: 'eager' | 'progressive' = config.skills?.mode ?? 'eager';
+  const eagerMaxChars = config.skills?.eagerMaxChars ?? DEFAULT_EAGER_MAX_CHARS;
+
+  const [skills, memoryFiles, update, trust, configIssues, sessionBytes] = await Promise.all([
+    gatherSkills(opts, skillMode),
+    gatherMemoryFiles(opts),
+    gatherUpdate(),
+    gatherTrust(opts),
+    gatherConfigIssues(opts),
+    gatherSessionBytes(opts),
+  ]);
+
+  return {
+    config,
+    skills,
+    eagerMaxChars,
+    skillMode,
+    mcp: opts.mcpStatus?.(),
+    memoryFiles,
+    update,
+    trust,
+    configIssues,
+    power,
+    env: {
+      cpuCount: os.cpus().length,
+      providerCount: Object.keys(config.providers ?? {}).length,
+      vaultHardened: !!process.env['WRONGSTACK_VAULT_PASSPHRASE'],
+      sessionBytes,
+    },
+  };
+}
+
+async function gatherSkills(
+  opts: SlashCommandContext,
+  skillMode: 'eager' | 'progressive',
+): Promise<TuneupSkill[]> {
+  const loader = opts.skillLoader;
+  if (!loader) return [];
+  let manifests: Awaited<ReturnType<typeof loader.list>>;
+  try {
+    manifests = await loader.list();
+  } catch {
+    return [];
+  }
+  if (skillMode !== 'eager') {
+    return manifests.map((m) => ({ name: m.name, source: m.source }));
+  }
+  return Promise.all(
+    manifests.map(async (m) => {
+      try {
+        const body = await loader.readBody(m.name);
+        return { name: m.name, source: m.source, bodyChars: body.length };
+      } catch {
+        return { name: m.name, source: m.source };
+      }
+    }),
+  );
+}
+
+async function gatherMemoryFiles(opts: SlashCommandContext): Promise<TuneupMemoryFile[]> {
+  const paths = opts.paths;
+  if (!paths) return [];
+  const candidates: Array<{ label: string; file: string; committed: boolean }> = [
+    { label: 'user memory', file: paths.globalMemory, committed: false },
+    { label: 'project AGENTS.md', file: paths.inProjectAgentsFile, committed: true },
+    { label: 'root CLAUDE.md', file: path.join(opts.projectRoot, 'CLAUDE.md'), committed: true },
+    { label: 'root AGENTS.md', file: path.join(opts.projectRoot, 'AGENTS.md'), committed: true },
+  ];
+  const out: TuneupMemoryFile[] = [];
+  for (const c of candidates) {
+    try {
+      const content = await fs.readFile(c.file, 'utf8');
+      out.push({ label: c.label, path: c.file, content, committed: c.committed });
+    } catch {
+      // missing layer — skip
+    }
+  }
+  return out;
+}
+
+async function gatherUpdate(): Promise<TuneupInput['update']> {
+  try {
+    return await checkForUpdate();
+  } catch {
+    return undefined;
+  }
+}
+
+async function gatherTrust(opts: SlashCommandContext): Promise<TuneupTrustPolicy | undefined> {
+  const file = opts.paths?.projectTrust;
+  if (!file) return undefined;
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed as TuneupTrustPolicy;
+  } catch {
+    // no trust file yet, or unreadable — no permission findings
+  }
+  return undefined;
+}
+
+/** Count `/doctor`-style config issues so /tuneup can point at /doctor fix. */
+async function gatherConfigIssues(opts: SlashCommandContext): Promise<number> {
+  const file = opts.paths?.globalConfig;
+  if (!file) return 0;
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return diagnoseConfig(parsed).findings.length;
+  } catch {
+    return 0;
+  }
+}
+
+/** Best-effort total byte size of this project's session logs. */
+async function gatherSessionBytes(opts: SlashCommandContext): Promise<number | undefined> {
+  const dir = opts.paths?.projectSessions;
+  if (!dir) return undefined;
+  try {
+    return await dirSize(dir);
+  } catch {
+    return undefined;
+  }
+}
+
+async function dirSize(dir: string): Promise<number> {
+  let total = 0;
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      total += await dirSize(full);
+    } else if (e.isFile()) {
+      try {
+        total += (await fs.stat(full)).size;
+      } catch {
+        // race with rotation — ignore
+      }
+    }
+  }
+  return total;
+}
+
+// ── Fix application (writes to the GLOBAL config only) ────────────────────────
+
+interface ApplyResult {
+  messages: string[];
+  changed: boolean;
+}
+
+async function applyActions(
+  actions: TuneupAction[],
+  opts: SlashCommandContext,
+): Promise<ApplyResult> {
+  const messages: string[] = [];
+  if (actions.length === 0 || !opts.paths) return { messages, changed: false };
+
+  const file = opts.paths.globalConfig;
+  let raw = '{}';
+  try {
+    raw = await fs.readFile(file, 'utf8');
+  } catch {
+    // no global config yet — start from an empty object
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {
+      messages: [`${color.red('✗')} global config is not valid JSON — run /doctor fix first`],
+      changed: false,
+    };
+  }
+  const before = JSON.stringify(parsed);
+
+  // Track live-apply intents so a fix takes effect this session, not just next boot.
+  let liveYolo = false;
+  let liveAutonomyAuto = false;
+
+  for (const action of actions) {
+    if (action.kind === 'set-config') {
+      setDeep(parsed, action.path, action.value);
+      messages.push(action.label);
+      if (action.path.length === 1 && action.path[0] === 'yolo' && action.value === true) {
+        liveYolo = true;
+      }
+      if (
+        action.path[0] === 'autonomy' &&
+        action.path[1] === 'defaultMode' &&
+        action.value === 'auto'
+      ) {
+        liveAutonomyAuto = true;
+      }
+    } else if (action.kind === 'add-exec-allow') {
+      const tools = asRecord(parsed.tools);
+      const exec = asRecord(tools.exec);
+      const existing = Array.isArray(exec.allow) ? (exec.allow as unknown[]).map(String) : [];
+      const merged = [...new Set([...existing, ...action.commands])].sort();
+      if (merged.length !== existing.length) {
+        exec.allow = merged;
+        tools.exec = exec;
+        parsed.tools = tools;
+        messages.push(`pre-approved: ${action.commands.join(', ')}`);
+      }
+    } else if (action.kind === 'normalize-hook-timeout') {
+      const clamped = clampHookTimeout(parsed, action);
+      if (clamped) {
+        messages.push(`clamped ${action.event} hook timeout to ${action.timeoutMs / 1000}s`);
+      }
+    }
+  }
+
+  const changed = JSON.stringify(parsed) !== before;
+  if (!changed) return { messages, changed: false };
+
+  try {
+    await atomicWrite(`${file}.last`, raw);
+    await atomicWrite(`${file}.${Date.now()}.bak`, raw);
+  } catch {
+    // backup is best-effort
+  }
+  await atomicWrite(file, JSON.stringify(parsed, null, 2));
+  try {
+    const homeFn = () => path.dirname(path.dirname(file));
+    await appendHistory(JSON.parse(raw), parsed, 'tuneup auto-fix', homeFn);
+  } catch {
+    // history is best-effort
+  }
+  opts.configStore.update(parsed as never);
+
+  // Live-apply the power toggles through the existing runtime controllers so
+  // they take effect immediately (mirrors how /yolo and /autonomy behave).
+  if (liveYolo) opts.onYolo?.(true);
+  if (liveAutonomyAuto) opts.onAutonomy?.('auto');
+
+  return { messages, changed: true };
+}
+
+/** Set a nested value at `path`, creating intermediate objects as needed. */
+function setDeep(root: Record<string, unknown>, keys: string[], value: unknown): void {
+  let node = root;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i] as string;
+    node[key] = asRecord(node[key]);
+    node = node[key] as Record<string, unknown>;
+  }
+  const last = keys[keys.length - 1];
+  if (last !== undefined) node[last] = value;
+}
+
+function clampHookTimeout(
+  parsed: Record<string, unknown>,
+  action: Extract<TuneupAction, { kind: 'normalize-hook-timeout' }>,
+): boolean {
+  const hooks = parsed.hooks;
+  if (!hooks || typeof hooks !== 'object') return false;
+  const list = (hooks as Record<string, unknown>)[action.event];
+  if (!Array.isArray(list)) return false;
+  const hook = list[action.index];
+  if (!hook || typeof hook !== 'object') return false;
+  const current = (hook as { timeoutMs?: unknown }).timeoutMs;
+  if (typeof current === 'number' && current > action.timeoutMs) {
+    (hook as Record<string, unknown>).timeoutMs = action.timeoutMs;
+    return true;
+  }
+  return false;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+const CATEGORY_LABELS: Record<TuneupCategory, string> = {
+  version: 'Version',
+  autonomy: 'Autonomy',
+  skills: 'Skills',
+  mcp: 'MCP servers',
+  plugins: 'Plugins',
+  memory: 'Instruction files',
+  hooks: 'Hooks',
+  permissions: 'Permissions',
+  performance: 'Performance',
+  reliability: 'Reliability',
+  config: 'Config',
+};
+
+const CATEGORY_ORDER: TuneupCategory[] = [
+  'version',
+  'autonomy',
+  'performance',
+  'reliability',
+  'config',
+  'skills',
+  'mcp',
+  'plugins',
+  'memory',
+  'hooks',
+  'permissions',
+];
+
+function severityIcon(severity: TuneupFinding['severity']): string {
+  switch (severity) {
+    case 'error':
+      return color.red('✗');
+    case 'warning':
+      return color.amber('!');
+    case 'ok':
+      return color.green('✓');
+    default:
+      return color.cyan('·');
+  }
+}
+
+function renderFindings(lines: string[], findings: TuneupFinding[]): void {
+  for (const category of CATEGORY_ORDER) {
+    const group = findings.filter((f) => f.category === category);
+    if (group.length === 0) continue;
+    lines.push('', color.bold(CATEGORY_LABELS[category]));
+    for (const f of group) {
+      lines.push(`  ${severityIcon(f.severity)} ${f.problem}`);
+      if (f.suggestion) {
+        for (const s of f.suggestion.split('\n')) lines.push(color.dim(`    ${s}`));
+      }
+      if (f.fix) lines.push(color.dim(`    → fixable: ${f.fix}`));
+    }
+  }
+}
+
+function summaryLine(
+  findings: TuneupFinding[],
+  fixable: number,
+  handoffs: number,
+  power: boolean,
+): string {
+  const warnings = findings.filter((f) => f.severity === 'warning' || f.severity === 'error').length;
+  if (warnings === 0 && fixable === 0 && handoffs === 0) {
+    return `${color.green('✓')} everything looks healthy`;
+  }
+  const parts: string[] = [];
+  if (warnings > 0) parts.push(`${warnings} warning(s)`);
+  if (fixable > 0) parts.push(`${fixable} auto-fixable`);
+  if (handoffs > 0) parts.push(`${handoffs} for the agent`);
+  const cmd = power ? '/tuneup fix --power' : '/tuneup fix';
+  return `${parts.join(', ')} ${color.dim(`— run ${cmd}`)}`;
+}

--- a/packages/cli/src/slash-commands/tuneup.ts
+++ b/packages/cli/src/slash-commands/tuneup.ts
@@ -89,9 +89,7 @@ export function buildTuneupCommand(opts: SlashCommandContext): SlashCommand {
       }
 
       // Fix mode: collect actions (optionally confirm each), apply, hand off fuzzy items.
-      let actions = report.findings
-        .map((f) => f.action)
-        .filter((a): a is TuneupAction => !!a);
+      let actions = report.findings.map((f) => f.action).filter((a): a is TuneupAction => !!a);
 
       if (parsed.pick && opts.confirm) {
         const chosen: TuneupAction[] = [];
@@ -492,7 +490,9 @@ function summaryLine(
   handoffs: number,
   power: boolean,
 ): string {
-  const warnings = findings.filter((f) => f.severity === 'warning' || f.severity === 'error').length;
+  const warnings = findings.filter(
+    (f) => f.severity === 'warning' || f.severity === 'error',
+  ).length;
   if (warnings === 0 && fixable === 0 && handoffs === 0) {
     return `${color.green('✓')} everything looks healthy`;
   }

--- a/packages/cli/src/tuneup.ts
+++ b/packages/cli/src/tuneup.ts
@@ -634,7 +634,8 @@ export function checkReliability(input: TuneupInput): TuneupFinding[] {
     findings.push({
       category: 'reliability',
       severity: 'info',
-      problem: 'Session audit level is "minimal" — tool timing, retries, and errors are not logged.',
+      problem:
+        'Session audit level is "minimal" — tool timing, retries, and errors are not logged.',
       suggestion: 'Use "standard" (the default) if you want richer post-hoc diagnostics.',
     });
   }

--- a/packages/cli/src/tuneup.ts
+++ b/packages/cli/src/tuneup.ts
@@ -1,0 +1,730 @@
+/**
+ * Tune-up engine — deterministic health, context-cost, and performance checks
+ * for a WrongStack session, mapping the "clean up + speed up your setup" idea
+ * onto WrongStack's own config knobs and subsystems.
+ *
+ * Pure module: none of these functions touch the filesystem, the network, or
+ * live registries. The `/tuneup` slash command owns all IO (reading config,
+ * skills, memory files, the trust file, the update check, disk sizes) and
+ * applies the writes; this engine only turns already-loaded data into findings.
+ * That keeps it trivially unit-testable, exactly like `config-doctor.ts`.
+ *
+ * Every finding may carry:
+ *   - `action`  — a structured, deterministic fix the command applies on
+ *                 `/tuneup fix`. Actions gated by `input.power` are only
+ *                 emitted for the explicit `/tuneup fix --power` profile so a
+ *                 plain tune-up never silently makes the agent autonomous.
+ *   - `handoff` — a line folded into an agent follow-up turn for the fuzzy,
+ *                 judgement-heavy items (instruction-file dedup / split).
+ */
+
+import type { Config } from '@wrongstack/core';
+import type { UpdateInfo } from './update-check.js';
+
+export type TuneupSeverity = 'error' | 'warning' | 'info' | 'ok';
+
+/** Stable check-group ids — one section per group in the rendered report. */
+export type TuneupCategory =
+  | 'version'
+  | 'autonomy'
+  | 'skills'
+  | 'mcp'
+  | 'plugins'
+  | 'memory'
+  | 'hooks'
+  | 'permissions'
+  | 'performance'
+  | 'reliability'
+  | 'config';
+
+/**
+ * A structured, deterministic repair the command knows how to apply.
+ * `set-config` is the generic one — a dot-path into the global config plus the
+ * value to set — so most knobs need no bespoke apply logic.
+ */
+export type TuneupAction =
+  | { kind: 'set-config'; path: string[]; value: unknown; label: string }
+  | { kind: 'add-exec-allow'; commands: string[] }
+  | { kind: 'normalize-hook-timeout'; event: string; index: number; timeoutMs: number };
+
+export interface TuneupFinding {
+  category: TuneupCategory;
+  severity: TuneupSeverity;
+  /** One-line problem statement. */
+  problem: string;
+  /** Optional human hint about the recommended action. */
+  suggestion?: string | undefined;
+  /** Present when a deterministic auto-fix exists; short description shown in the report. */
+  fix?: string | undefined;
+  /** Machine-readable descriptor the command applies on `/tuneup fix`. */
+  action?: TuneupAction | undefined;
+  /** A line folded into the agent follow-up turn (fuzzy items with no mechanical fix). */
+  handoff?: string | undefined;
+}
+
+/** A discovered skill, reduced to what the checks need. */
+export interface TuneupSkill {
+  name: string;
+  source: string;
+  /** Body length in chars, when the command could read it (best-effort). */
+  bodyChars?: number | undefined;
+}
+
+/** Live MCP server status, reduced from `mcpRegistry.describe()`. */
+export interface TuneupMcpServer {
+  name: string;
+  state: string;
+  enabled: boolean;
+  toolCount: number;
+}
+
+/** An instruction/memory file layer to compare + size-check. */
+export interface TuneupMemoryFile {
+  /** Human label, e.g. "user memory" or "project AGENTS.md". */
+  label: string;
+  path: string;
+  content: string;
+  /** True for committed/shared layers (project AGENTS.md, root CLAUDE.md). */
+  committed: boolean;
+}
+
+/** The persistent permission trust file, `~/.wrongstack/projects/<hash>/trust.json`. */
+export type TuneupTrustPolicy = Record<
+  string,
+  { allow?: string[] | undefined; deny?: string[] | undefined; auto?: boolean | undefined }
+>;
+
+/** Ambient facts the command precomputes (host / disk / env) for the checks. */
+export interface TuneupEnv {
+  /** Logical CPU count, for the maxConcurrent sanity check. */
+  cpuCount?: number | undefined;
+  /** Number of configured providers, for the fallback-chain check. */
+  providerCount?: number | undefined;
+  /** Whether the secret vault is passphrase-hardened at rest. */
+  vaultHardened?: boolean | undefined;
+  /** Total bytes of on-disk session logs for this project (disk-hygiene check). */
+  sessionBytes?: number | undefined;
+}
+
+export interface TuneupInput {
+  config: Config;
+  skills: TuneupSkill[];
+  /** `config.skills.eagerMaxChars` or its default. */
+  eagerMaxChars: number;
+  skillMode: 'eager' | 'progressive';
+  /** Live MCP status when the host wired `mcpStatus`; undefined → skip live MCP checks. */
+  mcp?: TuneupMcpServer[] | undefined;
+  /** Instruction-file layers (user memory, project AGENTS.md, root CLAUDE.md/AGENTS.md). */
+  memoryFiles: TuneupMemoryFile[];
+  /** Self-update info (from `checkForUpdate`), when the version check ran. */
+  update?: UpdateInfo | undefined;
+  /** Parsed trust file, when present. */
+  trust?: TuneupTrustPolicy | undefined;
+  /**
+   * Denied read-only commands mined from session history (optional richer
+   * signal). Each entry is a command line and how many times it was denied.
+   */
+  deniedFromHistory?: Array<{ command: string; count: number }> | undefined;
+  /** Ambient host/disk facts. */
+  env?: TuneupEnv | undefined;
+  /** Count of `/doctor`-style config issues (from `diagnoseConfig`). */
+  configIssues?: number | undefined;
+  /**
+   * Power profile: `/tuneup fix --power`. Gates the autonomy/yolo/director
+   * actions so a plain tune-up never flips them (respects the user-owned
+   * autonomy invariant).
+   */
+  power?: boolean | undefined;
+}
+
+export interface TuneupReport {
+  findings: TuneupFinding[];
+  /** Composed agent follow-up prompt for fuzzy items; empty when none. */
+  agentHandoff: string;
+}
+
+/** Default eager skill-body budget (mirrors `SkillsConfig.eagerMaxChars`). */
+export const DEFAULT_EAGER_MAX_CHARS = 24_000;
+
+/** timeoutMs at/above this is treated as a potentially slow hook. */
+const SLOW_HOOK_TIMEOUT_MS = 10_000;
+/** A single event with more than this many shell hooks is flagged as heavy. */
+const MANY_HOOKS_PER_EVENT = 4;
+/** Root instruction files larger than this (chars) are candidates for splitting. */
+const LARGE_INSTRUCTION_CHARS = 12_000;
+/** …or longer than this many lines. */
+const LARGE_INSTRUCTION_LINES = 400;
+/** A denied command must recur at least this many times to be worth pre-approving. */
+const MIN_DENY_COUNT = 2;
+/** Session-log bytes above this are worth a prune nudge (~50 MB). */
+const LARGE_SESSION_BYTES = 50 * 1024 * 1024;
+
+/**
+ * First tokens that make a bash/exec command line safe to auto-approve. Kept
+ * deliberately conservative — anything not on this list is left for the user.
+ */
+const READONLY_VERBS = new Set([
+  'ls',
+  'cat',
+  'pwd',
+  'echo',
+  'grep',
+  'rg',
+  'find',
+  'head',
+  'tail',
+  'wc',
+  'which',
+  'type',
+  'tree',
+  'stat',
+  'du',
+  'df',
+  'env',
+  'printenv',
+  'date',
+  'whoami',
+  'hostname',
+  'uname',
+  'sort',
+  'uniq',
+  'cut',
+  'awk',
+  'sed',
+  'diff',
+  'realpath',
+  'dirname',
+  'basename',
+]);
+
+/** Shell metacharacters that could turn an otherwise read-only verb destructive. */
+const SHELL_WRITE_TOKENS = /[>|;&`$()]|\brm\b|\bmv\b|\bcp\b|--write|--fix|--force|-i\b/;
+
+/** True when `command` is safely read-only by our conservative heuristic. */
+export function isReadOnlyCommand(command: string): boolean {
+  const trimmed = command.trim();
+  if (trimmed.length === 0) return false;
+  if (SHELL_WRITE_TOKENS.test(trimmed)) {
+    // `git status`/`git log`/`git diff`/`git show` are allowed despite the
+    // broad guard, but nothing with redirection or a write subcommand.
+    if (!/^git\s+(status|log|diff|show|branch|remote|blame)\b/.test(trimmed)) return false;
+    if (/[>|;&`$()]/.test(trimmed)) return false;
+  }
+  const first = trimmed.split(/\s+/)[0] ?? '';
+  if (first === 'git') {
+    return /^git\s+(status|log|diff|show|branch|remote|blame)\b/.test(trimmed);
+  }
+  return READONLY_VERBS.has(first);
+}
+
+// ── Item 1: unused skills / MCP / plugins ────────────────────────────────────
+
+export function checkSkills(input: TuneupInput): TuneupFinding[] {
+  const { skills, skillMode, eagerMaxChars } = input;
+  if (skills.length === 0) return [];
+  const findings: TuneupFinding[] = [];
+
+  const knownChars = skills.filter((s) => typeof s.bodyChars === 'number');
+  const totalChars = knownChars.reduce((n, s) => n + (s.bodyChars ?? 0), 0);
+  const approxTokens = Math.round(totalChars / 4);
+
+  if (skillMode === 'eager' && knownChars.length > 0 && totalChars > eagerMaxChars) {
+    findings.push({
+      category: 'skills',
+      severity: 'warning',
+      problem: `${skills.length} skills (~${approxTokens.toLocaleString()} tokens of bodies) exceed the eager inject budget (${eagerMaxChars.toLocaleString()} chars).`,
+      suggestion:
+        'Switch to progressive mode so bodies load on demand, or raise `skills.eagerMaxChars` — every eager skill body is spent on every request.',
+      fix: 'set skills.mode = "progressive"',
+      action: {
+        kind: 'set-config',
+        path: ['skills', 'mode'],
+        value: 'progressive',
+        label: 'skills now load progressively (bodies on demand)',
+      },
+    });
+  }
+
+  const foreign = skills.filter((s) => s.source === 'foreign' || s.source.startsWith('claude-'));
+  if (foreign.length > 0 && skillMode === 'eager') {
+    findings.push({
+      category: 'skills',
+      severity: 'info',
+      problem: `${foreign.length} of ${skills.length} skills come from foreign coding-agent dirs (.claude / other tools).`,
+      suggestion:
+        'If you do not use them, set `skills.readClaudeSkills: false` / `skills.foreignSources: false` to stop injecting them into the prompt.',
+    });
+  }
+
+  return findings;
+}
+
+export function checkMcp(input: TuneupInput): TuneupFinding[] {
+  const findings: TuneupFinding[] = [];
+
+  const configured = input.config.mcpServers ?? {};
+  for (const [name, cfg] of Object.entries(configured)) {
+    if (cfg && typeof cfg === 'object' && (cfg as { enabled?: boolean }).enabled === false) {
+      findings.push({
+        category: 'mcp',
+        severity: 'info',
+        problem: `MCP server "${name}" is configured but disabled.`,
+        suggestion: `Remove it from \`mcpServers\` if you no longer use it (\`/mcp remove ${name}\`).`,
+      });
+    }
+  }
+
+  for (const s of input.mcp ?? []) {
+    if (s.state === 'failed') {
+      findings.push({
+        category: 'mcp',
+        severity: 'warning',
+        problem: `MCP server "${s.name}" failed to connect (reconnect cycles exhausted).`,
+        suggestion: `Fix its command/URL or remove it — it contributes no tools but is retried on boot (\`/mcp restart ${s.name}\` / \`/mcp remove ${s.name}\`).`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export function checkPlugins(input: TuneupInput): TuneupFinding[] {
+  const plugins = input.config.plugins ?? [];
+  const findings: TuneupFinding[] = [];
+  for (const p of plugins) {
+    if (typeof p === 'object' && p.enabled === false) {
+      findings.push({
+        category: 'plugins',
+        severity: 'info',
+        problem: `Plugin "${p.name}" is listed but disabled.`,
+        suggestion:
+          'A disabled plugin still sits in your config. Remove the entry if you have no plans to re-enable it.',
+      });
+    }
+  }
+  return findings;
+}
+
+// ── Item 2 + 3: instruction-file dedup + oversize ────────────────────────────
+
+function normalizeLine(line: string): string {
+  return line.trim().replace(/\s+/g, ' ');
+}
+
+function isSignificantLine(line: string): boolean {
+  const n = normalizeLine(line);
+  if (n.length < 24) return false;
+  if (/^[#>*\-=_|`]+$/.test(n)) return false; // pure markdown structure
+  return true;
+}
+
+export function checkMemoryDedup(input: TuneupInput): TuneupFinding[] {
+  const files = input.memoryFiles.filter((f) => f.content.trim().length > 0);
+  if (files.length < 2) return [];
+
+  const lineToFiles = new Map<string, Set<string>>();
+  for (const f of files) {
+    const seen = new Set<string>();
+    for (const raw of f.content.split(/\r?\n/)) {
+      if (!isSignificantLine(raw)) continue;
+      const key = normalizeLine(raw);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const set = lineToFiles.get(key) ?? new Set<string>();
+      set.add(f.label);
+      lineToFiles.set(key, set);
+    }
+  }
+
+  const dupes = [...lineToFiles.entries()].filter(([, set]) => set.size >= 2);
+  if (dupes.length === 0) return [];
+
+  const sample = dupes
+    .slice(0, 3)
+    .map(([line]) => `  · ${line.length > 72 ? `${line.slice(0, 69)}…` : line}`)
+    .join('\n');
+
+  return [
+    {
+      category: 'memory',
+      severity: 'warning',
+      problem: `${dupes.length} instruction line(s) are duplicated across your memory/instruction files.`,
+      suggestion:
+        'Keep each fact in one layer (committed project AGENTS.md for shared rules, personal memory for personal ones). Duplicates cost prompt tokens on every turn.',
+      handoff: `De-duplicate instruction files. These lines appear in more than one of ${files.map((f) => f.label).join(', ')}:\n${sample}\nRemove each duplicate from the more local / less-authoritative layer, keeping the shared/committed copy.`,
+    },
+  ];
+}
+
+export function checkMemorySize(input: TuneupInput): TuneupFinding[] {
+  const findings: TuneupFinding[] = [];
+  for (const f of input.memoryFiles) {
+    const chars = f.content.length;
+    const lines = f.content.split(/\r?\n/).length;
+    if (chars > LARGE_INSTRUCTION_CHARS || lines > LARGE_INSTRUCTION_LINES) {
+      findings.push({
+        category: 'memory',
+        severity: 'info',
+        problem: `${f.label} is large (${chars.toLocaleString()} chars, ${lines} lines) — it is spent on every request.`,
+        suggestion:
+          'Split rarely-needed detail into a skill (load-on-demand) or a nested per-directory instruction file, keeping the root lean.',
+        handoff: `${f.label} (${f.path}) is ${chars} chars / ${lines} lines. Propose how to break it up: move stable, rarely-needed sections into skills or nested instruction files so the always-loaded root stays small. Do not delete anything without confirmation.`,
+      });
+    }
+  }
+  return findings;
+}
+
+// ── Item 4: slow hooks ───────────────────────────────────────────────────────
+
+export function checkHooks(input: TuneupInput): TuneupFinding[] {
+  const hooks = input.config.hooks;
+  if (!hooks) return [];
+  const findings: TuneupFinding[] = [];
+
+  for (const [event, list] of Object.entries(hooks)) {
+    if (!Array.isArray(list) || list.length === 0) continue;
+
+    if (list.length > MANY_HOOKS_PER_EVENT) {
+      findings.push({
+        category: 'hooks',
+        severity: 'info',
+        problem: `${event} runs ${list.length} shell hooks — each blocks the turn until it returns.`,
+        suggestion: 'Consolidate or drop hooks you no longer need to keep turns snappy.',
+      });
+    }
+
+    list.forEach((hook, index) => {
+      const timeoutMs = hook.timeoutMs;
+      if (typeof timeoutMs === 'number' && timeoutMs >= SLOW_HOOK_TIMEOUT_MS) {
+        findings.push({
+          category: 'hooks',
+          severity: 'warning',
+          problem: `${event} hook #${index + 1} allows up to ${(timeoutMs / 1000).toFixed(0)}s (\`${previewCommand(hook.command)}\`).`,
+          suggestion:
+            'A slow hook stalls every matching tool call. Lower the timeout or disable the hook.',
+          fix: `clamp timeout to ${SLOW_HOOK_TIMEOUT_MS / 1000}s`,
+          action: { kind: 'normalize-hook-timeout', event, index, timeoutMs: SLOW_HOOK_TIMEOUT_MS },
+        });
+      }
+    });
+  }
+
+  return findings;
+}
+
+function previewCommand(command: string): string {
+  const one = command.replace(/\s+/g, ' ').trim();
+  return one.length > 48 ? `${one.slice(0, 45)}…` : one;
+}
+
+// ── Item 5: version ──────────────────────────────────────────────────────────
+
+export function checkVersion(input: TuneupInput): TuneupFinding[] {
+  const info = input.update;
+  if (!info) return [];
+  if (info.outdated) {
+    return [
+      {
+        category: 'version',
+        severity: 'warning',
+        problem: `A newer WrongStack is available: v${info.current} → v${info.latest}.`,
+        suggestion: 'Run `wrongstack update` (or your package manager) to upgrade.',
+      },
+    ];
+  }
+  if (info.checkFailed) return [];
+  return [{ category: 'version', severity: 'ok', problem: `Up to date (v${info.current}).` }];
+}
+
+// ── Item 6: auto mode default (power-gated action) ───────────────────────────
+
+export function checkAutonomy(input: TuneupInput): TuneupFinding[] {
+  const mode = input.config.autonomy?.defaultMode;
+  if (mode === 'auto') {
+    return [{ category: 'autonomy', severity: 'ok', problem: 'Auto mode is the startup default.' }];
+  }
+  const finding: TuneupFinding = {
+    category: 'autonomy',
+    severity: 'info',
+    problem: `Startup autonomy default is "${mode ?? 'off'}", not "auto".`,
+    suggestion: input.power
+      ? 'Auto mode lets sessions self-drive between turns.'
+      : 'Auto mode lets sessions self-drive. Run `/tuneup fix --power` to enable it.',
+  };
+  // Only the explicit power profile writes autonomy — never a plain tune-up.
+  if (input.power) {
+    finding.fix = 'set autonomy.defaultMode = "auto"';
+    finding.action = {
+      kind: 'set-config',
+      path: ['autonomy', 'defaultMode'],
+      value: 'auto',
+      label: 'auto mode is now the startup default',
+    };
+  }
+  return [finding];
+}
+
+/** Power-only: yolo + director launch defaults (explicit `--power` opt-in). */
+export function checkPowerProfile(input: TuneupInput): TuneupFinding[] {
+  if (!input.power) return [];
+  const findings: TuneupFinding[] = [];
+
+  if (input.config.yolo !== true) {
+    findings.push({
+      category: 'autonomy',
+      severity: 'info',
+      problem: 'YOLO mode (auto-approve tool calls) is off.',
+      suggestion: 'Power profile enables it so the agent stops asking to run each tool.',
+      fix: 'set yolo = true',
+      action: { kind: 'set-config', path: ['yolo'], value: true, label: 'YOLO mode enabled' },
+    });
+  }
+
+  if (input.config.launch?.director !== true) {
+    findings.push({
+      category: 'autonomy',
+      severity: 'info',
+      problem: 'Director mode does not start by default.',
+      suggestion: 'Power profile launches with the fleet director + multi-agent orchestration on.',
+      fix: 'set launch.director = true',
+      action: {
+        kind: 'set-config',
+        path: ['launch', 'director'],
+        value: true,
+        label: 'director mode starts on next launch',
+      },
+    });
+  }
+
+  return findings;
+}
+
+// ── Item 7: frequently denied read-only commands ─────────────────────────────
+
+export function checkPermissions(input: TuneupInput): TuneupFinding[] {
+  const candidates = new Map<string, number>();
+
+  for (const [tool, entry] of Object.entries(input.trust ?? {})) {
+    if (tool !== 'bash' && tool !== 'exec') continue;
+    for (const pattern of entry.deny ?? []) {
+      if (isReadOnlyCommand(pattern)) {
+        candidates.set(pattern, Math.max(candidates.get(pattern) ?? 0, MIN_DENY_COUNT));
+      }
+    }
+  }
+
+  for (const { command, count } of input.deniedFromHistory ?? []) {
+    if (count >= MIN_DENY_COUNT && isReadOnlyCommand(command)) {
+      candidates.set(command, Math.max(candidates.get(command) ?? 0, count));
+    }
+  }
+
+  if (candidates.size === 0) return [];
+
+  const commandNames = [
+    ...new Set([...candidates.keys()].map((c) => c.trim().split(/\s+/)[0] ?? '')),
+  ]
+    .filter((n) => n.length > 0)
+    .sort();
+
+  const sample = [...candidates.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4)
+    .map(([c, n]) => `  · ${c}${n > MIN_DENY_COUNT ? ` (denied ${n}×)` : ''}`)
+    .join('\n');
+
+  return [
+    {
+      category: 'permissions',
+      severity: 'info',
+      problem: `${candidates.size} read-only command(s) keep getting denied/prompted.`,
+      suggestion: `They look safe to pre-approve:\n${sample}`,
+      fix: `add ${commandNames.join(', ')} to tools.exec.allow`,
+      action: { kind: 'add-exec-allow', commands: commandNames },
+    },
+  ];
+}
+
+// ── Performance knobs ────────────────────────────────────────────────────────
+
+export function checkPerformance(input: TuneupInput): TuneupFinding[] {
+  const { config, env } = input;
+  const findings: TuneupFinding[] = [];
+
+  // Fallback recovery: `fallbackAuto` defaults on; only flag an explicit opt-out
+  // with no manual chain, which leaves 429s un-recovered.
+  if (config.fallbackAuto === false && (config.fallbackModels?.length ?? 0) === 0) {
+    findings.push({
+      category: 'performance',
+      severity: 'warning',
+      problem:
+        'Automatic fallback is off and no fallback chain is configured — a 429 will just fail.',
+      suggestion: 'Re-enable the auto chain so rate-limits recover to another keyed model.',
+      fix: 'set fallbackAuto = true',
+      action: {
+        kind: 'set-config',
+        path: ['fallbackAuto'],
+        value: true,
+        label: 'automatic fallback re-enabled',
+      },
+    });
+  }
+
+  // Adaptive concurrency: safe to enable — it only reacts to 429s.
+  if (config.adaptiveConcurrency?.enabled !== true) {
+    findings.push({
+      category: 'performance',
+      severity: 'info',
+      problem: 'Adaptive concurrency is off — maxConcurrent will not back off on rate-limits.',
+      suggestion: 'Enable it to auto-tune concurrency on 429s and recover on sustained success.',
+      fix: 'set adaptiveConcurrency.enabled = true',
+      action: {
+        kind: 'set-config',
+        path: ['adaptiveConcurrency', 'enabled'],
+        value: true,
+        label: 'adaptive concurrency enabled',
+      },
+    });
+  }
+
+  // Circuit breaker: advisory only — enabling it can block bash on failures.
+  if (config.circuitBreaker?.enabled !== true) {
+    findings.push({
+      category: 'performance',
+      severity: 'info',
+      problem: 'The process circuit-breaker is off — repeated bash/exec failures are not gated.',
+      suggestion: 'Turn it on with `/settings breaker on` for bash-heavy or flaky workflows.',
+    });
+  }
+
+  // Codebase index: only nag when the user explicitly disabled the default-on run.
+  if (config.indexing && config.indexing.onSessionStart === false) {
+    findings.push({
+      category: 'performance',
+      severity: 'info',
+      problem:
+        'Session-start codebase indexing is disabled — symbol search/navigation is degraded.',
+      suggestion: 'Re-enable `indexing.onSessionStart` for faster, index-backed code navigation.',
+    });
+  }
+
+  // maxConcurrent sanity relative to CPU count.
+  const cpu = env?.cpuCount;
+  const mc = config.maxConcurrent;
+  if (typeof mc === 'number' && mc > 0 && typeof cpu === 'number' && cpu > 0 && mc > cpu * 4) {
+    findings.push({
+      category: 'performance',
+      severity: 'info',
+      problem: `maxConcurrent is ${mc} on a ${cpu}-core host — likely oversubscribed.`,
+      suggestion: `Consider lowering it toward ${cpu * 2} (or enable adaptive concurrency).`,
+    });
+  }
+
+  return findings;
+}
+
+// ── Reliability / hygiene ────────────────────────────────────────────────────
+
+export function checkReliability(input: TuneupInput): TuneupFinding[] {
+  const { config, env } = input;
+  const findings: TuneupFinding[] = [];
+
+  if (config.session?.auditLevel === 'minimal') {
+    findings.push({
+      category: 'reliability',
+      severity: 'info',
+      problem: 'Session audit level is "minimal" — tool timing, retries, and errors are not logged.',
+      suggestion: 'Use "standard" (the default) if you want richer post-hoc diagnostics.',
+    });
+  }
+
+  if (env?.vaultHardened === false) {
+    findings.push({
+      category: 'reliability',
+      severity: 'info',
+      problem: 'The secret vault key is stored in the clear (no at-rest passphrase).',
+      suggestion:
+        'Set `WRONGSTACK_VAULT_PASSPHRASE` to wrap the data key (scrypt + AES-256-GCM); existing secrets migrate automatically.',
+    });
+  }
+
+  if (typeof env?.sessionBytes === 'number' && env.sessionBytes > LARGE_SESSION_BYTES) {
+    findings.push({
+      category: 'reliability',
+      severity: 'info',
+      problem: `Session logs for this project are large (${(env.sessionBytes / (1024 * 1024)).toFixed(0)} MB).`,
+      suggestion: 'Run `/prune` to trim old sessions and reclaim disk.',
+    });
+  }
+
+  return findings;
+}
+
+// ── /doctor integration ──────────────────────────────────────────────────────
+
+export function checkConfigDoctor(input: TuneupInput): TuneupFinding[] {
+  const n = input.configIssues ?? 0;
+  if (n <= 0) return [];
+  return [
+    {
+      category: 'config',
+      severity: 'warning',
+      problem: `${n} config issue(s) detected in the global config.`,
+      suggestion: 'Run `/doctor fix` to repair field types, enums, and shape problems.',
+    },
+  ];
+}
+
+// ── Composition ──────────────────────────────────────────────────────────────
+
+/** Run every check and compose the report + agent hand-off text. */
+export function runTuneup(input: TuneupInput): TuneupReport {
+  const findings: TuneupFinding[] = [
+    ...checkVersion(input),
+    ...checkAutonomy(input),
+    ...checkPowerProfile(input),
+    ...checkSkills(input),
+    ...checkMcp(input),
+    ...checkPlugins(input),
+    ...checkMemoryDedup(input),
+    ...checkMemorySize(input),
+    ...checkHooks(input),
+    ...checkPermissions(input),
+    ...checkPerformance(input),
+    ...checkReliability(input),
+    ...checkConfigDoctor(input),
+  ];
+
+  const handoffLines = findings.map((f) => f.handoff).filter((h): h is string => !!h);
+  const agentHandoff =
+    handoffLines.length === 0
+      ? ''
+      : `The /tuneup checkup flagged instruction-file issues that need judgement. Address each, asking me before deleting anything:\n\n${handoffLines.map((h, i) => `${i + 1}. ${h}`).join('\n\n')}`;
+
+  return { findings, agentHandoff };
+}
+
+/**
+ * Build the rich follow-up prompt for `/tuneup deep` — hands the agent the live
+ * findings and asks for a project-specific optimization plan (the non-mechanical
+ * tier). Kept here so it is unit-testable alongside the checks.
+ */
+export function buildDeepPrompt(report: TuneupReport): string {
+  const lines = report.findings
+    .filter((f) => f.severity !== 'ok')
+    .map((f) => `- [${f.category}] ${f.problem}`)
+    .join('\n');
+  return [
+    'Act as a WrongStack optimization consultant. Using the tune-up findings below',
+    'plus a look at this project (its stack, size, and how it is used), produce a',
+    'concise, prioritized optimization plan tailored to THIS project.',
+    '',
+    'For each recommendation give: the change, why it helps here, and the exact',
+    'config knob or command to apply it. Call out anything risky. Do NOT change',
+    'any files or config yourself — this is a plan for me to approve.',
+    '',
+    'Tune-up findings:',
+    lines || '- (no mechanical findings — focus on higher-level workflow/model/tooling advice)',
+  ].join('\n');
+}

--- a/packages/cli/tests/slash-tuneup.test.ts
+++ b/packages/cli/tests/slash-tuneup.test.ts
@@ -6,13 +6,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SlashCommandContext } from '../src/slash-commands/index.js';
 import { buildTuneupCommand } from '../src/slash-commands/tuneup.js';
 import {
+  buildDeepPrompt,
   checkAutonomy,
+  checkConfigDoctor,
   checkHooks,
   checkMcp,
   checkMemoryDedup,
   checkMemorySize,
+  checkPerformance,
   checkPermissions,
   checkPlugins,
+  checkPowerProfile,
+  checkReliability,
   checkSkills,
   isReadOnlyCommand,
   runTuneup,
@@ -58,7 +63,8 @@ describe('checkAutonomy', () => {
       baseInput({ config: { autonomy: { defaultMode: 'off' } } as TuneupInput['config'] }),
     );
     expect(finding.severity).toBe('info');
-    expect(finding.action).toEqual({ kind: 'set-autonomy-auto' });
+    // Power-gated: a plain tune-up recommends but does not write autonomy.
+    expect(finding.action).toBeUndefined();
   });
 
   it('reports ok when auto is already the default', () => {
@@ -219,6 +225,96 @@ describe('checkPermissions', () => {
   });
 });
 
+describe('checkPerformance', () => {
+  it('flags disabled auto-fallback with a fix action', () => {
+    const findings = checkPerformance(
+      baseInput({
+        config: { fallbackAuto: false, fallbackModels: [] } as TuneupInput['config'],
+      }),
+    );
+    const fb = findings.find((f) => f.problem.includes('Automatic fallback is off'));
+    expect(fb?.action).toMatchObject({ kind: 'set-config', path: ['fallbackAuto'], value: true });
+  });
+
+  it('always offers an adaptive-concurrency enable action when off', () => {
+    const findings = checkPerformance(baseInput());
+    expect(
+      findings.some(
+        (f) =>
+          f.action?.kind === 'set-config' &&
+          f.action.path.join('.') === 'adaptiveConcurrency.enabled',
+      ),
+    ).toBe(true);
+  });
+
+  it('flags oversubscribed maxConcurrent against CPU count', () => {
+    const findings = checkPerformance(
+      baseInput({ config: { maxConcurrent: 40 } as TuneupInput['config'], env: { cpuCount: 8 } }),
+    );
+    expect(findings.some((f) => f.problem.includes('oversubscribed'))).toBe(true);
+  });
+});
+
+describe('checkReliability', () => {
+  it('flags minimal audit level, unhardened vault, and large session logs', () => {
+    const findings = checkReliability(
+      baseInput({
+        config: { session: { auditLevel: 'minimal' } } as TuneupInput['config'],
+        env: { vaultHardened: false, sessionBytes: 200 * 1024 * 1024 },
+      }),
+    );
+    expect(findings.some((f) => f.problem.includes('audit level'))).toBe(true);
+    expect(findings.some((f) => f.problem.includes('vault'))).toBe(true);
+    expect(findings.some((f) => f.problem.includes('Session logs'))).toBe(true);
+  });
+});
+
+describe('checkPowerProfile', () => {
+  it('emits yolo + director actions only under power', () => {
+    expect(checkPowerProfile(baseInput())).toEqual([]);
+    const findings = checkPowerProfile(baseInput({ power: true }));
+    expect(
+      findings.some((f) => f.action?.kind === 'set-config' && f.problem.includes('YOLO')),
+    ).toBe(true);
+    expect(findings.some((f) => f.problem.includes('Director'))).toBe(true);
+  });
+});
+
+describe('checkAutonomy power-gating', () => {
+  it('has no action without power, and an action with power', () => {
+    const off = checkAutonomy(
+      baseInput({ config: { autonomy: { defaultMode: 'off' } } as TuneupInput['config'] }),
+    );
+    expect(off[0].action).toBeUndefined();
+    const on = checkAutonomy(
+      baseInput({
+        config: { autonomy: { defaultMode: 'off' } } as TuneupInput['config'],
+        power: true,
+      }),
+    );
+    expect(on[0].action).toMatchObject({ kind: 'set-config', path: ['autonomy', 'defaultMode'] });
+  });
+});
+
+describe('checkConfigDoctor', () => {
+  it('surfaces a doctor pointer when config issues exist', () => {
+    expect(checkConfigDoctor(baseInput({ configIssues: 0 }))).toEqual([]);
+    const [finding] = checkConfigDoctor(baseInput({ configIssues: 3 }));
+    expect(finding.suggestion).toContain('/doctor fix');
+  });
+});
+
+describe('buildDeepPrompt', () => {
+  it('embeds non-ok findings and asks for a plan', () => {
+    const report = runTuneup(
+      baseInput({ config: { fallbackAuto: false, fallbackModels: [] } as TuneupInput['config'] }),
+    );
+    const prompt = buildDeepPrompt(report);
+    expect(prompt).toContain('optimization');
+    expect(prompt).toContain('[performance]');
+  });
+});
+
 describe('runTuneup', () => {
   it('composes findings and an agent hand-off from fuzzy items', () => {
     const report = runTuneup(
@@ -290,17 +386,43 @@ describe('/tuneup slash command', () => {
     expect(readFileSync(globalConfig, 'utf8')).toBe(before); // untouched
   });
 
-  it('fix mode enables auto mode, backs up, and updates the store', async () => {
+  it('plain fix applies safe knobs and never touches autonomy', async () => {
     const { ctx, globalConfig, update } = makeCtx({ autonomy: { defaultMode: 'off' } });
     const res = await buildTuneupCommand(ctx).run!('fix');
-    expect(stripAnsi(res!.message!)).toContain('auto mode is now the startup default');
+    const written = JSON.parse(readFileSync(globalConfig, 'utf8'));
+    // A safe performance knob is written…
+    expect(written.adaptiveConcurrency.enabled).toBe(true);
+    // …but a plain tune-up must NOT flip autonomy (power-gated).
+    expect(written.autonomy.defaultMode).toBe('off');
+    expect(existsSync(`${globalConfig}.last`)).toBe(true);
+    expect(update).toHaveBeenCalled();
+    expect(stripAnsi(res!.message!)).toContain('adaptive concurrency enabled');
+  });
 
+  it('fix --power enables autonomy, yolo, and director (live-applied)', async () => {
+    const { ctx, globalConfig } = makeCtx({ autonomy: { defaultMode: 'off' } });
+    const onYolo = vi.fn();
+    const onAutonomy = vi.fn();
+    (ctx as { onYolo: unknown }).onYolo = onYolo;
+    (ctx as { onAutonomy: unknown }).onAutonomy = onAutonomy;
+
+    const res = await buildTuneupCommand(ctx).run!('fix --power');
     const written = JSON.parse(readFileSync(globalConfig, 'utf8'));
     expect(written.autonomy.defaultMode).toBe('auto');
-    expect(existsSync(`${globalConfig}.last`)).toBe(true);
-    expect(update).toHaveBeenCalledWith(
-      expect.objectContaining({ autonomy: expect.objectContaining({ defaultMode: 'auto' }) }),
-    );
+    expect(written.yolo).toBe(true);
+    expect(written.launch.director).toBe(true);
+    // Live-applied through the runtime controllers.
+    expect(onYolo).toHaveBeenCalledWith(true);
+    expect(onAutonomy).toHaveBeenCalledWith('auto');
+    expect(stripAnsi(res!.message!)).toContain('YOLO mode enabled');
+  });
+
+  it('deep mode hands a tailored-plan prompt to the agent', async () => {
+    const { ctx, globalConfig } = makeCtx({ autonomy: { defaultMode: 'off' } });
+    const before = readFileSync(globalConfig, 'utf8');
+    const res = await buildTuneupCommand(ctx).run!('deep');
+    expect(res!.runText).toContain('optimization');
+    expect(readFileSync(globalConfig, 'utf8')).toBe(before); // deep never writes
   });
 
   it('fix mode hands fuzzy instruction-file items to the agent via runText', async () => {

--- a/packages/cli/tests/slash-tuneup.test.ts
+++ b/packages/cli/tests/slash-tuneup.test.ts
@@ -1,0 +1,319 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import path from 'node:path';
+import { stripAnsi } from '@wrongstack/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SlashCommandContext } from '../src/slash-commands/index.js';
+import { buildTuneupCommand } from '../src/slash-commands/tuneup.js';
+import {
+  checkAutonomy,
+  checkHooks,
+  checkMcp,
+  checkMemoryDedup,
+  checkMemorySize,
+  checkPermissions,
+  checkPlugins,
+  checkSkills,
+  isReadOnlyCommand,
+  runTuneup,
+  type TuneupInput,
+} from '../src/tuneup.js';
+
+// ---------------------------------------------------------------------------
+// Pure engine
+// ---------------------------------------------------------------------------
+
+function baseInput(overrides: Partial<TuneupInput> = {}): TuneupInput {
+  return {
+    config: {} as TuneupInput['config'],
+    skills: [],
+    eagerMaxChars: 24_000,
+    skillMode: 'eager',
+    memoryFiles: [],
+    ...overrides,
+  };
+}
+
+describe('isReadOnlyCommand', () => {
+  it('accepts conservative read-only verbs', () => {
+    expect(isReadOnlyCommand('ls -la')).toBe(true);
+    expect(isReadOnlyCommand('grep -R foo src')).toBe(true);
+    expect(isReadOnlyCommand('git status')).toBe(true);
+    expect(isReadOnlyCommand('git log --oneline')).toBe(true);
+  });
+
+  it('rejects mutating or shell-piped commands', () => {
+    expect(isReadOnlyCommand('rm -rf build')).toBe(false);
+    expect(isReadOnlyCommand('git push --force')).toBe(false);
+    expect(isReadOnlyCommand('echo hi > file')).toBe(false);
+    expect(isReadOnlyCommand('cat a | tee b')).toBe(false);
+    expect(isReadOnlyCommand('npm install')).toBe(false);
+    expect(isReadOnlyCommand('')).toBe(false);
+  });
+});
+
+describe('checkAutonomy', () => {
+  it('flags a non-auto default with a fix action', () => {
+    const [finding] = checkAutonomy(
+      baseInput({ config: { autonomy: { defaultMode: 'off' } } as TuneupInput['config'] }),
+    );
+    expect(finding.severity).toBe('info');
+    expect(finding.action).toEqual({ kind: 'set-autonomy-auto' });
+  });
+
+  it('reports ok when auto is already the default', () => {
+    const [finding] = checkAutonomy(
+      baseInput({ config: { autonomy: { defaultMode: 'auto' } } as TuneupInput['config'] }),
+    );
+    expect(finding.severity).toBe('ok');
+    expect(finding.action).toBeUndefined();
+  });
+});
+
+describe('checkHooks', () => {
+  it('flags a slow hook with a clamp action', () => {
+    const findings = checkHooks(
+      baseInput({
+        config: {
+          hooks: { PreToolUse: [{ command: 'sleep 30', timeoutMs: 30_000 }] },
+        } as TuneupInput['config'],
+      }),
+    );
+    const slow = findings.find((f) => f.action?.kind === 'normalize-hook-timeout');
+    expect(slow).toBeDefined();
+    expect(slow?.action).toMatchObject({ event: 'PreToolUse', index: 0, timeoutMs: 10_000 });
+  });
+
+  it('flags many hooks on one event', () => {
+    const findings = checkHooks(
+      baseInput({
+        config: {
+          hooks: {
+            PostToolUse: Array.from({ length: 5 }, () => ({ command: 'noop' })),
+          },
+        } as TuneupInput['config'],
+      }),
+    );
+    expect(findings.some((f) => f.problem.includes('5 shell hooks'))).toBe(true);
+  });
+
+  it('is silent with no hooks', () => {
+    expect(checkHooks(baseInput())).toEqual([]);
+  });
+});
+
+describe('checkMemoryDedup', () => {
+  it('flags a significant line duplicated across two files', () => {
+    const dupLine = 'Always run the full test suite before every release.';
+    const findings = checkMemoryDedup(
+      baseInput({
+        memoryFiles: [
+          { label: 'user memory', path: '/a', content: dupLine, committed: false },
+          {
+            label: 'project AGENTS.md',
+            path: '/b',
+            content: `# Rules\n${dupLine}`,
+            committed: true,
+          },
+        ],
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].handoff).toBeTruthy();
+  });
+
+  it('ignores short/trivial lines and single files', () => {
+    expect(
+      checkMemoryDedup(
+        baseInput({
+          memoryFiles: [
+            { label: 'a', path: '/a', content: '# Title\nok\n', committed: false },
+            { label: 'b', path: '/b', content: '# Title\nok\n', committed: true },
+          ],
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('checkMemorySize', () => {
+  it('flags an oversized instruction file with a handoff', () => {
+    const big = 'x'.repeat(13_000);
+    const [finding] = checkMemorySize(
+      baseInput({
+        memoryFiles: [{ label: 'root CLAUDE.md', path: '/c', content: big, committed: true }],
+      }),
+    );
+    expect(finding.severity).toBe('info');
+    expect(finding.handoff).toContain('root CLAUDE.md');
+  });
+});
+
+describe('checkMcp', () => {
+  it('flags configured-but-disabled and live-failed servers', () => {
+    const findings = checkMcp(
+      baseInput({
+        config: { mcpServers: { old: { enabled: false } } } as TuneupInput['config'],
+        mcp: [{ name: 'broken', state: 'failed', enabled: true, toolCount: 0 }],
+      }),
+    );
+    expect(findings.some((f) => f.problem.includes('"old"') && f.severity === 'info')).toBe(true);
+    expect(findings.some((f) => f.problem.includes('"broken"') && f.severity === 'warning')).toBe(
+      true,
+    );
+  });
+});
+
+describe('checkPlugins', () => {
+  it('flags disabled-but-listed plugins', () => {
+    const [finding] = checkPlugins(
+      baseInput({
+        config: { plugins: [{ name: 'telemetry', enabled: false }] } as TuneupInput['config'],
+      }),
+    );
+    expect(finding.problem).toContain('telemetry');
+  });
+});
+
+describe('checkSkills', () => {
+  it('flags eager skill bodies over the budget', () => {
+    const skills = Array.from({ length: 6 }, (_, i) => ({
+      name: `s${i}`,
+      source: 'user',
+      bodyChars: 5_000,
+    }));
+    const [finding] = checkSkills(baseInput({ skills, eagerMaxChars: 24_000 }));
+    expect(finding.severity).toBe('warning');
+    expect(finding.problem).toContain('exceed the eager inject budget');
+  });
+
+  it('stays quiet in progressive mode', () => {
+    const skills = [{ name: 's', source: 'user', bodyChars: 99_999 }];
+    expect(checkSkills(baseInput({ skills, skillMode: 'progressive' }))).toEqual([]);
+  });
+});
+
+describe('checkPermissions', () => {
+  it('promotes read-only denied commands to an exec-allow action', () => {
+    const [finding] = checkPermissions(
+      baseInput({
+        trust: { bash: { deny: ['ls -la', 'rm -rf /'] } },
+      }),
+    );
+    expect(finding.category).toBe('permissions');
+    expect(finding.action).toMatchObject({ kind: 'add-exec-allow', commands: ['ls'] });
+  });
+
+  it('mines history counts and de-dupes command names', () => {
+    const [finding] = checkPermissions(
+      baseInput({
+        deniedFromHistory: [
+          { command: 'grep foo', count: 4 },
+          { command: 'grep bar', count: 2 },
+          { command: 'make build', count: 3 },
+        ],
+      }),
+    );
+    expect(finding.action).toMatchObject({ kind: 'add-exec-allow', commands: ['grep'] });
+  });
+});
+
+describe('runTuneup', () => {
+  it('composes findings and an agent hand-off from fuzzy items', () => {
+    const report = runTuneup(
+      baseInput({
+        config: { autonomy: { defaultMode: 'off' } } as TuneupInput['config'],
+        memoryFiles: [
+          { label: 'root CLAUDE.md', path: '/c', content: 'x'.repeat(13_000), committed: true },
+        ],
+      }),
+    );
+    expect(report.findings.some((f) => f.category === 'autonomy')).toBe(true);
+    expect(report.agentHandoff).toContain('root CLAUDE.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slash command (IO)
+// ---------------------------------------------------------------------------
+
+// Keep checkForUpdate hermetic + offline: seed a fresh cache so it returns
+// from disk without a network round-trip, and restore the real cache after.
+const updateCache = path.join(homedir(), '.wrongstack', 'update-cache.json');
+let savedCache: string | null = null;
+
+beforeEach(() => {
+  savedCache = existsSync(updateCache) ? readFileSync(updateCache, 'utf8') : null;
+  mkdirSync(path.dirname(updateCache), { recursive: true });
+  writeFileSync(updateCache, JSON.stringify({ timestamp: Date.now(), latestVersion: '0.0.0' }));
+});
+
+afterEach(() => {
+  if (savedCache !== null) writeFileSync(updateCache, savedCache);
+  else if (existsSync(updateCache)) rmSync(updateCache);
+});
+
+function makeCtx(configObj: Record<string, unknown>): {
+  ctx: SlashCommandContext;
+  globalConfig: string;
+  update: ReturnType<typeof vi.fn>;
+} {
+  const dir = mkdtempSync(path.join(tmpdir(), 'wstack-tuneup-test-'));
+  const wsDir = path.join(dir, '.wrongstack');
+  mkdirSync(wsDir, { recursive: true });
+  const globalConfig = path.join(wsDir, 'config.json');
+  writeFileSync(globalConfig, JSON.stringify(configObj));
+  const update = vi.fn();
+  const ctx = {
+    projectRoot: dir,
+    configStore: { get: vi.fn(() => configObj), update },
+    paths: {
+      globalConfig,
+      globalMemory: path.join(wsDir, 'memory.md'),
+      inProjectAgentsFile: path.join(dir, 'project', '.wrongstack', 'AGENTS.md'),
+      projectTrust: path.join(wsDir, 'trust.json'),
+    },
+  } as never as SlashCommandContext;
+  return { ctx, globalConfig, update };
+}
+
+describe('/tuneup slash command', () => {
+  it('reports without writing in report mode', async () => {
+    const { ctx, globalConfig } = makeCtx({ autonomy: { defaultMode: 'off' } });
+    const before = readFileSync(globalConfig, 'utf8');
+    const res = await buildTuneupCommand(ctx).run!('');
+    const text = stripAnsi(res!.message!);
+    expect(text).toContain('Tune-up');
+    expect(text).toContain('Autonomy');
+    expect(text).toContain('/tuneup fix');
+    expect(readFileSync(globalConfig, 'utf8')).toBe(before); // untouched
+  });
+
+  it('fix mode enables auto mode, backs up, and updates the store', async () => {
+    const { ctx, globalConfig, update } = makeCtx({ autonomy: { defaultMode: 'off' } });
+    const res = await buildTuneupCommand(ctx).run!('fix');
+    expect(stripAnsi(res!.message!)).toContain('auto mode is now the startup default');
+
+    const written = JSON.parse(readFileSync(globalConfig, 'utf8'));
+    expect(written.autonomy.defaultMode).toBe('auto');
+    expect(existsSync(`${globalConfig}.last`)).toBe(true);
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({ autonomy: expect.objectContaining({ defaultMode: 'auto' }) }),
+    );
+  });
+
+  it('fix mode hands fuzzy instruction-file items to the agent via runText', async () => {
+    const { ctx } = makeCtx({ autonomy: { defaultMode: 'auto' } });
+    // Seed an oversized root instruction file so a handoff is produced.
+    writeFileSync(path.join(ctx.projectRoot, 'CLAUDE.md'), 'x'.repeat(13_000));
+    const res = await buildTuneupCommand(ctx).run!('fix');
+    expect(res!.runText).toContain('CLAUDE.md');
+  });
+
+  it('rejects unknown subcommands', async () => {
+    const { ctx } = makeCtx({});
+    const res = await buildTuneupCommand(ctx).run!('bogus');
+    expect(stripAnsi(res!.message!)).toContain('Usage:');
+  });
+});


### PR DESCRIPTION
## What

Adds `/tuneup` (alias `/checkup`), a broad session **health + context-cost + performance** checkup — the counterpart to `/doctor` (which only repairs the config JSON). Report-first, with a safe deterministic `fix`, an explicit `--power` profile, and an LLM `deep` mode.

Mirrors the `/doctor` split: a pure, unit-testable engine (`packages/cli/src/tuneup.ts`) + an IO command (`slash-commands/tuneup.ts`).

## Checks (13)

- **Version** — reuses `checkForUpdate()` (cached, best-effort).
- **Autonomy** — recommends `defaultMode: auto`; **power-gated** (never written by a plain `fix`).
- **Performance** — fallbackAuto, adaptiveConcurrency, circuit-breaker, session-start indexing, `maxConcurrent`/CPU sanity.
- **Reliability** — `session.auditLevel: minimal`, unhardened vault, large session logs.
- **Config** — folds in `diagnoseConfig()` issue count → points at `/doctor fix`.
- **Skills / MCP / Plugins** — eager-budget bloat, disabled/failed servers, disabled-but-listed plugins.
- **Instruction files** — dedup + oversize (agent hand-off, never auto-deleted).
- **Hooks** — slow-hook timeout clamp.
- **Permissions** — pre-approve frequently-denied read-only commands (trust file + history).

## Modes

| Command | Effect |
|---|---|
| `/tuneup` | Read-only report |
| `/tuneup fix` | Safe deterministic fixes (backs up global config like `/doctor`); **never touches autonomy** |
| `/tuneup fix --power` | Also enables `autonomy.defaultMode: auto` + `yolo` + `launch.director`, live-applied via the runtime controllers |
| `/tuneup fix --pick` | Confirm each fix |
| `/tuneup deep` | Hand the findings to the agent for a project-specific optimization plan |

## Safety

- Writes target the **global** config only (never the untrusted in-project config); `tools.exec.allow` is trusted-source-only.
- `--power` is the ONLY path that flips autonomy/yolo/director — respects the "autonomy is user-owned" invariant.
- Instruction-file cleanups are handed to the agent with an explicit "ask before deleting" instruction.

## Tests / verification

- `packages/cli/tests/slash-tuneup.test.ts` — 31 tests (pure checks, power-gating, apply, deep). All green.
- Zero TS errors in the added files; biome clean.

## Wiring

- New optional `SlashCommandContext.mcpStatus` (backed by `mcpRegistry.describe()`) for structured MCP status.