### PR TITLE
fix(desktop): pass explicit dist-dir to webui-server and harden startup state

### DIFF
--- a/apps/desktop/src/main/runtime-manager.ts
+++ b/apps/desktop/src/main/runtime-manager.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import * as http from 'node:http';
 import { createRequire } from 'node:module';
 import * as net from 'node:net';
@@ -246,6 +247,7 @@ export class DesktopRuntimeManager extends EventEmitter {
 
     try {
       const entry = resolveWebUiEntry();
+      const distDir = resolveWebUiDistDir();
       const child = spawn(
         process.execPath,
         [
@@ -256,6 +258,8 @@ export class DesktopRuntimeManager extends EventEmitter {
           String(httpPort),
           '--ws-port',
           String(wsPort),
+          '--dist-dir',
+          distDir,
           '--token',
           token,
           '--require-token',
@@ -286,14 +290,22 @@ export class DesktopRuntimeManager extends EventEmitter {
         this.scheduleLogChanged(runtime);
         process.stderr.write(`[desktop:${runtime.id}] ${text}`);
       });
+      child.once('error', (err) => {
+        runtime.status = 'error';
+        runtime.error = toErrorMessage(err);
+        runtime.child = null;
+        if (this.activeRuntimeId === runtime.id) {
+          this.activeRuntimeId = firstRunningRuntimeId(this.runtimes);
+        }
+        this.emitChanged();
+      });
       child.once('exit', (code, signal) => {
-        runtime.status = runtime.status === 'error' ? 'error' : 'stopped';
+        if (runtime.status === 'error') return;
+        runtime.status = 'stopped';
         runtime.error =
-          runtime.status === 'error'
-            ? runtime.error
-            : code === 0
-              ? undefined
-              : `Exited with ${signal ?? `code ${code ?? 'unknown'}`}`;
+          code === 0
+            ? undefined
+            : `Exited with ${signal ?? `code ${code ?? 'unknown'}`}`;
         runtime.child = null;
         if (this.activeRuntimeId === runtime.id) {
           this.activeRuntimeId = firstRunningRuntimeId(this.runtimes);
@@ -302,15 +314,26 @@ export class DesktopRuntimeManager extends EventEmitter {
       });
 
       await waitForHttpReady(runtime.url, token, START_TIMEOUT_MS);
+      if (runtime.status !== 'starting') {
+        // The child exited or hit a spawn error while we were waiting.
+        throw new Error(runtime.error ?? 'WebUI process exited during startup');
+      }
       runtime.status = 'running';
       await this.persistWorkspaceState();
       this.emitChanged();
       return publicRuntime(runtime);
     } catch (err) {
-      runtime.status = 'error';
-      runtime.error = toErrorMessage(err);
+      if (runtime.status !== 'stopped' && runtime.status !== 'error') {
+        runtime.status = 'error';
+      }
+      if (runtime.error === undefined) {
+        runtime.error = toErrorMessage(err);
+      }
       await terminateProcessTree(runtime.child);
       runtime.child = null;
+      if (this.activeRuntimeId === runtime.id) {
+        this.activeRuntimeId = firstRunningRuntimeId(this.runtimes);
+      }
       this.emitChanged();
       throw err;
     }
@@ -742,14 +765,31 @@ function resolveWebUiEntry(): string {
   }
   const require = createRequire(import.meta.url);
   // After PR #018b, the server entry lives in @wrongstack/webui-server.
-  // Try the new package first; fall back to the legacy path for older builds.
+  // Try the new package first; fall back to the legacy path for older builds
+  // or when the new package is not yet built.
   try {
     const serverPkgPath = require.resolve('@wrongstack/webui-server/package.json');
-    return path.join(path.dirname(serverPkgPath), 'dist', 'server', 'entry.js');
+    const candidate = path.join(path.dirname(serverPkgPath), 'dist', 'server', 'entry.js');
+    if (existsSync(candidate)) return candidate;
   } catch {
-    const serverIndex = require.resolve('@wrongstack/webui/server');
-    return path.join(path.dirname(serverIndex), 'entry.js');
+    // fall through to legacy path
   }
+  const serverIndex = require.resolve('@wrongstack/webui/server');
+  return path.join(path.dirname(serverIndex), 'entry.js');
+}
+
+function resolveWebUiDistDir(): string {
+  if (process.env['WRONGSTACK_WEBUI_DIST']) {
+    return path.resolve(process.env['WRONGSTACK_WEBUI_DIST']);
+  }
+  const require = createRequire(import.meta.url);
+  // The built React frontend assets live in @wrongstack/webui/dist.
+  const serverIndex = require.resolve('@wrongstack/webui/server');
+  const candidate = path.resolve(path.dirname(serverIndex), '..');
+  if (existsSync(candidate)) return candidate;
+  throw new Error(
+    `WebUI frontend assets not found at ${candidate}. Build @wrongstack/webui or set WRONGSTACK_WEBUI_DIST.`,
+  );
 }
 
 async function readGlobalProjectManifest(): Promise<DesktopProjectEntry[]> {

--- a/packages/webui-server/src/server/entry.ts
+++ b/packages/webui-server/src/server/entry.ts
@@ -52,6 +52,7 @@ Options:
   --host <host>             Bind host/interface (default: 127.0.0.1)
   --port <port>             HTTP frontend port (default: 3456)
   --ws-port <port>          WebSocket backend port (default: 3457)
+  --dist-dir <dir>          Path to the built WebUI frontend assets (default: resolve @wrongstack/webui)
   --token <token>           Fixed access token/password (default: random per process)
   --public-url <url>        Browser-facing HTTP URL for tunnels/proxies
   --public-ws-url <url>     Browser-facing ws:// or wss:// URL for tunnels/proxies
@@ -89,6 +90,7 @@ if (argv.includes('--help') || argv.includes('-h')) {
   let accessToken: string | undefined;
   let publicUrl: string | undefined;
   let publicWsUrl: string | undefined;
+  let distDir: string | undefined;
   try {
     wsHost =
       readArg(['--host']) ??
@@ -107,6 +109,7 @@ if (argv.includes('--help') || argv.includes('-h')) {
       process.env['WEBUI_AUTH_TOKEN'];
     publicUrl = readArg(['--public-url']) ?? process.env['WEBUI_PUBLIC_URL'];
     publicWsUrl = readArg(['--public-ws-url']) ?? process.env['WEBUI_PUBLIC_WS_URL'];
+    distDir = readArg(['--dist-dir']) ?? process.env['WEBUI_DIST_DIR'];
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
@@ -126,6 +129,7 @@ if (argv.includes('--help') || argv.includes('-h')) {
     publicWsUrl,
     requireToken,
     open,
+    distDir,
   }).catch((err) => {
     console.error(JSON.stringify({
       level: 'fatal',

--- a/packages/webui-server/src/server/server-runtime.ts
+++ b/packages/webui-server/src/server/server-runtime.ts
@@ -11,6 +11,8 @@
  * behind four focused entry points.
  */
 import * as path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 import type { Config, ModelsRegistry } from '@wrongstack/core';
 import { WebSocketServer, type WebSocket } from 'ws';
 import { verifyClient as verifyWsClient } from './ws-auth.js';
@@ -281,6 +283,32 @@ export function armEvents(
 
 // ── HTTP server + shutdown ──────────────────────────────────────────────
 
+/**
+ * Resolve the directory containing the built WebUI frontend assets.
+ *
+ * The standalone webui-server package does not bundle the React frontend;
+ * it lives in the separate `@wrongstack/webui` package. Callers can pass an
+ * explicit `distDir`; when they don't, we try to resolve the frontend package
+ * relative to the server entry that is asking. This lets the standalone
+ * `wstackui` binary serve the webui assets when both packages are installed,
+ * while also allowing embedded callers (e.g. the desktop app) to pass an exact
+ * path so they don't depend on module-resolution layout.
+ */
+export function resolveWebuiDistDir(fromUrl: string, explicitDistDir?: string | undefined): string {
+  if (explicitDistDir) return path.resolve(explicitDistDir);
+  try {
+    const requireFromHere = createRequire(fromUrl);
+    const serverEntry = requireFromHere.resolve('@wrongstack/webui/server');
+    return path.resolve(path.dirname(serverEntry), '..'); // .../dist
+  } catch {
+    // Legacy fallback: assume the webui dist is co-located with the server
+    // runtime (the pre-extraction layout). This path is wrong for the
+    // extracted @wrongstack/webui-server package, but keeping it preserves
+    // any bespoke/test setups that still lay out files that way.
+    return path.resolve(path.dirname(fileURLToPath(fromUrl)), '..', '..', 'dist');
+  }
+}
+
 export function startHttpServer(opts: {
   wsHost: string;
   httpPort: number;
@@ -295,10 +323,11 @@ export function startHttpServer(opts: {
   openBrowser: boolean;
   watcherMetrics: FileWatcherMetrics;
   onFleetPing: () => void;
+  distDir?: string | undefined;
 }): import('node:http').Server {
   const httpServer = createHttpServer({
     host: opts.wsHost,
-    distDir: path.resolve(import.meta.dirname, '../../dist'),
+    distDir: resolveWebuiDistDir(import.meta.url, opts.distDir),
     wsPort: opts.wsPort,
     publicWsUrl: opts.publicWsUrl,
     globalRoot: opts.globalRoot,

--- a/packages/webui-server/src/server/start-webui.ts
+++ b/packages/webui-server/src/server/start-webui.ts
@@ -576,6 +576,7 @@ export async function startWebUI(
     globalRoot: wpaths.globalRoot, globalConfigPath, projectRoot,
     openBrowser: !!opts.open, watcherMetrics: watcherMetricsRef,
     onFleetPing: () => { void eventArming.getFleetBroadcast()?.(); },
+    distDir: opts.distDir,
   });
 
   registerShutdown({

--- a/packages/webui-server/src/server/types.ts
+++ b/packages/webui-server/src/server/types.ts
@@ -42,6 +42,14 @@ export interface WebUIOptions {
   /** Force token/password protection even on loopback binds. */
   requireToken?: boolean | undefined;
   /**
+   * Path to the directory containing the built WebUI frontend assets
+   * (the `dist` directory of `@wrongstack/webui`). When omitted, the
+   * server tries to resolve the frontend package from its own module
+   * location; callers that embed the server (e.g. the desktop app) should
+   * pass an explicit path for deterministic resolution.
+   */
+  distDir?: string | undefined;
+  /**
    * Pre-built backend services. When provided, `startWebUI` skips its
    * default agent/event-bus/session/store construction and wires the
    * supplied instances into the WS message router and HTTP API


### PR DESCRIPTION
- Resolve and pass the WebUI frontend asset directory from the desktop main
  process so the spawned server doesn't depend on module-resolution layout.
- Add WEBUI_DIST_DIR env override and existence checks for the entry file and
  dist directory, falling back to the legacy webui/server path when the new
  webui-server package is not yet built.
- Harden openProject() against race conditions: handle child 'error' events,
  guard the transition from 'starting' to 'running' if the process exited or
  errored during waitForHttpReady, and clear activeRuntimeId on startup failure.
