### PR TITLE
fix: resolve 9 code review findings across core packages

### DIFF
--- a/packages/core/src/core/agent.ts
+++ b/packages/core/src/core/agent.ts
@@ -234,14 +234,7 @@ export class Agent {
       span?.setAttribute('agent.status', result.status);
       span?.setAttribute('agent.iterations', result.iterations);
       await this.extensions.runAfterRun(this.ctx, result);
-      this.events.emit('agent.run.completed', {
-        sessionId,
-        ctx: this.ctx,
-        status: result.status,
-        iterations: result.iterations,
-        at: new Date().toISOString(),
-        durationMs: Date.now() - runStartedAt,
-      });
+      this._emitRunCompleted(result, sessionId, runStartedAt);
       return result;
     } catch (err) {
       const wse = err instanceof AgentError ? err : toWrongStackError(err);
@@ -262,6 +255,8 @@ export class Agent {
         error: wse,
         abortReason: signal.aborted ? signalAbortReason(signal) : undefined,
       };
+      // runAfterRun must fire before agent.run.error so extensions see the
+      // failed result before the error event is emitted to other listeners.
       await this.extensions.runAfterRun(this.ctx, result);
       if (result.status === 'failed') {
         this.events.emit('agent.run.error', {
@@ -272,20 +267,33 @@ export class Agent {
           durationMs: Date.now() - runStartedAt,
         });
       }
-      this.events.emit('agent.run.completed', {
-        sessionId,
-        ctx: this.ctx,
-        status: result.status,
-        iterations: result.iterations,
-        at: new Date().toISOString(),
-        durationMs: Date.now() - runStartedAt,
-      });
+      this._emitRunCompleted(result, sessionId, runStartedAt);
       return result;
     } finally {
       this._runInProgress = false;
       span?.end();
       await controller.dispose();
     }
+  }
+
+  /**
+   * Emit the terminal `agent.run.completed` event. Extracted to eliminate
+   * duplication between the try and catch blocks — adding a new field to
+   * the event payload only needs one edit.
+   */
+  private _emitRunCompleted(
+    result: RunResult,
+    sessionId: string,
+    runStartedAt: number,
+  ): void {
+    this.events.emit('agent.run.completed', {
+      sessionId,
+      ctx: this.ctx,
+      status: result.status,
+      iterations: result.iterations,
+      at: new Date().toISOString(),
+      durationMs: Date.now() - runStartedAt,
+    });
   }
 
   // ── Tool + response execution handled by AgentToolHandler / AgentResponseHandler ──

--- a/packages/core/src/security/secret-scrubber.ts
+++ b/packages/core/src/security/secret-scrubber.ts
@@ -188,6 +188,11 @@ function hasCredentialAnchors(text: string): boolean {
     // with a recognisable prefix (sk-, ghp_, etc.), so we anchor on common
     // key names. The `"` prefix avoids matching prose that happens to mention
     // these words — JSON serialisation always quotes string keys.
+    // NOTE: `high_entropy_env` (below) only captures alphanumeric + `_/+=-`
+    // value chars. This deliberately excludes `!@#$%^&*()` etc to keep the
+    // false-positive rate low — generated secrets containing those characters
+    // may not be redacted by this pattern. The other 16 patterns still catch
+    // them if they have recognisable prefixes (e.g. `sk-`, `Bearer `, etc.).
     text.includes('"apiKey"') ||
     text.includes('"api_key"') ||
     text.includes('"token"') ||
@@ -251,8 +256,9 @@ export class DefaultSecretScrubber implements SecretScrubber {
   }
 
   private scrubOne(text: string): string {
-    // Redundant guard: if we reached scrubOne via the chunked path, the
-    // chunk may have been small enough to anchor-skip independently.
+    // The caller (scrub) already ran hasCredentialAnchors on the full
+    // text. For the chunked path, the chunk may have been small enough
+    // to anchor-skip independently — the re-check here is cheap.
     if (!hasCredentialAnchors(text)) return text;
 
     // Pass 1: combined single-pass regex for all simple patterns. Each

--- a/packages/core/src/utils/lru-cache.ts
+++ b/packages/core/src/utils/lru-cache.ts
@@ -26,22 +26,21 @@ export class LruCache<K, V> {
   }
 
   get(key: K): V | undefined {
+    if (!this.store.has(key)) return undefined;
     const value = this.store.get(key);
-    if (value === undefined) return undefined;
     // Re-insert so this key becomes the most-recently-used (moves to end).
     this.store.delete(key);
-    this.store.set(key, value);
+    this.store.set(key, value as V);
     return value;
   }
 
   set(key: K, value: V): void {
     if (this.store.has(key)) this.store.delete(key);
     this.store.set(key, value);
-    // Evict the oldest (least-recently-used) entry while over capacity.
-    while (this.store.size > this.capacity) {
+    // Evict the oldest (least-recently-used) entry if over capacity.
+    if (this.store.size > this.capacity) {
       const oldest = this.store.keys().next();
-      if (oldest.done) break;
-      this.store.delete(oldest.value);
+      if (!oldest.done) this.store.delete(oldest.value);
     }
   }
 

--- a/packages/core/src/utils/safe-json.ts
+++ b/packages/core/src/utils/safe-json.ts
@@ -7,7 +7,7 @@ export interface SafeParseResult<T> {
 }
 
 export function safeParse<T = unknown>(input: string, maxBytes = 5_000_000): SafeParseResult<T> {
-  if (input.length > maxBytes) {
+  if (Buffer.byteLength(input, 'utf8') > maxBytes) {
     return { ok: false, error: `Input exceeds limit (${maxBytes} bytes)` };
   }
   try {
@@ -29,7 +29,9 @@ export function safeStringify(value: unknown, pretty = false): string {
     }
     if (typeof v === 'object' && v !== null) {
       if (seen.has(v as object)) return '[Circular]';
-      seen.add(v as object);
+      // WeakSet.add can throw for non-extensible objects or proxies —
+      // skip cycle tracking for that value rather than failing entirely.
+      try { seen.add(v as object); } catch { /* skip cycle guard */ }
     }
     return v;
   };
@@ -48,9 +50,10 @@ export function safeStringify(value: unknown, pretty = false): string {
  * that are common in provider output.
  *
  * Returns the sanitized string if it parses successfully as JSON,
- * or `null` if the input cannot be made valid. Callers use this to
- * decide whether to proceed with the parsed result or fall back to
- * raw handling.
+ * or `null` if the input cannot be made valid. Callers that get
+ * `null` should try `repairJson()` (from json-repair.ts) as a
+ * second pass — sanitisation handles comments/commas/control-chars,
+ * repair handles structure. If both fail, fall back to raw handling.
  */
 export function sanitizeJsonString(s: string): string | null {
   let out = s.trim();
@@ -60,6 +63,12 @@ export function sanitizeJsonString(s: string): string | null {
   // are preserved because we only strip // when preceded by a char that
   // strongly suggests we're not in a string (quote count modulo 2 is even).
   out = stripSingleLineComments(out);
+
+  // Stage 1b: strip block comments (/* ... */) that appear outside of
+  // string values. LLMs increasingly emit JSON5, and block comments are
+  // the second most common non-standard extension after trailing commas.
+  // Uses the same inString heuristic as single-line comments.
+  out = stripBlockComments(out);
 
   // Stage 2: strip trailing commas before } or ]
   out = out.replace(/,(\s*[}\]])/g, '$1');
@@ -162,6 +171,36 @@ function stripSingleLineComments(s: string): string {
     } else if (c === '/' && s.charAt(i + 1) === '/' && !inString) {
       // skip to end of line
       while (i < s.length && s.charAt(i) !== '\n') i++;
+    } else {
+      chars.push(c);
+    }
+    i++;
+  }
+  return chars.join('');
+}
+
+function stripBlockComments(s: string): string {
+  let inString = false;
+  const chars: string[] = [];
+  let i = 0;
+  while (i < s.length) {
+    const c = s.charAt(i);
+    if (c === '"' && (i === 0 || s.charAt(i - 1) !== '\\')) {
+      inString = !inString;
+      chars.push(c);
+    } else if (c === '/' && s.charAt(i + 1) === '*' && !inString) {
+      // skip to after the closing */
+      i += 2; // skip /*
+      while (i < s.length - 1) {
+        if (s.charAt(i) === '*' && s.charAt(i + 1) === '/') {
+          i += 2; // skip */
+          break;
+        }
+        i++;
+      }
+      // If we hit end-of-string without closing */, the comment is
+      // unterminated — consume everything (safer to over-strip than
+      // leak comment text into parsed output).
     } else {
       chars.push(c);
     }

--- a/packages/core/tests/utils/lru-cache.test.ts
+++ b/packages/core/tests/utils/lru-cache.test.ts
@@ -102,4 +102,28 @@ describe('LruCache — minimal LRU eviction (P3 #17)', () => {
     expect(cache.get(0)).toBeUndefined();
     expect(cache.get(100)).toBeUndefined();
   });
+
+  it('handles undefined as a stored value', () => {
+    // get() must distinguish "key not found" from "value is undefined"
+    const cache = new LruCache<string, number | undefined>(3);
+    cache.set('x', undefined);
+    expect(cache.has('x')).toBe(true);
+    expect(cache.get('x')).toBeUndefined();
+    // LRU semantics: reading 'x' promotes it, so 'a' (oldest) gets evicted
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.get('x'); // promote x to MRU
+    cache.set('c', 3); // evicts the oldest (a), not x
+    expect(cache.has('a')).toBe(false);
+    expect(cache.has('x')).toBe(true);
+    expect(cache.has('b')).toBe(true);
+    expect(cache.has('c')).toBe(true);
+  });
+
+  it('returns undefined for missing keys even after storing undefined', () => {
+    const cache = new LruCache<string, number | undefined>(5);
+    cache.set('x', undefined);
+    expect(cache.get('missing')).toBeUndefined();
+    expect(cache.has('x')).toBe(true); // miss didn't disturb it
+  });
 });

--- a/packages/core/tests/utils/safe-json.test.ts
+++ b/packages/core/tests/utils/safe-json.test.ts
@@ -21,6 +21,16 @@ describe('safe-json', () => {
     const r = safeParse('x'.repeat(100), 10);
     expect(r.ok).toBe(false);
   });
+  it('safeParse maxBytes uses byte length, not char length', () => {
+    // '€' is 3 bytes in UTF-8, so 4 of them = 12 bytes > 10-byte limit
+    const r = safeParse('€€€€', 10);
+    expect(r.ok).toBe(false);
+  });
+  it('safeParse allows input when byte length is within limit', () => {
+    // 4 chars * 1 byte each = 4 bytes < 10-byte limit
+    const r = safeParse('"abc"', 10);
+    expect(r.ok).toBe(true);
+  });
   it('safeStringify handles circular refs', () => {
     const obj: Record<string, unknown> = { a: 1 };
     obj.self = obj;
@@ -34,6 +44,11 @@ describe('safe-json', () => {
   it('safeStringify handles Error', () => {
     const out = safeStringify({ err: new Error('boom') });
     expect(out).toContain('boom');
+  });
+  it('safeStringify survives non-extensible objects', () => {
+    const obj = Object.preventExtensions({ a: 1 });
+    const out = safeStringify(obj);
+    expect(JSON.parse(out)).toEqual({ a: 1 });
   });
   it('sanitizeJsonString strips trailing commas', () => {
     expect(sanitizeJsonString('{"a":1,}')).toBe('{"a":1}');
@@ -59,6 +74,47 @@ describe('safe-json', () => {
     const raw = '{"code":"line1\\nline2"}';
     expect(JSON.parse(sanitizeJsonString(raw)!)).toEqual({ code: 'line1\nline2' });
   });
+  it('sanitizeJsonString strips single-line JSON5 comments', () => {
+    const raw = `{
+  // this is a comment
+  "a": 1,
+  "b": 2 // trailing comment
+}`;
+    const fixed = sanitizeJsonString(raw);
+    expect(fixed).not.toBe(null);
+    expect(JSON.parse(fixed!)).toEqual({ a: 1, b: 2 });
+  });
+
+  it('sanitizeJsonString strips block comments outside strings', () => {
+    const raw = `{
+  /* multi-line
+     block comment */
+  "a": 1,
+  /* another one */ "b": 2
+}`;
+    const fixed = sanitizeJsonString(raw);
+    expect(fixed).not.toBe(null);
+    expect(JSON.parse(fixed!)).toEqual({ a: 1, b: 2 });
+  });
+
+  it('sanitizeJsonString does not strip // or /* inside string values', () => {
+    const raw = '{"url":"https://example.com","code":"/* not a comment */"}';
+    const fixed = sanitizeJsonString(raw);
+    expect(fixed).not.toBe(null);
+    expect(JSON.parse(fixed!)).toEqual({
+      url: 'https://example.com',
+      code: '/* not a comment */',
+    });
+  });
+
+  it('sanitizeJsonString handles unterminated block comment gracefully', () => {
+    // Unterminated /* ... consumes rest — over-stripping is safer than leaking
+    const raw = '{"a":1,/* unterminated\n"b":2}';
+    const fixed = sanitizeJsonString(raw);
+    // With /* consumed to end, "b":2 never appears → can't be valid JSON
+    expect(fixed).toBe(null);
+  });
+
   it('sanitizeJsonString does not touch insignificant whitespace outside strings', () => {
     const raw = '{\n  "a": 1,\n  "b": 2\n}';
     expect(JSON.parse(sanitizeJsonString(raw)!)).toEqual({ a: 1, b: 2 });


### PR DESCRIPTION
## Summary

Fixes 9 issues identified during a comprehensive code review of the core packages (0 critical, 0 high, 7 medium, 2 low).

### Changes

**packages/core/src/utils/lru-cache.ts**
- `get()`: use `has()` before `get()` to distinguish stored `undefined` from missing key
- `set()`: replace `while` with `if` for eviction — private store can never exceed size+1

**packages/core/src/utils/safe-json.ts**
- `safeParse`: `Buffer.byteLength(input, 'utf8')` instead of `input.length` for `maxBytes`
- `safeStringify`: `try/catch` around `WeakSet.add` to survive non-extensible objects and proxies
- `sanitizeJsonString`: new `stripBlockComments()` function for JSON5 `/* */` comments
- `sanitizeJsonString`: JSDoc documents `repairJson()` as recommended fallback

**packages/core/src/core/agent.ts**
- Extract `_emitRunCompleted()` private method — `agent.run.completed` event payload is now defined once instead of duplicated in try/catch blocks

**packages/core/src/security/secret-scrubber.ts**
- Document `high_entropy_env` regex char-class limitation (alphanumeric-only, 16 other patterns cover the gap)
- Clarify `scrubOne` `hasCredentialAnchors` comment (caller already pre-scans; chunk re-check is intentional)

**packages/core/tests/utils/lru-cache.test.ts** (+24 lines)
- `undefined` value stored in cache, retrieved, participates in LRU eviction
- Missing key returns `undefined` without disturbing stored-`undefined` entry

**packages/core/tests/utils/safe-json.test.ts** (+56 lines)
- `safeParse` byte-length vs char-length with multi-byte Unicode
- `safeStringify` survives `Object.preventExtensions`
- JSON5 block comments: multi-line, inline, inside string values, unterminated

### Verification
- Biome format: 0 errors, 0 warnings
- All existing tests are compatible (no breaking API changes)