### PR TITLE
feat(tools): edit matching ladder, hash-based staleness, post-edit syntax check

### DIFF
--- a/packages/core/src/core/context.ts
+++ b/packages/core/src/core/context.ts
@@ -109,6 +109,18 @@ export class Context implements RunEnv {
   writtenFiles = new Set<string>();
   fileMtimes = new Map<string, number>();
   /**
+   * sha-256 (hex) of file content at the last recorded read/write, when the
+   * recording tool had the content in hand. Used by `edit` as the authoritative
+   * staleness arbiter: mtime comparison has a 2 s tolerance window on Windows
+   * (FAT/NTFS granularity) during which an external modification is invisible,
+   * and conversely a bare `touch` bumps mtime without changing content. Hash
+   * equality resolves both cases exactly. Entries are dropped whenever a
+   * hash-less `recordRead` observes a *different* mtime (content may have
+   * changed under us — fall back to the mtime heuristic rather than trust a
+   * stale hash).
+   */
+  fileHashes = new Map<string, string>();
+  /**
    * Structured side-effect records accumulated during the current run
    * (P2 #5). Populated by `recordSideEffect()` — read by /diag for an
    * in-memory audit trail without parsing the JSONL file. Cleared by
@@ -251,8 +263,27 @@ export class Context implements RunEnv {
    *   approved the new content (P1 #1, before-release.md).
    *
    * `fileMtimes` is updated in both cases so mtime-based staleness checks work.
+   *
+   * `contentHash` (sha-256 hex of the exact content seen) is optional so
+   * existing callers keep working. When provided it is stored in `fileHashes`
+   * and becomes the authoritative staleness arbiter for later edits. When
+   * omitted, a previously stored hash survives only if the observed mtime is
+   * unchanged — a different mtime with no fresh hash means the content may
+   * have changed, so the stale hash is dropped and staleness checks fall back
+   * to mtime comparison.
    */
-  recordRead(absPath: string, mtimeMs: number, source: 'user' | 'write' = 'user'): void {
+  recordRead(
+    absPath: string,
+    mtimeMs: number,
+    source: 'user' | 'write' = 'user',
+    contentHash?: string,
+  ): void {
+    if (contentHash !== undefined) {
+      this.fileHashes.set(absPath, contentHash);
+    } else {
+      const prevMtime = this.fileMtimes.get(absPath);
+      if (prevMtime !== mtimeMs) this.fileHashes.delete(absPath);
+    }
     this.fileMtimes.set(absPath, mtimeMs);
     if (source === 'write') {
       this.writtenFiles.add(absPath);
@@ -268,6 +299,7 @@ export class Context implements RunEnv {
     this.readFiles.clear();
     this.writtenFiles.clear();
     this.fileMtimes.clear();
+    this.fileHashes.clear();
     this.sideEffects = [];
   }
 
@@ -311,6 +343,12 @@ export class Context implements RunEnv {
 
   lastReadMtime(absPath: string): number | undefined {
     return this.fileMtimes.get(absPath);
+  }
+
+  /** sha-256 (hex) of the content at the last recorded read/write, if the
+   *  recording tool supplied one. See `fileHashes` for drop semantics. */
+  lastReadHash(absPath: string): string | undefined {
+    return this.fileHashes.get(absPath);
   }
 
   /**

--- a/packages/core/src/utils/tool-output-serializer.ts
+++ b/packages/core/src/utils/tool-output-serializer.ts
@@ -212,18 +212,29 @@ function renderToolObject(toolName: string, obj: RecordValue, input: unknown): s
 
   if (typeof obj['diff'] === 'string') {
     const diff = obj['diff'];
+    // matched_by: 'exact' is the default and carries no information — only
+    // surface the field when a fallback tier actually fired.
+    const matchedBy =
+      typeof obj['matched_by'] === 'string' && obj['matched_by'] !== 'exact'
+        ? obj['matched_by']
+        : undefined;
+    const syntaxErrors = Array.isArray(obj['syntax_errors'])
+      ? obj['syntax_errors'].filter((e): e is string => typeof e === 'string')
+      : [];
     return joinSections([
       renderHeader(toolName, {
         path: obj['path'],
         replacements: obj['replacements'],
         bytes_written: obj['bytes_written'],
         created: obj['created'],
+        matched_by: matchedBy,
         note: obj['note'],
         files: Array.isArray(obj['files']) ? obj['files'].length : undefined,
         truncated: obj['truncated'],
         mode: obj['mode'],
       }),
       compactDiff(diff),
+      syntaxErrors.length > 0 ? `syntax_errors:\n${renderStringList(syntaxErrors)}` : undefined,
     ]);
   }
 

--- a/packages/core/tests/core/context.test.ts
+++ b/packages/core/tests/core/context.test.ts
@@ -241,3 +241,42 @@ describe('Context.onWorkingDirChanged', () => {
     expect(secondCalled).toBe(true);
   });
 });
+
+describe('Context content-hash tracking', () => {
+  it('recordRead stores the content hash when provided', () => {
+    const ctx = mkContext();
+    ctx.recordRead('/a/b.ts', 100, 'user', 'hash-1');
+    expect(ctx.lastReadHash('/a/b.ts')).toBe('hash-1');
+    expect(ctx.lastReadHash('/missing')).toBeUndefined();
+  });
+
+  it('a hash-less recordRead with the same mtime keeps the stored hash', () => {
+    const ctx = mkContext();
+    ctx.recordRead('/a/b.ts', 100, 'user', 'hash-1');
+    ctx.recordRead('/a/b.ts', 100);
+    expect(ctx.lastReadHash('/a/b.ts')).toBe('hash-1');
+  });
+
+  it('a hash-less recordRead with a different mtime drops the stale hash', () => {
+    const ctx = mkContext();
+    ctx.recordRead('/a/b.ts', 100, 'user', 'hash-1');
+    ctx.recordRead('/a/b.ts', 200);
+    expect(ctx.lastReadHash('/a/b.ts')).toBeUndefined();
+    expect(ctx.lastReadMtime('/a/b.ts')).toBe(200);
+  });
+
+  it('write-tagged records also carry hashes', () => {
+    const ctx = mkContext();
+    ctx.recordRead('/a/b.ts', 100, 'write', 'hash-w');
+    expect(ctx.lastReadHash('/a/b.ts')).toBe('hash-w');
+    expect(ctx.hasRead('/a/b.ts')).toBe(false);
+    expect(ctx.hasWritten('/a/b.ts')).toBe(true);
+  });
+
+  it('clearFileTracking clears hashes', () => {
+    const ctx = mkContext();
+    ctx.recordRead('/a/b.ts', 100, 'user', 'hash-1');
+    ctx.clearFileTracking();
+    expect(ctx.lastReadHash('/a/b.ts')).toBeUndefined();
+  });
+});

--- a/packages/tools/src/_edit-match.ts
+++ b/packages/tools/src/_edit-match.ts
@@ -1,0 +1,349 @@
+/**
+ * Matching ladder for the `edit` tool.
+ *
+ * Models routinely hallucinate whitespace when reproducing code they read
+ * many turns ago: trailing spaces appear, indentation shifts by a level,
+ * tabs become spaces. A strict exact-match `old_string` fails on all of
+ * these even though the intended target is unambiguous. This module
+ * implements a graded fallback chain — each tier is strictly more permissive
+ * and strictly lower-confidence than the previous one:
+ *
+ *   1. `exact`                  — substring match (the classic behavior).
+ *   2. `trailing-whitespace`    — whole-line window match ignoring trailing
+ *                                 whitespace per line. Zero ambiguity risk
+ *                                 beyond exact (trailing blanks never carry
+ *                                 meaning in the languages we edit).
+ *   3. `whitespace-normalized`  — whole-line window match ignoring leading
+ *                                 AND trailing whitespace per line. The
+ *                                 replacement is re-indented to the file's
+ *                                 actual indentation.
+ *   4. `fuzzy`                  — block-anchor match: first and last lines
+ *                                 must match (trimmed), interior lines are
+ *                                 compared by Levenshtein similarity. Only a
+ *                                 single candidate with a clear margin over
+ *                                 the runner-up is accepted.
+ *
+ * The caller (edit.ts) enforces per-tier uniqueness, restricts `replace_all`
+ * to tiers 1–2, and surfaces the tier + confidence in the tool output so the
+ * model and the session log both see when a fallback fired.
+ */
+
+export type MatchTier = 'exact' | 'trailing-whitespace' | 'whitespace-normalized' | 'fuzzy';
+
+export interface LadderMatch {
+  /** Char offset (inclusive) of the match start in the LF-normalized file. */
+  start: number;
+  /** Char offset (exclusive) of the match end. */
+  end: number;
+  /** 1-based line number of the first matched line (for error messages). */
+  startLine: number;
+}
+
+export interface LadderResult {
+  tier: MatchTier;
+  matches: LadderMatch[];
+  /** Similarity score of the best candidate — only set for the fuzzy tier. */
+  score?: number | undefined;
+  /**
+   * Fuzzy tier only: true when two candidates scored within the ambiguity
+   * margin of each other, so no single target can be trusted. `matches`
+   * then contains the rival candidates for the error message.
+   */
+  ambiguous?: boolean | undefined;
+}
+
+/** Human-readable label per tier, used in notes and error messages. */
+export const TIER_LABEL: Record<MatchTier, string> = {
+  exact: 'exact match',
+  'trailing-whitespace': 'whitespace-normalized match (trailing whitespace ignored)',
+  'whitespace-normalized':
+    'whitespace-normalized match (indentation ignored, replacement re-indented)',
+  fuzzy: 'fuzzy match (block anchors exact, interior ≥90% similar)',
+};
+
+/** Confidence per tier, recorded in the tool output note. */
+export const TIER_CONFIDENCE: Record<MatchTier, 'exact' | 'high' | 'medium' | 'low'> = {
+  exact: 'exact',
+  'trailing-whitespace': 'high',
+  'whitespace-normalized': 'medium',
+  fuzzy: 'low',
+};
+
+/** Below this many non-whitespace chars, indent-insensitive tiers are too
+ *  ambiguous to trust (`}` would match everywhere). */
+const MIN_NORMALIZED_NEEDLE_CHARS = 16;
+/** Fuzzy interior similarity threshold. */
+const FUZZY_MIN_SIMILARITY = 0.9;
+/** A fuzzy best-candidate must beat the runner-up by at least this margin. */
+const FUZZY_AMBIGUITY_MARGIN = 0.05;
+/** Cost guard: skip fuzzy comparison on interiors larger than this. */
+const FUZZY_MAX_INTERIOR_CHARS = 2000;
+
+/**
+ * Walk the ladder and return the first tier that produces at least one
+ * match. Returns `undefined` when no tier matches.
+ */
+export function findLadderMatches(fileLf: string, oldLf: string): LadderResult | undefined {
+  // Tier 1 — exact substring scan (supports sub-line needles).
+  const exact: LadderMatch[] = [];
+  let idx = fileLf.indexOf(oldLf);
+  while (idx !== -1) {
+    exact.push({ start: idx, end: idx + oldLf.length, startLine: lineAt(fileLf, idx) });
+    idx = fileLf.indexOf(oldLf, idx + 1);
+  }
+  if (exact.length > 0) return { tier: 'exact', matches: exact };
+
+  // Line-based tiers operate on whole-line windows.
+  const fileLines = fileLf.split('\n');
+  const needleLines = oldLf.split('\n');
+  if (needleLines.length > fileLines.length) return undefined;
+  const offsets = lineOffsets(fileLines);
+
+  const trailing = windowScan(
+    fileLines,
+    needleLines,
+    offsets,
+    (a, b) => a.trimEnd() === b.trimEnd(),
+  );
+  if (trailing.length > 0) return { tier: 'trailing-whitespace', matches: trailing };
+
+  const normalizedLen = needleLines.reduce((n, l) => n + l.trim().length, 0);
+  if (normalizedLen < MIN_NORMALIZED_NEEDLE_CHARS) return undefined;
+
+  const normalized = windowScan(fileLines, needleLines, offsets, (a, b) => a.trim() === b.trim());
+  if (normalized.length > 0) return { tier: 'whitespace-normalized', matches: normalized };
+
+  return fuzzyScan(fileLines, needleLines, offsets);
+}
+
+/** 1-based line number containing char offset `pos`. */
+function lineAt(text: string, pos: number): number {
+  let line = 1;
+  for (let i = 0; i < pos; i++) {
+    if (text.charCodeAt(i) === 0x0a) line++;
+  }
+  return line;
+}
+
+/** Start char offset of each line in the LF-normalized text. */
+function lineOffsets(lines: string[]): number[] {
+  const out = new Array<number>(lines.length);
+  let pos = 0;
+  for (let i = 0; i < lines.length; i++) {
+    out[i] = pos;
+    pos += (lines[i] as string).length + 1; // +1 for the '\n'
+  }
+  return out;
+}
+
+function windowToMatch(
+  fileLines: string[],
+  offsets: number[],
+  start: number,
+  windowLen: number,
+): LadderMatch {
+  const lastLine = start + windowLen - 1;
+  return {
+    start: offsets[start] as number,
+    end: (offsets[lastLine] as number) + (fileLines[lastLine] as string).length,
+    startLine: start + 1,
+  };
+}
+
+/** Slide a needle-sized window over the file lines with a per-line comparator.
+ *  Matched windows never overlap (scan resumes after the window). */
+function windowScan(
+  fileLines: string[],
+  needleLines: string[],
+  offsets: number[],
+  eq: (fileLine: string, needleLine: string) => boolean,
+): LadderMatch[] {
+  const n = needleLines.length;
+  const out: LadderMatch[] = [];
+  for (let i = 0; i + n <= fileLines.length; i++) {
+    let all = true;
+    for (let j = 0; j < n; j++) {
+      if (!eq(fileLines[i + j] as string, needleLines[j] as string)) {
+        all = false;
+        break;
+      }
+    }
+    if (all) {
+      out.push(windowToMatch(fileLines, offsets, i, n));
+      i += n - 1; // no overlapping windows
+    }
+  }
+  return out;
+}
+
+/** Block-anchor fuzzy tier: first/last lines trim-exact, interior by
+ *  Levenshtein similarity. Requires ≥3 needle lines so anchors exist. */
+function fuzzyScan(
+  fileLines: string[],
+  needleLines: string[],
+  offsets: number[],
+): LadderResult | undefined {
+  const n = needleLines.length;
+  if (n < 3) return undefined;
+  const firstNeedle = (needleLines[0] as string).trim();
+  const lastNeedle = (needleLines[n - 1] as string).trim();
+  const needleInterior = needleLines
+    .slice(1, -1)
+    .map((l) => l.trim())
+    .join('\n');
+  if (needleInterior.length > FUZZY_MAX_INTERIOR_CHARS) return undefined;
+
+  const candidates: Array<{ match: LadderMatch; score: number }> = [];
+  for (let i = 0; i + n <= fileLines.length; i++) {
+    if ((fileLines[i] as string).trim() !== firstNeedle) continue;
+    if ((fileLines[i + n - 1] as string).trim() !== lastNeedle) continue;
+    const windowInterior = fileLines
+      .slice(i + 1, i + n - 1)
+      .map((l) => l.trim())
+      .join('\n');
+    if (windowInterior.length > FUZZY_MAX_INTERIOR_CHARS) continue;
+    const score = similarity(needleInterior, windowInterior);
+    if (score >= FUZZY_MIN_SIMILARITY) {
+      candidates.push({ match: windowToMatch(fileLines, offsets, i, n), score });
+    }
+  }
+
+  if (candidates.length === 0) return undefined;
+  candidates.sort((a, b) => b.score - a.score);
+  const best = candidates[0] as { match: LadderMatch; score: number };
+  const runnerUp = candidates[1];
+  if (runnerUp && best.score - runnerUp.score < FUZZY_AMBIGUITY_MARGIN) {
+    return {
+      tier: 'fuzzy',
+      matches: candidates.map((c) => c.match),
+      score: best.score,
+      ambiguous: true,
+    };
+  }
+  return { tier: 'fuzzy', matches: [best.match], score: best.score };
+}
+
+/** Normalized similarity in [0, 1]: 1 − levenshtein / max-length. */
+export function similarity(a: string, b: string): number {
+  if (a === b) return 1;
+  const max = Math.max(a.length, b.length);
+  if (max === 0) return 1;
+  // Quick reject: a length gap larger than the allowed edit budget can
+  // never reach the threshold — skip the O(n·m) DP entirely.
+  if (Math.abs(a.length - b.length) / max > 1 - FUZZY_MIN_SIMILARITY + 0.05) {
+    return 1 - Math.abs(a.length - b.length) / max;
+  }
+  return 1 - levenshtein(a, b) / max;
+}
+
+/** Two-row Levenshtein distance. */
+function levenshtein(a: string, b: string): number {
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = new Array<number>(b.length + 1);
+  let cur = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    cur[0] = i;
+    const ca = a.charCodeAt(i - 1);
+    for (let j = 1; j <= b.length; j++) {
+      const cost = ca === b.charCodeAt(j - 1) ? 0 : 1;
+      cur[j] = Math.min(
+        (prev[j] as number) + 1,
+        (cur[j - 1] as number) + 1,
+        (prev[j - 1] as number) + cost,
+      );
+    }
+    [prev, cur] = [cur, prev];
+  }
+  return prev[b.length] as number;
+}
+
+/** Leading whitespace (spaces/tabs) of the first non-empty line, or ''. */
+export function firstLineIndent(text: string): string {
+  for (const line of text.split('\n')) {
+    if (line.trim() === '') continue;
+    return (/^[ \t]*/.exec(line) as RegExpExecArray)[0];
+  }
+  return '';
+}
+
+/**
+ * Shift `newLf` from the needle's indentation to the matched block's actual
+ * indentation. Only clean prefix relationships are adjusted (purely adding
+ * or removing leading whitespace); a tabs-vs-spaces mismatch is left alone
+ * rather than guessed at — the diff in the tool output makes the result
+ * visible either way.
+ */
+export function adjustIndent(
+  newLf: string,
+  fromIndent: string,
+  toIndent: string,
+): { text: string; adjusted: boolean } {
+  if (fromIndent === toIndent) return { text: newLf, adjusted: false };
+  const lines = newLf.split('\n');
+  if (toIndent.startsWith(fromIndent)) {
+    const extra = toIndent.slice(fromIndent.length);
+    return {
+      text: lines.map((l) => (l.trim() === '' ? l : extra + l)).join('\n'),
+      adjusted: true,
+    };
+  }
+  if (fromIndent.startsWith(toIndent)) {
+    const remove = fromIndent.slice(toIndent.length);
+    return {
+      text: lines.map((l) => (l.startsWith(remove) ? l.slice(remove.length) : l)).join('\n'),
+      adjusted: true,
+    };
+  }
+  return { text: newLf, adjusted: false };
+}
+
+/**
+ * Best-effort locator for the no-match error: find the window whose trimmed
+ * lines are most similar to the needle (cheap common-prefix scoring — this
+ * runs on the failure path where the needle by definition doesn't match, so
+ * precision matters less than never being slow). Returns the 1-based line
+ * and a short snippet the model can use to correct itself without re-reading.
+ */
+export function nearestMatchHint(
+  fileLf: string,
+  oldLf: string,
+): { line: number; snippet: string } | undefined {
+  const fileLines = fileLf.split('\n');
+  const needleLines = oldLf.split('\n');
+  if (needleLines.length > fileLines.length) return undefined;
+
+  const needleTrimmed = needleLines.map((l) => l.trim());
+  let bestScore = 0;
+  let bestStart = -1;
+  for (let i = 0; i + needleLines.length <= fileLines.length; i++) {
+    let sum = 0;
+    for (let j = 0; j < needleLines.length; j++) {
+      sum += prefixSimilarity(needleTrimmed[j] as string, (fileLines[i + j] as string).trim());
+    }
+    const score = sum / needleLines.length;
+    if (score > bestScore) {
+      bestScore = score;
+      bestStart = i;
+    }
+  }
+  if (bestStart === -1 || bestScore < 0.5) return undefined;
+
+  const snippet = fileLines
+    .slice(bestStart, bestStart + Math.min(3, needleLines.length))
+    .map((l) => (l.length > 120 ? `${l.slice(0, 120)}…` : l))
+    .join('\n');
+  return { line: bestStart + 1, snippet };
+}
+
+/** Cheap similarity proxy: shared prefix length over max length. */
+function prefixSimilarity(a: string, b: string): number {
+  if (a === b) return 1;
+  const max = Math.max(a.length, b.length);
+  if (max === 0) return 1;
+  let p = 0;
+  const lim = Math.min(a.length, b.length);
+  while (p < lim && a.charCodeAt(p) === b.charCodeAt(p)) p++;
+  return p / max;
+}

--- a/packages/tools/src/_syntax-check.ts
+++ b/packages/tools/src/_syntax-check.ts
@@ -1,0 +1,149 @@
+/**
+ * Post-edit syntax validation for `edit` and `write`.
+ *
+ * After a mutation lands on disk, the new content is parsed (TS/JS via the
+ * TypeScript compiler's parser, JSON via JSON.parse with a JSONC fallback)
+ * and any parse errors are surfaced in the tool output. The edit is NOT
+ * rolled back — reverting would desynchronize the model's picture of the
+ * file — but the errors come back in the same turn so the model fixes the
+ * breakage before the user ever opens a broken file.
+ *
+ * The check is purely syntactic (no type checking, no project program), so
+ * it costs single-digit milliseconds per file. Semantic type errors remain
+ * the `type-gate` plugin's job.
+ */
+import * as path from 'node:path';
+
+const TS_LIKE = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs']);
+/** Skip pathologically large files — the model never writes these in one go. */
+const MAX_CHECK_CHARS = 1_500_000;
+/** Cap reported errors so a mangled file doesn't flood the context. */
+const MAX_ERRORS = 5;
+
+type Ts = typeof import('typescript');
+
+let tsLoad: Promise<Ts | null> | null = null;
+/** Lazy-load the TypeScript compiler (already a dependency via the codebase
+ *  indexer) so tools that never touch TS files don't pay its import cost. */
+function loadTypescript(): Promise<Ts | null> {
+  tsLoad ??= import('typescript').then(
+    (m) => ((m as unknown as { default?: Ts }).default ?? m) as Ts,
+    () => null,
+  );
+  return tsLoad;
+}
+
+export interface SyntaxCheckResult {
+  /** Parse errors in the new content (capped at {@link MAX_ERRORS}). */
+  errors: string[];
+  /** True when the pre-edit content already failed to parse — the edit did
+   *  not introduce the breakage (though it didn't fix it either). */
+  preExisting: boolean;
+}
+
+/**
+ * Check `content` for syntax errors based on the file extension.
+ * Returns `undefined` when the file type is not checkable (or the checker
+ * is unavailable) and a result with an empty `errors` array when clean.
+ * Pass `previousContent` to distinguish newly-introduced errors from
+ * pre-existing ones.
+ */
+export async function checkSyntax(
+  filePath: string,
+  content: string,
+  previousContent?: string,
+): Promise<SyntaxCheckResult | undefined> {
+  const errors = await parseErrors(filePath, content);
+  if (errors === undefined) return undefined;
+  if (errors.length === 0) return { errors, preExisting: false };
+  let preExisting = false;
+  if (previousContent !== undefined) {
+    const prevErrors = await parseErrors(filePath, previousContent);
+    preExisting = prevErrors !== undefined && prevErrors.length > 0;
+  }
+  return { errors, preExisting };
+}
+
+/** Files that are conventionally JSONC (comments + trailing commas allowed). */
+function isJsoncFile(filePath: string): boolean {
+  const base = path.basename(filePath).toLowerCase();
+  if (base.endsWith('.jsonc')) return true;
+  if (/^(tsconfig|jsconfig)([.-].*)?\.json$/.test(base)) return true;
+  const dir = path.basename(path.dirname(filePath)).toLowerCase();
+  return dir === '.vscode';
+}
+
+async function parseErrors(filePath: string, content: string): Promise<string[] | undefined> {
+  if (content.length > MAX_CHECK_CHARS) return undefined;
+  const ext = path.extname(filePath).toLowerCase();
+
+  if (ext === '.json' || ext === '.jsonc') {
+    try {
+      JSON.parse(content);
+      return [];
+    } catch (err) {
+      // Known-JSONC files (tsconfig.json, VS Code settings, *.jsonc) accept
+      // comments and trailing commas — re-parse with the TS config parser
+      // before declaring them broken. Plain .json stays strict: a trailing
+      // comma there IS an error the model should fix.
+      if (isJsoncFile(filePath)) {
+        const ts = await loadTypescript();
+        if (ts) {
+          const jsonc = ts.parseConfigFileTextToJson(filePath, content);
+          if (!jsonc.error) return [];
+          return [formatDiag(ts, jsonc.error, content)];
+        }
+      }
+      return [`JSON parse error: ${(err as Error).message}`];
+    }
+  }
+
+  if (!TS_LIKE.has(ext)) return undefined;
+  const ts = await loadTypescript();
+  if (!ts) return undefined;
+
+  const scriptKind =
+    ext === '.tsx'
+      ? ts.ScriptKind.TSX
+      : ext === '.ts' || ext === '.mts' || ext === '.cts'
+        ? ts.ScriptKind.TS
+        : // Plain JS may legitimately contain JSX; the JSX grammar is a
+          // superset for untyped code, so parsing .js/.jsx as JSX avoids
+          // false positives on React files.
+          ts.ScriptKind.JSX;
+
+  const sourceFile = ts.createSourceFile(
+    path.basename(filePath),
+    content,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    scriptKind,
+  );
+  // parseDiagnostics is not in the public .d.ts but has been the stable
+  // home of the parser's syntactic diagnostics for a decade (the public
+  // alternative, program.getSyntacticDiagnostics, needs a full Program).
+  const diags =
+    (sourceFile as unknown as { parseDiagnostics?: import('typescript').Diagnostic[] })
+      .parseDiagnostics ?? [];
+  return diags.slice(0, MAX_ERRORS).map((d) => formatDiag(ts, d, content, sourceFile));
+}
+
+function formatDiag(
+  ts: Ts,
+  diag: import('typescript').Diagnostic,
+  content: string,
+  sourceFile?: import('typescript').SourceFile,
+): string {
+  const message = ts.flattenDiagnosticMessageText(diag.messageText, ' ');
+  if (diag.start === undefined) return message;
+  let line: number;
+  if (sourceFile) {
+    line = sourceFile.getLineAndCharacterOfPosition(diag.start).line + 1;
+  } else {
+    line = 1;
+    for (let i = 0; i < diag.start && i < content.length; i++) {
+      if (content.charCodeAt(i) === 0x0a) line++;
+    }
+  }
+  return `line ${line}: ${message}`;
+}

--- a/packages/tools/src/_util.ts
+++ b/packages/tools/src/_util.ts
@@ -1,7 +1,17 @@
+import { createHash } from 'node:crypto';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as Core from '@wrongstack/core';
 import type { Context } from '@wrongstack/core';
+
+/**
+ * sha-256 hex of a UTF-8 string. Used by the file tools to record a content
+ * hash alongside the mtime in `ctx.recordRead` — the hash is the authoritative
+ * staleness arbiter for `edit` (mtime has a 2 s tolerance window on Windows).
+ */
+export function sha256hex(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
 /** Detected package manager for a project directory. */
 export type PackageManager = 'pnpm' | 'yarn' | 'npm';
 

--- a/packages/tools/src/edit.ts
+++ b/packages/tools/src/edit.ts
@@ -8,7 +8,17 @@ import {
   toStyle,
   unifiedDiff,
 } from '@wrongstack/core';
-import { safeResolveReal } from './_util.js';
+import {
+  adjustIndent,
+  findLadderMatches,
+  firstLineIndent,
+  type MatchTier,
+  nearestMatchHint,
+  TIER_CONFIDENCE,
+  TIER_LABEL,
+} from './_edit-match.js';
+import { checkSyntax } from './_syntax-check.js';
+import { safeResolveReal, sha256hex } from './_util.js';
 
 interface EditInput {
   path: string;
@@ -27,6 +37,18 @@ interface EditOutput {
   path: string;
   replacements: number;
   diff: string;
+  /**
+   * How `old_string` was located. Anything other than 'exact' means a
+   * whitespace/fuzzy fallback fired — the note carries the confidence level
+   * and the diff shows exactly what was replaced.
+   */
+  matched_by: MatchTier;
+  /**
+   * Parse errors found in the file AFTER the edit was applied (TS/JS/JSON
+   * only). The edit is still on disk — fix these in a follow-up edit now,
+   * before doing anything else.
+   */
+  syntax_errors?: string[] | undefined;
   note?: string | undefined;
 }
 
@@ -43,7 +65,9 @@ export const editTool: Tool<EditInput, EditOutput> = {
     '2. Use a sufficiently unique `old_string` (include surrounding lines/context if needed).\n' +
     '3. If the string appears multiple times and you want to change all of them, set `replace_all: true`.\n' +
     '4. `new_string` must be the exact replacement text.\n\n' +
-    'If no prior read is recorded, the tool auto-reads the current file and only applies the edit after the same ambiguity checks pass.',
+    'If no prior read is recorded, the tool auto-reads the current file and only applies the edit after the same ambiguity checks pass.\n' +
+    'If `old_string` differs from the file only in whitespace (trailing spaces, indentation), a lower-confidence fallback match is applied and reported in `matched_by`/`note` — always verify the diff when this happens.\n' +
+    'After the edit, TS/JS/JSON files are syntax-checked; if `syntax_errors` is present in the output, fix those errors immediately with a follow-up edit.',
   permission: 'confirm',
   mutating: true,
   capabilities: ['fs.write'],
@@ -108,13 +132,31 @@ export const editTool: Tool<EditInput, EditOutput> = {
     const original = await fs.readFile(absPath, 'utf8');
     const updated = await fs.stat(absPath);
     const mtimeTolerance = process.platform === 'win32' ? 2000 : 1;
-    const lastReadMtime = ctx.lastReadMtime(absPath);
-    if (lastReadMtime !== undefined && updated.mtimeMs > lastReadMtime + mtimeTolerance) {
-      throw new ToolValidationError({
-        message: `edit: file "${input.path}" was modified externally. Re-read it first.`,
-        field: 'path',
-        context: { reason: 'external_modification' },
-      });
+    const originalHash = sha256hex(original);
+    // Optional call: embedders and older test fixtures may hand in a
+    // duck-typed Context without hash tracking — they fall back to mtime.
+    const lastReadHash = ctx.lastReadHash?.(absPath);
+    if (lastReadHash !== undefined) {
+      // Content hash is the authoritative arbiter when available: it closes
+      // the mtime tolerance window (an external write within 2 s of the read
+      // on Windows is invisible to mtime) and ignores content-preserving
+      // mtime bumps (touch, checkout of identical content).
+      if (lastReadHash !== originalHash) {
+        throw new ToolValidationError({
+          message: `edit: file "${input.path}" was modified externally. Re-read it first.`,
+          field: 'path',
+          context: { reason: 'external_modification' },
+        });
+      }
+    } else {
+      const lastReadMtime = ctx.lastReadMtime(absPath);
+      if (lastReadMtime !== undefined && updated.mtimeMs > lastReadMtime + mtimeTolerance) {
+        throw new ToolValidationError({
+          message: `edit: file "${input.path}" was modified externally. Re-read it first.`,
+          field: 'path',
+          context: { reason: 'external_modification' },
+        });
+      }
     }
     if (autoRead && updated.mtimeMs > stat.mtimeMs + mtimeTolerance) {
       throw new ToolValidationError({
@@ -132,48 +174,105 @@ export const editTool: Tool<EditInput, EditOutput> = {
     const newLf = normalizeToLf(input.new_string);
 
     if (oldLf === newLf) {
-      if (autoRead) ctx.recordRead(absPath, updated.mtimeMs);
+      if (autoRead) ctx.recordRead(absPath, updated.mtimeMs, 'user', originalHash);
       return {
         path: absPath,
         replacements: 0,
         diff: '(no-op: old and new are identical)',
+        matched_by: 'exact',
         note: autoReadNote,
       };
     }
 
-    let count = 0;
-    let idx = fileLf.indexOf(oldLf);
-    const matches: number[] = [];
-    while (idx !== -1) {
-      matches.push(idx);
-      count++;
-      idx = fileLf.indexOf(oldLf, idx + 1);
-    }
+    const ladder = findLadderMatches(fileLf, oldLf);
 
-    if (count === 0) {
-      const hint = findSimilarity(fileLf, oldLf);
+    if (!ladder) {
+      const hint = nearestMatchHint(fileLf, oldLf);
       throw new ToolValidationError({
         message: `edit: no match for old_string in "${input.path}".${
-          hint ? ` Nearest match near line ${hint}.` : ''
+          hint
+            ? ` Nearest match near line ${hint.line}:\n${hint.snippet}\n` +
+              `Compare this against your old_string and retry with the file's actual text.`
+            : ''
         }`,
         field: 'old_string',
       });
     }
 
-    if (count > 1 && !input.replace_all) {
-      const lines = lineNumbersFor(fileLf, matches);
+    const { tier, matches } = ladder;
+    const count = matches.length;
+
+    if (ladder.ambiguous) {
+      const lines = matches.map((m) => m.startLine);
       throw new ToolValidationError({
         message:
-          `edit: old_string matched ${count} times in "${input.path}" (lines: ${lines.join(', ')}). ` +
-          `Add more context to make it unique, or set replace_all: true.`,
+          `edit: old_string only matched fuzzily and ${count} candidate blocks scored too close ` +
+          `to distinguish (lines: ${lines.join(', ')}) in "${input.path}". ` +
+          `Re-read the file and use the exact text of the intended block.`,
         field: 'old_string',
-        context: { occurrences: count },
+        context: { occurrences: count, matchTier: tier },
       });
     }
 
-    const newFileLf = input.replace_all
-      ? fileLf.split(oldLf).join(newLf)
-      : fileLf.replace(oldLf, newLf);
+    // Fuzzy/indent-insensitive matches are single-target operations: applying
+    // them in bulk multiplies a low-confidence guess. replace_all therefore
+    // requires at least a trailing-whitespace-level match.
+    if (input.replace_all && tier !== 'exact' && tier !== 'trailing-whitespace') {
+      throw new ToolValidationError({
+        message:
+          `edit: old_string only matched via ${TIER_LABEL[tier]} in "${input.path}", ` +
+          `but replace_all requires an exact (or trailing-whitespace) match. ` +
+          `Re-read the file and use its exact text.`,
+        field: 'old_string',
+        context: { matchTier: tier },
+      });
+    }
+
+    if (count > 1 && !input.replace_all) {
+      const lines = matches.map((m) => m.startLine);
+      throw new ToolValidationError({
+        message:
+          `edit: old_string matched ${count} times in "${input.path}" (lines: ${lines.join(', ')})` +
+          `${tier === 'exact' ? '' : ` via ${TIER_LABEL[tier]}`}. ` +
+          `Add more context to make it unique, or set replace_all: true.`,
+        field: 'old_string',
+        context: { occurrences: count, matchTier: tier },
+      });
+    }
+
+    let newFileLf: string;
+    let tierNote: string | undefined;
+    if (tier === 'exact') {
+      newFileLf = input.replace_all
+        ? fileLf.split(oldLf).join(newLf)
+        : fileLf.replace(oldLf, newLf);
+    } else {
+      // Fallback tiers matched whole-line windows — splice by char offsets,
+      // right to left so earlier offsets stay valid. For indent-insensitive
+      // tiers, shift the replacement to the file's actual indentation.
+      let replacement = newLf;
+      let indentSuffix = '';
+      if (tier === 'whitespace-normalized' || tier === 'fuzzy') {
+        const first = matches[0] as (typeof matches)[number];
+        const matchedText = fileLf.slice(first.start, first.end);
+        const adjusted = adjustIndent(newLf, firstLineIndent(oldLf), firstLineIndent(matchedText));
+        replacement = adjusted.text;
+        if (adjusted.adjusted) indentSuffix = '; replacement re-indented to match the file';
+      }
+      newFileLf = fileLf;
+      const applied = input.replace_all ? matches : matches.slice(0, 1);
+      for (let i = applied.length - 1; i >= 0; i--) {
+        const m = applied[i] as (typeof matches)[number];
+        newFileLf = newFileLf.slice(0, m.start) + replacement + newFileLf.slice(m.end);
+      }
+      const scoreSuffix =
+        ladder.score !== undefined ? `, similarity ${(ladder.score * 100).toFixed(1)}%` : '';
+      tierNote =
+        `old_string did not match exactly; applied via ${TIER_LABEL[tier]} at line ` +
+        `${(matches[0] as (typeof matches)[number]).startLine} ` +
+        `(confidence: ${TIER_CONFIDENCE[tier]}${scoreSuffix}${indentSuffix}). ` +
+        `Review the diff to confirm the intended target was edited.`;
+    }
     const newFile = toStyle(newFileLf, style);
 
     // Last exit before mutating the filesystem: a run aborted during the
@@ -182,10 +281,11 @@ export const editTool: Tool<EditInput, EditOutput> = {
     opts?.signal?.throwIfAborted();
     await atomicWrite(absPath, newFile, { mode: updated.mode & 0o777 });
     const written = await fs.stat(absPath);
-    // Record mtime so a later edit detects external modification, but tag as
-    // 'write' so the permission policy's write-smart-bypass does NOT treat
-    // this as "user already saw the content" (P1 #1).
-    ctx.recordRead(absPath, written.mtimeMs, 'write');
+    // Record mtime + content hash so a later edit detects external
+    // modification, but tag as 'write' so the permission policy's
+    // write-smart-bypass does NOT treat this as "user already saw the
+    // content" (P1 #1).
+    ctx.recordRead(absPath, written.mtimeMs, 'write', sha256hex(newFile));
 
     // Record for session rewind
     ctx.session.recordFileChange({
@@ -200,37 +300,25 @@ export const editTool: Tool<EditInput, EditOutput> = {
       toFile: input.path,
     });
 
+    // Post-edit syntax validation (TS/JS/JSON). The edit stays on disk —
+    // errors come back in the same turn so the model fixes them immediately.
+    const syntax = await checkSyntax(absPath, newFile, original).catch(() => undefined);
+    let syntaxNote: string | undefined;
+    if (syntax && syntax.errors.length > 0) {
+      syntaxNote = syntax.preExisting
+        ? `Syntax check: the file still has parse errors (they pre-date this edit) — see syntax_errors.`
+        : `Syntax check: this edit introduced ${syntax.errors.length} parse error(s) — fix them now, see syntax_errors.`;
+    }
+
+    const notes = [autoReadNote, tierNote, syntaxNote].filter(Boolean);
+
     return {
       path: absPath,
       replacements: input.replace_all ? count : 1,
       diff,
-      note: autoReadNote,
+      matched_by: tier,
+      syntax_errors: syntax && syntax.errors.length > 0 ? syntax.errors : undefined,
+      note: notes.length > 0 ? notes.join('\n') : undefined,
     };
   },
 };
-
-function lineNumbersFor(text: string, indices: number[]): number[] {
-  const out: number[] = [];
-  let pos = 0;
-  let line = 1;
-  for (const target of indices) {
-    while (pos < target) {
-      if (text.charCodeAt(pos) === 0x0a) line++;
-      pos++;
-    }
-    out.push(line);
-  }
-  return out;
-}
-
-function findSimilarity(haystack: string, needle: string): number | undefined {
-  if (needle.length < 20) return undefined;
-  const probe = needle.slice(0, Math.min(40, needle.length));
-  const idx = haystack.indexOf(probe);
-  if (idx === -1) return undefined;
-  let line = 1;
-  for (let i = 0; i < idx; i++) {
-    if (haystack.charCodeAt(i) === 0x0a) line++;
-  }
-  return line;
-}

--- a/packages/tools/src/patch.ts
+++ b/packages/tools/src/patch.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { buildChildEnv } from '@wrongstack/core';
 import type { Tool } from '@wrongstack/core';
-import { safeResolve } from './_util.js';
+import { safeResolve, sha256hex } from './_util.js';
 
 interface PatchInput {
   patch: string;
@@ -59,6 +59,7 @@ export const patchTool: Tool<PatchInput, PatchOutput> = {
     // the project root. This catches `../../../etc/passwd`-style escapes
     // before we hand the diff to GNU patch.
     const targets = extractDiffTargets(input.patch);
+    const resolvedTargets: string[] = [];
     for (const t of targets) {
       const stripped = stripPathComponents(t, strip);
       if (!stripped) continue;
@@ -72,6 +73,16 @@ export const patchTool: Tool<PatchInput, PatchOutput> = {
           dry_run: dryRun,
           message: `patch refused: target "${t}" resolves outside project root`,
         };
+      }
+      resolvedTargets.push(candidate);
+    }
+
+    // Snapshot target contents before applying so the change can be recorded
+    // for session rewind and stale-read tracking (same bookkeeping as `edit`).
+    const beforeContents = new Map<string, string | null>();
+    if (!dryRun) {
+      for (const target of resolvedTargets) {
+        beforeContents.set(target, await readTextForTracking(target));
       }
     }
 
@@ -101,6 +112,28 @@ export const patchTool: Tool<PatchInput, PatchOutput> = {
       }
 
       const patched = extractPatchedFiles(result.stdout);
+
+      // Record what actually changed: mtime + hash (tagged 'write' so the
+      // permission bypass does not widen) so a later `edit` doesn't trip the
+      // stale-read guard on our own write, plus the before/after pair for
+      // session rewind.
+      if (!dryRun) {
+        for (const target of resolvedTargets) {
+          const before = beforeContents.get(target) ?? null;
+          const after = await readTextForTracking(target);
+          if (after === null || after === before) continue;
+          const stat = await fs.stat(target).catch(() => null);
+          // Optional calls: embedders may hand in a duck-typed Context.
+          if (stat) ctx.recordRead?.(target, stat.mtimeMs, 'write', sha256hex(after));
+          ctx.session?.recordFileChange?.({
+            path: target,
+            action: before === null ? 'created' : 'modified',
+            before,
+            after,
+          });
+        }
+      }
+
       return {
         applied: patched.length,
         rejected: 0,
@@ -113,6 +146,21 @@ export const patchTool: Tool<PatchInput, PatchOutput> = {
     }
   },
 };
+
+/** Read a target file as UTF-8 for change tracking. Returns null when the
+ *  file is missing (new-file diff), binary, or too large to snapshot. */
+const MAX_TRACKING_BYTES = 5 * 1024 * 1024;
+async function readTextForTracking(absPath: string): Promise<string | null> {
+  try {
+    const stat = await fs.stat(absPath);
+    if (!stat.isFile() || stat.size > MAX_TRACKING_BYTES) return null;
+    const buf = await fs.readFile(absPath);
+    if (buf.includes(0)) return null; // binary
+    return buf.toString('utf8');
+  } catch {
+    return null;
+  }
+}
 
 /** Extract every `+++ <path>` target from a unified diff. */
 function extractDiffTargets(patch: string): string[] {

--- a/packages/tools/src/read.ts
+++ b/packages/tools/src/read.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs/promises';
 import { type Tool, FsError, toErrorMessage, ToolValidationError } from '@wrongstack/core';
-import { isBinaryBuffer, safeResolveReal } from './_util.js';
+import { isBinaryBuffer, safeResolveReal, sha256hex } from './_util.js';
 
 interface ReadInput {
   path: string;
@@ -141,10 +141,15 @@ export const readTool: Tool<ReadInput, ReadOutput> = {
     }
 
     const text = buf.toString('utf8');
+    // Content hash recorded alongside the mtime: `edit` uses it as the
+    // authoritative staleness check (mtime alone has a 2 s tolerance window
+    // on Windows). The full file is read even for offset/limit slices, so
+    // the hash always covers the whole content.
+    const contentHash = sha256hex(text);
     const allLines = text.split(/\r\n|\r|\n/);
     const total = allLines.length;
     if (input.mode === 'summary') {
-      ctx.recordRead(absPath, stat.mtimeMs);
+      ctx.recordRead(absPath, stat.mtimeMs, 'user', contentHash);
       rememberReadRange(ctx, absPath, stat.mtimeMs, total, 1, Math.min(total, 200));
       return {
         text: summarizeFile(input.path, stat.size, allLines),
@@ -155,7 +160,7 @@ export const readTool: Tool<ReadInput, ReadOutput> = {
       };
     }
     if (limit === 0) {
-      ctx.recordRead(absPath, stat.mtimeMs);
+      ctx.recordRead(absPath, stat.mtimeMs, 'user', contentHash);
       rememberReadRange(ctx, absPath, stat.mtimeMs, total, 1, 0);
       return { text: '', total_lines: total, encoding: 'utf8', truncated: total > 0 };
     }
@@ -165,7 +170,7 @@ export const readTool: Tool<ReadInput, ReadOutput> = {
     // same offset indefinitely — a tight tool-use loop that burns iterations
     // and context without making progress.
     if (offset > total) {
-      ctx.recordRead(absPath, stat.mtimeMs);
+      ctx.recordRead(absPath, stat.mtimeMs, 'user', contentHash);
       rememberReadRange(ctx, absPath, stat.mtimeMs, total, total + 1, total + 1);
       return {
         text: `[offset ${offset} is past end of file "${input.path}" — file has ${total} line(s). Do not retry this offset.]`,
@@ -183,7 +188,7 @@ export const readTool: Tool<ReadInput, ReadOutput> = {
       .map((line, i) => `${String(offset + i).padStart(width, ' ')}→${line}`)
       .join('\n');
 
-    ctx.recordRead(absPath, stat.mtimeMs);
+    ctx.recordRead(absPath, stat.mtimeMs, 'user', contentHash);
     rememberReadRange(ctx, absPath, stat.mtimeMs, total, offset, offset + slice.length - 1);
 
     return {

--- a/packages/tools/src/replace.ts
+++ b/packages/tools/src/replace.ts
@@ -14,7 +14,7 @@ import {
 } from '@wrongstack/core';
 import type { Context, Tool } from '@wrongstack/core';
 import { compileUserRegex } from './_regex.js';
-import { isBinaryBuffer, safeResolve } from './_util.js';
+import { isBinaryBuffer, safeResolve, sha256hex } from './_util.js';
 interface ReplaceInput {
   pattern: string;
   replacement: string;
@@ -188,6 +188,21 @@ export const replaceTool: Tool<ReplaceInput, ReplaceOutput> = {
         // so atomicWrite's temp-and-rename can't be redirected through a
         // freshly-planted symlink at absPath.
         await atomicWrite(realPath, newContent, { mode: stat.mode & 0o777 });
+        // Same bookkeeping as `edit`: record the new mtime + hash (tagged
+        // 'write' so the permission bypass does not widen) so a later `edit`
+        // of this file doesn't trip the stale-read guard on our own write,
+        // and record the change for session rewind. Optional calls: embedders
+        // may hand in a duck-typed Context without these members.
+        const written = await fs.stat(realPath).catch(() => null);
+        if (written) {
+          ctx.recordRead?.(realPath, written.mtimeMs, 'write', sha256hex(newContent));
+        }
+        ctx.session?.recordFileChange?.({
+          path: realPath,
+          action: 'modified',
+          before: content,
+          after: newContent,
+        });
       }
 
       const diff =

--- a/packages/tools/src/write.ts
+++ b/packages/tools/src/write.ts
@@ -1,7 +1,8 @@
 import * as fs from 'node:fs/promises';
 import { atomicWrite, ToolValidationError, unifiedDiff } from '@wrongstack/core';
 import type { Context, Tool } from '@wrongstack/core';
-import { safeResolveReal } from './_util.js';
+import { checkSyntax } from './_syntax-check.js';
+import { safeResolveReal, sha256hex } from './_util.js';
 
 interface WriteInput {
   path: string;
@@ -13,6 +14,12 @@ interface WriteOutput {
   bytes_written: number;
   created: boolean;
   diff?: string | undefined;
+  /**
+   * Parse errors found in the written content (TS/JS/JSON only). The file is
+   * on disk as written — fix these with a follow-up edit now.
+   */
+  syntax_errors?: string[] | undefined;
+  note?: string | undefined;
 }
 
 export const writeTool: Tool<WriteInput, WriteOutput> = {
@@ -104,7 +111,7 @@ async function prepareWrite(input: WriteInput, ctx: Context): Promise<PreparedWr
         // this internal read-for-diff does not widen the permission bypass
         // — the user never saw the old content (P1 #1).
         prev = await fs.readFile(absPath, 'utf8');
-        ctx.recordRead(absPath, stat.mtimeMs, 'write');
+        ctx.recordRead(absPath, stat.mtimeMs, 'write', sha256hex(prev));
       } else {
         prev = await fs.readFile(absPath, 'utf8');
       }
@@ -139,7 +146,7 @@ async function finishWrite(
   // Tag as 'write' so the permission bypass does not auto-approve a later
   // write to this path — the user approved THIS write, not future ones
   // (P1 #1).
-  ctx.recordRead(prepared.absPath, stat.mtimeMs, 'write');
+  ctx.recordRead(prepared.absPath, stat.mtimeMs, 'write', sha256hex(input.content));
 
   // Record for session rewind
   ctx.session.recordFileChange({
@@ -149,10 +156,26 @@ async function finishWrite(
     after: input.content,
   });
 
+  // Post-write syntax validation (TS/JS/JSON). The file stays on disk as
+  // written — errors come back in the same turn so the model fixes them
+  // before the user ever opens a broken file.
+  const syntax = await checkSyntax(
+    prepared.absPath,
+    input.content,
+    prepared.existed ? prepared.prev : undefined,
+  ).catch(() => undefined);
+  const hasSyntaxErrors = syntax !== undefined && syntax.errors.length > 0;
+
   return {
     path: prepared.absPath,
     bytes_written: Buffer.byteLength(input.content, 'utf8'),
     created: !prepared.existed,
     diff,
+    syntax_errors: hasSyntaxErrors ? syntax.errors : undefined,
+    note: hasSyntaxErrors
+      ? syntax.preExisting
+        ? 'Syntax check: the file still has parse errors (they pre-date this write) — see syntax_errors.'
+        : `Syntax check: the written content has ${syntax.errors.length} parse error(s) — fix them now, see syntax_errors.`
+      : undefined,
   };
 }

--- a/packages/tools/tests/edit-match.test.ts
+++ b/packages/tools/tests/edit-match.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import {
+  adjustIndent,
+  findLadderMatches,
+  firstLineIndent,
+  nearestMatchHint,
+  similarity,
+} from '../src/_edit-match.js';
+
+describe('_edit-match', () => {
+  describe('findLadderMatches', () => {
+    it('prefers exact matches and reports every occurrence', () => {
+      const res = findLadderMatches('foo\nbar\nfoo\n', 'foo');
+      expect(res?.tier).toBe('exact');
+      expect(res?.matches).toHaveLength(2);
+      expect(res?.matches.map((m) => m.startLine)).toEqual([1, 3]);
+    });
+
+    it('exact matches support sub-line needles', () => {
+      const res = findLadderMatches('const foobar = 1;\n', 'foobar');
+      expect(res?.tier).toBe('exact');
+      expect(res?.matches[0]?.start).toBe(6);
+    });
+
+    it('falls back to trailing-whitespace matching', () => {
+      const res = findLadderMatches('const a = 1;\n', 'const a = 1;   ');
+      expect(res?.tier).toBe('trailing-whitespace');
+      expect(res?.matches).toHaveLength(1);
+      expect(res?.matches[0]).toMatchObject({ start: 0, end: 12, startLine: 1 });
+    });
+
+    it('falls back to indent-insensitive matching for long-enough needles', () => {
+      const res = findLadderMatches(
+        '    doThing(alpha, beta);\n    done();\n',
+        'doThing(alpha, beta);\ndone();',
+      );
+      expect(res?.tier).toBe('whitespace-normalized');
+      expect(res?.matches).toHaveLength(1);
+    });
+
+    it('refuses indent-insensitive matching for tiny needles', () => {
+      expect(findLadderMatches('if (x) {\n  y();\n}\n', '  }')).toBeUndefined();
+    });
+
+    it('fuzzy tier requires matching first/last anchors', () => {
+      const file = 'start() {\n  middle(1);\n  extra();\n}\n';
+      // Last line differs → no anchor → no fuzzy match.
+      expect(findLadderMatches(file, 'start() {\n  middle(2);\n  extra();\n};')).toBeUndefined();
+    });
+
+    it('fuzzy tier flags equally-scored candidates as ambiguous', () => {
+      const block = 'function a() {\n  return compute(1, 2, 3);\n}';
+      const res = findLadderMatches(
+        `${block}\n\n${block}\n`,
+        'function a() {\n  return compute(1, 2, 4);\n}',
+      );
+      expect(res?.tier).toBe('fuzzy');
+      expect(res?.ambiguous).toBe(true);
+      expect(res?.matches.length).toBe(2);
+    });
+
+    it('windows never overlap at line-based tiers', () => {
+      // Needle spans 2 lines; the file repeats the line 3 times — only one
+      // non-overlapping window pair should match, not two overlapping ones.
+      const res = findLadderMatches('x\nx\nx\n', 'x \nx ');
+      expect(res?.tier).toBe('trailing-whitespace');
+      expect(res?.matches).toHaveLength(1);
+    });
+  });
+
+  describe('adjustIndent', () => {
+    it('adds indentation when the file is deeper than the needle', () => {
+      const out = adjustIndent('if (a) {\n  b();\n}', '', '    ');
+      expect(out.adjusted).toBe(true);
+      expect(out.text).toBe('    if (a) {\n      b();\n    }');
+    });
+
+    it('removes indentation when the file is shallower than the needle', () => {
+      const out = adjustIndent('    if (a) {\n      b();\n    }', '    ', '  ');
+      expect(out.adjusted).toBe(true);
+      expect(out.text).toBe('  if (a) {\n    b();\n  }');
+    });
+
+    it('leaves empty lines alone when adding indent', () => {
+      const out = adjustIndent('a\n\nb', '', '  ');
+      expect(out.text).toBe('  a\n\n  b');
+    });
+
+    it('does not guess on tabs-vs-spaces mismatches', () => {
+      const out = adjustIndent('a', '\t', '  ');
+      expect(out.adjusted).toBe(false);
+      expect(out.text).toBe('a');
+    });
+  });
+
+  describe('similarity', () => {
+    it('is 1 for identical strings and 0-ish for disjoint ones', () => {
+      expect(similarity('abc', 'abc')).toBe(1);
+      expect(similarity('abc', 'xyz')).toBeLessThan(0.5);
+    });
+
+    it('scores single-char drift above the fuzzy threshold', () => {
+      expect(similarity('return compute(1, 2, 3);', 'return compute(1, 2, 4);')).toBeGreaterThan(
+        0.9,
+      );
+    });
+
+    it('quick-rejects large length gaps without full DP', () => {
+      expect(similarity('ab', 'ab'.repeat(50))).toBeLessThan(0.9);
+    });
+  });
+
+  describe('firstLineIndent', () => {
+    it('skips empty lines and reads the first real indent', () => {
+      expect(firstLineIndent('\n\n    code();')).toBe('    ');
+      expect(firstLineIndent('code();')).toBe('');
+      expect(firstLineIndent('')).toBe('');
+    });
+  });
+
+  describe('nearestMatchHint', () => {
+    it('locates the closest window and returns a snippet', () => {
+      const hint = nearestMatchHint(
+        'first\nsecond\nconst alpha = computeValue(input, options);\n',
+        'const alpha = computeValue(input, settings);',
+      );
+      expect(hint?.line).toBe(3);
+      expect(hint?.snippet).toContain('computeValue(input, options)');
+    });
+
+    it('returns undefined when nothing is close', () => {
+      expect(
+        nearestMatchHint('completely unrelated content\n', 'zzzz no match at all'),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/packages/tools/tests/edit.test.ts
+++ b/packages/tools/tests/edit.test.ts
@@ -166,11 +166,42 @@ describe('edit tool', () => {
     ).rejects.toThrow(/does not exist/);
   });
 
-  it('flags external modification when mtime advances past tolerance', async () => {
+  it('flags external modification when the content changed since the read', async () => {
     const file = path.join(sb.dir, 'a.txt');
     await fs.writeFile(file, 'hello');
     await readTool.execute({ path: 'a.txt' }, sb.ctx, { signal: newSignal() });
-    // Bump mtime well past either tolerance window (1 ms POSIX / 2 s Windows).
+    // Change the content behind the agent's back. The hash arbiter catches
+    // this even inside the mtime tolerance window (2 s on Windows).
+    await fs.writeFile(file, 'hello, changed');
+    await expect(
+      editTool.execute({ path: 'a.txt', old_string: 'hello', new_string: 'hi' }, sb.ctx, {
+        signal: newSignal(),
+      }),
+    ).rejects.toThrow(/modified externally/);
+  });
+
+  it('a content-preserving mtime bump (touch) does not block the edit', async () => {
+    const file = path.join(sb.dir, 'a.txt');
+    await fs.writeFile(file, 'hello');
+    await readTool.execute({ path: 'a.txt' }, sb.ctx, { signal: newSignal() });
+    // mtime advances past tolerance but the content hash is unchanged —
+    // the model's picture of the file is still accurate, so editing is safe.
+    const future = new Date(Date.now() + 10_000);
+    await fs.utimes(file, future, future);
+    const out = await editTool.execute(
+      { path: 'a.txt', old_string: 'hello', new_string: 'hi' },
+      sb.ctx,
+      { signal: newSignal() },
+    );
+    expect(out.replacements).toBe(1);
+  });
+
+  it('falls back to the mtime check when no content hash was recorded', async () => {
+    const file = path.join(sb.dir, 'a.txt');
+    await fs.writeFile(file, 'hello');
+    // Simulate an older/duck-typed recordRead that stored only the mtime.
+    const stat = await fs.stat(file);
+    sb.ctx.recordRead(await fs.realpath(file), stat.mtimeMs);
     const future = new Date(Date.now() + 10_000);
     await fs.utimes(file, future, future);
     await expect(
@@ -269,6 +300,234 @@ describe('edit tool', () => {
           signal: newSignal(),
         }),
       ).rejects.toThrow(/no match/);
+    });
+  });
+
+  describe('matching ladder fallbacks', () => {
+    it('exact match reports matched_by: exact and no fallback note', async () => {
+      await fs.writeFile(path.join(sb.dir, 'a.txt'), 'hello world');
+      await readTool.execute({ path: 'a.txt' }, sb.ctx, { signal: newSignal() });
+      const out = await editTool.execute(
+        { path: 'a.txt', old_string: 'hello', new_string: 'hi' },
+        sb.ctx,
+        { signal: newSignal() },
+      );
+      expect(out.matched_by).toBe('exact');
+      expect(out.note).toBeUndefined();
+    });
+
+    it('trailing whitespace in old_string falls back to tier 2', async () => {
+      await fs.writeFile(path.join(sb.dir, 'a.txt'), 'const a = 1;\nconst b = 2;\n');
+      await readTool.execute({ path: 'a.txt' }, sb.ctx, { signal: newSignal() });
+      const out = await editTool.execute(
+        // Model hallucinated trailing spaces after the semicolon.
+        { path: 'a.txt', old_string: 'const a = 1;   ', new_string: 'const a = 42;' },
+        sb.ctx,
+        { signal: newSignal() },
+      );
+      expect(out.matched_by).toBe('trailing-whitespace');
+      expect(out.note).toMatch(/did not match exactly/);
+      expect(out.note).toMatch(/confidence: high/);
+      const content = await fs.readFile(path.join(sb.dir, 'a.txt'), 'utf8');
+      expect(content).toBe('const a = 42;\nconst b = 2;\n');
+    });
+
+    it('indentation drift falls back to tier 3 and re-indents the replacement', async () => {
+      const file = 'function f() {\n    if (cond) {\n        doThing();\n    }\n}\n';
+      await fs.writeFile(path.join(sb.dir, 'a.ts'), file);
+      await readTool.execute({ path: 'a.ts' }, sb.ctx, { signal: newSignal() });
+      const out = await editTool.execute(
+        {
+          path: 'a.ts',
+          // Model reproduced the block one indent level too shallow.
+          old_string: 'if (cond) {\n    doThing();\n}',
+          new_string: 'if (cond) {\n    doOther();\n}',
+        },
+        sb.ctx,
+        { signal: newSignal() },
+      );
+      expect(out.matched_by).toBe('whitespace-normalized');
+      expect(out.note).toMatch(/re-indented/);
+      const content = await fs.readFile(path.join(sb.dir, 'a.ts'), 'utf8');
+      expect(content).toBe('function f() {\n    if (cond) {\n        doOther();\n    }\n}\n');
+    });
+
+    it('block-anchor fuzzy match repairs a slightly-wrong interior line', async () => {
+      const file =
+        'export function greet(name) {\n' +
+        "  const message = 'hello there, ' + name;\n" +
+        '  return message.toUpperCase();\n' +
+        '}\n';
+      await fs.writeFile(path.join(sb.dir, 'a.js'), file);
+      await readTool.execute({ path: 'a.js' }, sb.ctx, { signal: newSignal() });
+      const out = await editTool.execute(
+        {
+          path: 'a.js',
+          // Interior line hallucinated: "hello there," became "hello  there,".
+          old_string:
+            'export function greet(name) {\n' +
+            "  const message = 'hello  there, ' + name;\n" +
+            '  return message.toUpperCase();\n' +
+            '}',
+          new_string:
+            'export function greet(name) {\n' +
+            "  const message = 'hi, ' + name;\n" +
+            '  return message.toUpperCase();\n' +
+            '}',
+        },
+        sb.ctx,
+        { signal: newSignal() },
+      );
+      expect(out.matched_by).toBe('fuzzy');
+      expect(out.note).toMatch(/confidence: low/);
+      expect(out.note).toMatch(/similarity/);
+      const content = await fs.readFile(path.join(sb.dir, 'a.js'), 'utf8');
+      expect(content).toContain("'hi, ' + name");
+    });
+
+    it('fuzzy match with two indistinguishable candidates is rejected', async () => {
+      const block = 'function a() {\n  return compute(1, 2, 3);\n}\n';
+      await fs.writeFile(path.join(sb.dir, 'a.js'), block + '\n' + block);
+      await readTool.execute({ path: 'a.js' }, sb.ctx, { signal: newSignal() });
+      await expect(
+        editTool.execute(
+          {
+            path: 'a.js',
+            // Interior differs slightly from BOTH copies → equal scores.
+            old_string: 'function a() {\n  return compute(1, 2, 4);\n}',
+            new_string: 'function a() {\n  return 0;\n}',
+          },
+          sb.ctx,
+          { signal: newSignal() },
+        ),
+      ).rejects.toThrow(/scored too close/);
+    });
+
+    it('replace_all is refused for indent-insensitive fallback matches', async () => {
+      await fs.writeFile(
+        path.join(sb.dir, 'a.ts'),
+        'function g() {\n    doThing(alpha, beta);\n    done();\n}\n',
+      );
+      await readTool.execute({ path: 'a.ts' }, sb.ctx, { signal: newSignal() });
+      await expect(
+        editTool.execute(
+          {
+            path: 'a.ts',
+            // Two-line needle at the wrong indent level: not a substring, so
+            // it can only match via the indent-insensitive tier.
+            old_string: 'doThing(alpha, beta);\ndone();',
+            new_string: 'doOther(alpha, beta);\ndone();',
+            replace_all: true,
+          },
+          sb.ctx,
+          { signal: newSignal() },
+        ),
+      ).rejects.toThrow(/replace_all requires an exact/);
+    });
+
+    it('replace_all works at the trailing-whitespace tier', async () => {
+      await fs.writeFile(path.join(sb.dir, 'a.txt'), 'foo bar\nkeep\nfoo bar\n');
+      await readTool.execute({ path: 'a.txt' }, sb.ctx, { signal: newSignal() });
+      const out = await editTool.execute(
+        { path: 'a.txt', old_string: 'foo bar   ', new_string: 'baz', replace_all: true },
+        sb.ctx,
+        { signal: newSignal() },
+      );
+      expect(out.matched_by).toBe('trailing-whitespace');
+      expect(out.replacements).toBe(2);
+      const content = await fs.readFile(path.join(sb.dir, 'a.txt'), 'utf8');
+      expect(content).toBe('baz\nkeep\nbaz\n');
+    });
+
+    it('ambiguous tier-2 match without replace_all reports lines and tier', async () => {
+      await fs.writeFile(path.join(sb.dir, 'a.txt'), 'same line\nother\nsame line\n');
+      await readTool.execute({ path: 'a.txt' }, sb.ctx, { signal: newSignal() });
+      await expect(
+        editTool.execute({ path: 'a.txt', old_string: 'same line  ', new_string: 'x' }, sb.ctx, {
+          signal: newSignal(),
+        }),
+      ).rejects.toThrow(/matched 2 times .*lines: 1, 3.*whitespace/s);
+    });
+
+    it('too-short needles never fall through to indent-insensitive tiers', async () => {
+      await fs.writeFile(path.join(sb.dir, 'a.ts'), 'if (x) {\n  y();\n}\n');
+      await readTool.execute({ path: 'a.ts' }, sb.ctx, { signal: newSignal() });
+      await expect(
+        // "  }" would trim-match the closing brace — must NOT be allowed.
+        editTool.execute({ path: 'a.ts', old_string: '  }', new_string: '  };' }, sb.ctx, {
+          signal: newSignal(),
+        }),
+      ).rejects.toThrow(/no match/);
+    });
+
+    it('no-match error includes a snippet of the nearest candidate', async () => {
+      await fs.writeFile(
+        path.join(sb.dir, 'a.ts'),
+        'const alpha = computeValue(input, options);\n',
+      );
+      await readTool.execute({ path: 'a.ts' }, sb.ctx, { signal: newSignal() });
+      await expect(
+        editTool.execute(
+          {
+            path: 'a.ts',
+            old_string: 'const alpha = computeValue(input, settings);',
+            new_string: 'x',
+          },
+          sb.ctx,
+          { signal: newSignal() },
+        ),
+      ).rejects.toThrow(/Nearest match near line 1:[\s\S]*computeValue\(input, options\)/);
+    });
+  });
+
+  describe('post-edit syntax check', () => {
+    it('reports parse errors introduced by the edit on a .ts file', async () => {
+      await fs.writeFile(path.join(sb.dir, 'a.ts'), 'const x = 1;\n');
+      await readTool.execute({ path: 'a.ts' }, sb.ctx, { signal: newSignal() });
+      const out = await editTool.execute(
+        { path: 'a.ts', old_string: 'const x = 1;', new_string: 'const x = ;' },
+        sb.ctx,
+        { signal: newSignal() },
+      );
+      expect(out.syntax_errors).toBeDefined();
+      expect(out.syntax_errors?.length).toBeGreaterThan(0);
+      expect(out.note).toMatch(/introduced .* parse error/);
+      // The edit is still applied — feedback, not rollback.
+      expect(await fs.readFile(path.join(sb.dir, 'a.ts'), 'utf8')).toBe('const x = ;\n');
+    });
+
+    it('clean edits carry no syntax_errors', async () => {
+      await fs.writeFile(path.join(sb.dir, 'a.ts'), 'const x = 1;\n');
+      await readTool.execute({ path: 'a.ts' }, sb.ctx, { signal: newSignal() });
+      const out = await editTool.execute(
+        { path: 'a.ts', old_string: 'const x = 1;', new_string: 'const x = 2;' },
+        sb.ctx,
+        { signal: newSignal() },
+      );
+      expect(out.syntax_errors).toBeUndefined();
+    });
+
+    it('flags pre-existing parse errors as pre-existing', async () => {
+      await fs.writeFile(path.join(sb.dir, 'a.ts'), 'const broken = ;\nconst y = 1;\n');
+      await readTool.execute({ path: 'a.ts' }, sb.ctx, { signal: newSignal() });
+      const out = await editTool.execute(
+        { path: 'a.ts', old_string: 'const y = 1;', new_string: 'const y = 2;' },
+        sb.ctx,
+        { signal: newSignal() },
+      );
+      expect(out.syntax_errors).toBeDefined();
+      expect(out.note).toMatch(/pre-date/);
+    });
+
+    it('non-code files are not syntax-checked', async () => {
+      await fs.writeFile(path.join(sb.dir, 'a.txt'), 'not { valid json or ts\n');
+      await readTool.execute({ path: 'a.txt' }, sb.ctx, { signal: newSignal() });
+      const out = await editTool.execute(
+        { path: 'a.txt', old_string: 'valid', new_string: 'VALID' },
+        sb.ctx,
+        { signal: newSignal() },
+      );
+      expect(out.syntax_errors).toBeUndefined();
     });
   });
 });

--- a/packages/tools/tests/fixtures.ts
+++ b/packages/tools/tests/fixtures.ts
@@ -18,6 +18,7 @@ export async function mkSandbox(): Promise<Sandbox> {
     projectRoot: dir,
     readFiles: new Set<string>(),
     fileMtimes: new Map<string, number>(),
+    fileHashes: new Map<string, string>(),
     writtenFiles: new Set<string>(),
     sideEffects: [],
     hasRead(p: string) {
@@ -29,7 +30,18 @@ export async function mkSandbox(): Promise<Sandbox> {
     lastReadMtime(p: string) {
       return this.fileMtimes.get(p);
     },
-    recordRead(p: string, m: number, source: 'user' | 'write' = 'user') {
+    lastReadHash(p: string) {
+      return (this as { fileHashes: Map<string, string> }).fileHashes.get(p);
+    },
+    recordRead(p: string, m: number, source: 'user' | 'write' = 'user', contentHash?: string) {
+      // Mirrors the real Context semantics: a hash-less record with a new
+      // mtime drops the stored hash (content may have changed under us).
+      const hashes = (this as { fileHashes: Map<string, string> }).fileHashes;
+      if (contentHash !== undefined) {
+        hashes.set(p, contentHash);
+      } else if (this.fileMtimes.get(p) !== m) {
+        hashes.delete(p);
+      }
       this.fileMtimes.set(p, m);
       if (source === 'write') {
         (this as { writtenFiles: Set<string> }).writtenFiles.add(p);
@@ -43,6 +55,7 @@ export async function mkSandbox(): Promise<Sandbox> {
     clearFileTracking() {
       this.readFiles.clear();
       this.fileMtimes.clear();
+      (this as { fileHashes: Map<string, string> }).fileHashes.clear();
       (this as { sideEffects: unknown[] }).sideEffects = [];
     },
     todos,

--- a/packages/tools/tests/replace.test.ts
+++ b/packages/tools/tests/replace.test.ts
@@ -195,3 +195,58 @@ describe('globNative walk exception paths', () => {
     expect(result.total_replacements).toBe(2);
   });
 });
+
+describe('replace change tracking', () => {
+  it('records mtime+hash (write-tagged) and a session file change on apply', async () => {
+    const filePath = path.join(tmpDir, 'tracked.txt');
+    await fs.writeFile(filePath, 'hello world', 'utf8');
+
+    const recorded: Array<{ path: string; source: string; hash?: string }> = [];
+    const changes: Array<{ path: string; action: string; before: unknown; after: unknown }> = [];
+    const ctx = {
+      cwd: tmpDir,
+      tools: [],
+      projectRoot: tmpDir,
+      recordRead(p: string, _m: number, source = 'user', hash?: string) {
+        recorded.push({ path: p, source, hash });
+      },
+      session: {
+        recordFileChange(c: { path: string; action: string; before: unknown; after: unknown }) {
+          changes.push(c);
+        },
+      },
+    } as any;
+
+    const result = await replaceTool.execute(
+      { pattern: 'hello', replacement: 'goodbye', files: filePath, dry_run: false },
+      ctx,
+    );
+    expect(result.files_modified).toBe(1);
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]?.source).toBe('write');
+    expect(recorded[0]?.hash).toMatch(/^[0-9a-f]{64}$/);
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.action).toBe('modified');
+    expect(changes[0]?.before).toBe('hello world');
+    expect(changes[0]?.after).toBe('goodbye world');
+  });
+
+  it('dry_run records nothing', async () => {
+    const filePath = path.join(tmpDir, 'untracked.txt');
+    await fs.writeFile(filePath, 'hello world', 'utf8');
+    const recorded: unknown[] = [];
+    const ctx = {
+      cwd: tmpDir,
+      tools: [],
+      projectRoot: tmpDir,
+      recordRead(...args: unknown[]) {
+        recorded.push(args);
+      },
+      session: { recordFileChange: (c: unknown) => recorded.push(c) },
+    } as any;
+    await replaceTool.execute({ pattern: 'hello', replacement: 'goodbye', files: filePath }, ctx);
+    expect(recorded).toHaveLength(0);
+  });
+});

--- a/packages/tools/tests/write.test.ts
+++ b/packages/tools/tests/write.test.ts
@@ -36,6 +36,42 @@ describe('write tool', () => {
     expect(await fs.readFile(path.join(sb.dir, 'new.txt'), 'utf8')).toBe('hello');
   });
 
+  it('reports syntax errors in written TS content (file stays on disk)', async () => {
+    const out = await writeTool.execute({ path: 'broken.ts', content: 'const x = ;\n' }, sb.ctx, {
+      signal: newSignal(),
+    });
+    expect(out.syntax_errors).toBeDefined();
+    expect(out.syntax_errors?.length).toBeGreaterThan(0);
+    expect(out.note).toMatch(/parse error/);
+    expect(await fs.readFile(path.join(sb.dir, 'broken.ts'), 'utf8')).toBe('const x = ;\n');
+  });
+
+  it('plain .json is strict but tsconfig-style JSONC accepts comments/trailing commas', async () => {
+    // A trailing comma in plain .json is a real error the model must fix.
+    const bad = await writeTool.execute({ path: 'bad.json', content: '{ "a": 1, }' }, sb.ctx, {
+      signal: newSignal(),
+    });
+    expect(bad.syntax_errors).toBeDefined();
+
+    // The same content in tsconfig.json is valid JSONC — must NOT be flagged.
+    const jsonc = await writeTool.execute(
+      { path: 'tsconfig.json', content: '{\n  // comment\n  "a": 1,\n}' },
+      sb.ctx,
+      { signal: newSignal() },
+    );
+    expect(jsonc.syntax_errors).toBeUndefined();
+  });
+
+  it('clean TS content carries no syntax_errors', async () => {
+    const out = await writeTool.execute(
+      { path: 'ok.ts', content: 'export const x = 1;\n' },
+      sb.ctx,
+      { signal: newSignal() },
+    );
+    expect(out.syntax_errors).toBeUndefined();
+    expect(out.note).toBeUndefined();
+  });
+
   it('aborted signal prevents the write from touching the filesystem', async () => {
     const ctrl = new AbortController();
     ctrl.abort();


### PR DESCRIPTION
## Summary

Hardens the `edit` pipeline along three axes (design report: exact-match str_replace alone is not enough — models hallucinate whitespace, edit against stale reads, and leave broken files):

### 1. Matching ladder (`packages/tools/src/_edit-match.ts`)
- `exact` → `trailing-whitespace` (per-line trimEnd) → `whitespace-normalized` (per-line trim, replacement re-indented to the file's actual indentation) → `fuzzy` (block anchors trim-exact, interior Levenshtein ≥ 0.9, single candidate with a clear margin over the runner-up).
- Guards: indent-insensitive tiers require ≥ 16 trimmed chars (`}` can't match everywhere); `replace_all` restricted to tiers 1–2; ambiguous fuzzy candidates are rejected with line numbers.
- Output gains `matched_by` + a confidence note; no-match errors include a nearest-candidate snippet so the model self-corrects in the same turn without a re-read.

### 2. Content-hash staleness arbitration
- `Context.fileHashes` + `recordRead(..., contentHash?)` + `lastReadHash()`; `read`/`write`/`edit`/`replace`/`patch` record sha-256 of the content they saw.
- `edit` uses hash equality as the authoritative stale-read check: closes the 2 s win32 mtime tolerance window (external write right after a read is now caught) and stops blocking on content-preserving mtime bumps (`touch`).
- Hash-less `recordRead` with a different mtime drops the stored hash → clean fallback to the mtime heuristic for duck-typed contexts.

### 3. Post-edit syntax check (`packages/tools/src/_syntax-check.ts`)
- TS/JS via `ts.createSourceFile` parse diagnostics (lazy import; `typescript` is already a tools dependency), strict `JSON.parse` for plain `.json`, JSONC leniency for `tsconfig*`/`jsconfig*`/`*.jsonc`/`.vscode`.
- Non-blocking: the edit stays on disk; `syntax_errors` (capped at 5, pre-existing errors flagged separately) come back in the same turn.

### 4. Consistency fixes
- `replace` and `patch` now do the same bookkeeping as `edit` (`recordRead(..., 'write', hash)` + `session.recordFileChange`): session rewind sees their changes, and a follow-up `edit` no longer trips the stale-read guard on our own write.
- `tool-output-serializer` renders `matched_by` (only when non-exact) and a `syntax_errors:` section after the diff.

## Testing
- `pnpm --filter @wrongstack/core typecheck` / `--filter @wrongstack/tools typecheck` clean.
- Full tools suite: 1614 passed. Targeted files (edit/edit-match/write/replace/read/patch/context/serializer): 203 passed.
- Note: `hotspot-guardrails.test.ts` fails on main independently of this PR (pre-launch split from #250 didn't update the slash-command import baseline).