### PR TITLE
fix(core): stop persisting empty assistant turns and repair them on replay (#271)

### DIFF
--- a/packages/core/src/core/agent-response.ts
+++ b/packages/core/src/core/agent-response.ts
@@ -166,6 +166,12 @@ export function createAgentResponseHandler(a: AgentInternals): AgentResponseHand
     });
     a.ctx.tokenCounter.account(res.usage, req.model);
 
+    // Issue #271: never append or persist a semantically empty assistant
+    // response (e.g. a stream interrupted before the first meaningful delta,
+    // which the response builders represent as a single empty text block).
+    // Strict providers reject empty assistant turns on the next request, and
+    // once journaled, the malformed turn survived every repair path. Partial
+    // text, tool calls, and thinking content remain meaningful and are kept.
     if (hasMeaningfulContent(res.content)) {
       a.ctx.state.appendMessage({ role: 'assistant', content: res.content });
       // If the assistant emitted tool_use blocks, mark the message adjacency
@@ -196,7 +202,11 @@ export function createAgentResponseHandler(a: AgentInternals): AgentResponseHand
         (a.logger.debug ?? a.logger.warn)?.(`LLM response flush failed: ${toErrorMessage(err)}`);
       }
     } else {
-      a.logger.warn('Skipping empty assistant response; nothing was added to session history.');
+      a.logger.warn('Empty assistant response — not appended to context or session', {
+        model: req.model,
+        stopReason: res.stopReason,
+        aborted: a.ctx.signal.aborted,
+      });
     }
 
     if (a.ctx.signal.aborted) {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -53,6 +53,7 @@ export {
   hasMeaningfulContent,
   type MessageRepairReport,
   type MessageRepairResult,
+  hasMeaningfulContent,
   repairToolUseAdjacency,
 } from './message-invariants.js';
 export * from './newline-normalize.js';

--- a/packages/core/src/utils/message-invariants.ts
+++ b/packages/core/src/utils/message-invariants.ts
@@ -140,6 +140,36 @@ function mapContent(msg: Message, fn: (blocks: ContentBlock[]) => ContentBlock[]
   return { ...msg, content: next };
 }
 
+/**
+ * True when a message content payload carries meaningful information for
+ * the provider: non-whitespace text, a tool call/result, thinking with
+ * text or a signature, or any other block type.
+ *
+ * False for empty strings/arrays and for arrays whose only blocks are
+ * empty or whitespace-only text — the shape persisted when a stream is
+ * interrupted before the first meaningful delta (issue #271). Strict
+ * providers reject such assistant turns, so repair and replay paths must
+ * treat them as empty.
+ */
+export function hasMeaningfulContent(content: Message['content']): boolean {
+  if (typeof content === 'string') return content.trim().length > 0;
+  for (const block of content) {
+    if (block.type === 'text') {
+      if (block.text.trim().length > 0) return true;
+      continue;
+    }
+    if (block.type === 'thinking') {
+      // Signature-only thinking blocks are valid and required for replay;
+      // blocks with neither text nor signature are provider-rejected noise.
+      if (block.thinking.trim().length > 0 || block.signature) return true;
+      continue;
+    }
+    // tool_use, tool_result, image, redacted_thinking, … — always meaningful.
+    return true;
+  }
+  return false;
+}
+
 function isEmptyMessage(msg: Message): boolean {
   return !hasMeaningfulContent(msg.content);
 }

--- a/packages/core/tests/core/agent-response-empty.test.ts
+++ b/packages/core/tests/core/agent-response-empty.test.ts
@@ -1,94 +1,145 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { AgentInternals } from '../../src/core/agent-internals.js';
 import { createAgentResponseHandler } from '../../src/core/agent-response.js';
+import type { AgentInternals } from '../../src/core/agent-internals.js';
+import type { Message } from '../../src/types/messages.js';
 import type { Request, Response } from '../../src/types/provider.js';
 
-function createHarness() {
-  const appendMessage = vi.fn();
-  const appendSession = vi.fn(async () => undefined);
-  const flushSession = vi.fn(async () => undefined);
-  const flushConversationJournal = vi.fn(async () => undefined);
-  const warn = vi.fn();
+/**
+ * Issue #271 — a stream interrupted before the first meaningful delta must
+ * not be appended to the conversation context or persisted to the session
+ * journal. Strict providers reject empty assistant turns on the next
+ * request, and journaled empty turns survived every repair path.
+ */
 
-  const internals = {
+interface MockInternals {
+  a: AgentInternals;
+  messages: Message[];
+  appendedEvents: Array<Record<string, unknown>>;
+  flushJournal: ReturnType<typeof vi.fn>;
+  sessionFlush: ReturnType<typeof vi.fn>;
+}
+
+function makeInternals(opts: { aborted?: boolean } = {}): MockInternals {
+  const messages: Message[] = [];
+  const appendedEvents: Array<Record<string, unknown>> = [];
+  const flushJournal = vi.fn(async () => {});
+  const sessionFlush = vi.fn(async () => {});
+  const controller = new AbortController();
+  if (opts.aborted) controller.abort();
+
+  const ctx = {
+    session: {
+      id: 'sess-271',
+      append: vi.fn(async (ev: Record<string, unknown>) => {
+        appendedEvents.push(ev);
+      }),
+      flush: sessionFlush,
+    },
+    state: {
+      appendMessage: vi.fn((msg: Message) => {
+        messages.push(msg);
+      }),
+    },
+    tokenCounter: { account: vi.fn() },
+    signal: controller.signal,
+    toolAdjacencyDirty: false,
+    provider: { capabilities: { streaming: true } },
+    flushConversationJournal: flushJournal,
+  };
+
+  const a = {
+    ctx,
     events: { emit: vi.fn() },
     pipelines: {
-      response: { run: vi.fn(async (response: Response) => response) },
+      response: { run: vi.fn(async (res: Response) => res) },
       assistantOutput: { run: vi.fn(async (block: unknown) => block) },
     },
-    ctx: {
-      session: {
-        id: 'session-1',
-        append: appendSession,
-        flush: flushSession,
-      },
-      state: { appendMessage },
-      tokenCounter: { account: vi.fn() },
-      provider: { capabilities: { streaming: false } },
-      signal: new AbortController().signal,
-      toolAdjacencyDirty: false,
-      flushConversationJournal,
-    },
-    logger: { warn },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     renderer: undefined,
   } as unknown as AgentInternals;
 
-  const request = { model: 'test-model', messages: [] } as Request;
-  return {
-    handler: createAgentResponseHandler(internals),
-    request,
-    appendMessage,
-    appendSession,
-    flushSession,
-    flushConversationJournal,
-    warn,
-  };
+  return { a, messages, appendedEvents, flushJournal, sessionFlush };
 }
 
-function response(content: Response['content']): Response {
-  return {
-    content,
-    model: 'test-model',
-    stopReason: 'end_turn',
-    usage: { input: 1, output: 0 },
-  };
+const req = { model: 'test-model' } as Request;
+
+function res(content: Response['content']): Response {
+  return { content, stopReason: 'end_turn', usage: { input: 0, output: 0 }, model: 'test-model' };
 }
 
-describe('agent response persistence', () => {
-  it('does not persist an assistant response containing only empty text', async () => {
-    const h = createHarness();
+describe('processResponse — empty assistant turns (#271)', () => {
+  it('does not append or persist an aborted stream with zero output', async () => {
+    const { a, messages, appendedEvents, flushJournal, sessionFlush } = makeInternals({
+      aborted: true,
+    });
+    const handler = createAgentResponseHandler(a);
 
-    const result = await h.handler.processResponse(
-      response([{ type: 'text', text: '' }]),
-      h.request,
-    );
+    // The exact shape streaming-response-builder produces for an empty stream.
+    const result = await handler.processResponse(res([{ type: 'text', text: '' }]), req);
 
+    expect(result.aborted).toBe(true);
     expect(result.finalText).toBe('');
-    expect(h.appendMessage).not.toHaveBeenCalled();
-    expect(h.appendSession).not.toHaveBeenCalled();
-    expect(h.flushConversationJournal).not.toHaveBeenCalled();
-    expect(h.flushSession).not.toHaveBeenCalled();
-    expect(h.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Skipping empty assistant response'),
-    );
+    expect(messages).toHaveLength(0);
+    expect(appendedEvents).toHaveLength(0);
+    expect(flushJournal).not.toHaveBeenCalled();
+    expect(sessionFlush).not.toHaveBeenCalled();
   });
 
-  it('persists protocol-only assistant responses', async () => {
-    const h = createHarness();
-    const content: Response['content'] = [
-      { type: 'tool_use', id: 'tool-1', name: 'read', input: { path: 'README.md' } },
-    ];
+  it('does not append or persist a non-aborted empty response', async () => {
+    const { a, messages, appendedEvents } = makeInternals();
+    const handler = createAgentResponseHandler(a);
 
-    await h.handler.processResponse(response(content), h.request);
+    const result = await handler.processResponse(res([{ type: 'text', text: '  \n' }]), req);
 
-    expect(h.appendMessage).toHaveBeenCalledWith({ role: 'assistant', content });
-    expect(h.appendSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'llm_response',
-        content,
-      }),
+    expect(result.aborted).toBe(false);
+    expect(result.finalText.trim()).toBe('');
+    expect(messages).toHaveLength(0);
+    expect(appendedEvents).toHaveLength(0);
+  });
+
+  it('preserves meaningful partial text streamed before an abort', async () => {
+    const { a, messages, appendedEvents } = makeInternals({ aborted: true });
+    const handler = createAgentResponseHandler(a);
+
+    const result = await handler.processResponse(res([{ type: 'text', text: 'partial ans' }]), req);
+
+    expect(result.aborted).toBe(true);
+    expect(result.finalText).toBe('partial ans');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'partial ans' }],
+    });
+    expect(appendedEvents).toHaveLength(1);
+    expect(appendedEvents[0]).toMatchObject({ type: 'llm_response' });
+  });
+
+  it('keeps tool-call-only assistant responses and marks adjacency dirty', async () => {
+    const { a, messages, appendedEvents } = makeInternals();
+    const handler = createAgentResponseHandler(a);
+
+    const result = await handler.processResponse(
+      res([{ type: 'tool_use', id: 'u1', name: 'read', input: {} }]),
+      req,
     );
-    expect(h.flushConversationJournal).toHaveBeenCalledOnce();
-    expect(h.flushSession).toHaveBeenCalledOnce();
+
+    expect(result.aborted).toBe(false);
+    expect(messages).toHaveLength(1);
+    expect(appendedEvents).toHaveLength(1);
+    expect(a.ctx.toolAdjacencyDirty).toBe(true);
+  });
+
+  it('keeps thinking responses that carry a signature', async () => {
+    const { a, messages, appendedEvents } = makeInternals({ aborted: true });
+    const handler = createAgentResponseHandler(a);
+
+    const result = await handler.processResponse(
+      res([{ type: 'thinking', thinking: '', signature: 'sig-1' }]),
+      req,
+    );
+
+    expect(result.aborted).toBe(true);
+    expect(messages).toHaveLength(1);
+    expect(appendedEvents).toHaveLength(1);
   });
 });

--- a/packages/core/tests/storage/session-store.test.ts
+++ b/packages/core/tests/storage/session-store.test.ts
@@ -44,6 +44,88 @@ describe('DefaultSessionStore — basic lifecycle', () => {
     await expect(store.load('nonexistent-id')).rejects.toThrow();
   });
 
+  it('replay excludes empty assistant turns persisted by interrupted streams (#271)', async () => {
+    const w = await store.create({ id: 'poisoned', model: 'm', provider: 'p' });
+    await w.append({
+      type: 'user_input',
+      ts: new Date().toISOString(),
+      content: 'first',
+    });
+    // Exact shape an aborted zero-output stream used to persist.
+    await w.append({
+      type: 'llm_response',
+      ts: new Date().toISOString(),
+      content: [{ type: 'text', text: '' }],
+      stopReason: 'end_turn',
+      usage: { input: 0, output: 0 },
+    });
+    await w.append({
+      type: 'llm_response',
+      ts: new Date().toISOString(),
+      content: [{ type: 'text', text: '  \n ' }],
+      stopReason: 'end_turn',
+      usage: { input: 0, output: 0 },
+    });
+    // Meaningful turns around the malformed ones must survive replay.
+    await w.append({
+      type: 'llm_response',
+      ts: new Date().toISOString(),
+      content: [{ type: 'text', text: 'partial before interrupt' }],
+      stopReason: 'end_turn',
+      usage: { input: 3, output: 1 },
+    });
+    await w.append({
+      type: 'user_input',
+      ts: new Date().toISOString(),
+      content: 'second',
+    });
+    await w.close();
+
+    const reloaded = await store.load('poisoned');
+    expect(reloaded.messages).toEqual([
+      { role: 'user', content: 'first', ts: expect.any(String) },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'partial before interrupt' }],
+        ts: expect.any(String),
+      },
+      { role: 'user', content: 'second', ts: expect.any(String) },
+    ]);
+    // No empty assistant turn remains to break strict providers.
+    for (const msg of reloaded.messages) {
+      if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue;
+      expect(
+        msg.content.some((b) => b.type !== 'text' || b.text.trim().length > 0),
+      ).toBe(true);
+    }
+  });
+
+  it('loads and replays user_input + llm_response events', async () => {
+    const w = await store.create({ id: 's1', model: 'm', provider: 'p' });
+    await w.append({
+      type: 'user_input',
+      ts: new Date().toISOString(),
+      content: 'hello',
+    });
+    await w.append({
+      type: 'llm_response',
+      ts: new Date().toISOString(),
+      content: [{ type: 'text', text: 'hi back' }],
+      usage: { input: 10, output: 5 },
+      model: 'm',
+    });
+    await w.close();
+
+    const data = await store.load('s1');
+    expect(data.metadata.id).toBe('s1');
+    expect(data.metadata.model).toBe('m');
+    expect(data.messages).toHaveLength(2);
+    // Replayed messages also carry the event's `ts` — match the core shape.
+    expect(data.messages[0]).toMatchObject({ role: 'user', content: 'hello' });
+    expect(data.usage.input).toBe(10);
+    expect(data.usage.output).toBe(5);
+  });
+
   it('loadEventsOnly throws for nonexistent session', async () => {
     const store = new DefaultSessionStore({ dir: tmpDir });
     await expect(store.loadEventsOnly('nonexistent-id')).rejects.toThrow();

--- a/packages/core/tests/utils/message-invariants.test.ts
+++ b/packages/core/tests/utils/message-invariants.test.ts
@@ -1,26 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Message } from '../../src/types/messages.js';
-import {
-  hasMeaningfulContent,
-  repairToolUseAdjacency,
-} from '../../src/utils/message-invariants.js';
-
-describe('hasMeaningfulContent', () => {
-  it('rejects empty strings and empty text blocks', () => {
-    expect(hasMeaningfulContent('  \n')).toBe(false);
-    expect(hasMeaningfulContent([])).toBe(false);
-    expect(hasMeaningfulContent([{ type: 'text', text: '   ' }])).toBe(false);
-  });
-
-  it('keeps protocol content and signed thinking blocks', () => {
-    expect(hasMeaningfulContent([{ type: 'tool_use', id: 'u1', name: 'read', input: {} }])).toBe(
-      true,
-    );
-    expect(hasMeaningfulContent([{ type: 'thinking', thinking: '', signature: 'signed' }])).toBe(
-      true,
-    );
-  });
-});
+import { hasMeaningfulContent, repairToolUseAdjacency } from '../../src/utils/message-invariants.js';
 
 describe('repairToolUseAdjacency', () => {
   it('leaves valid tool_use/tool_result pairs untouched', () => {
@@ -88,16 +68,122 @@ describe('repairToolUseAdjacency', () => {
     ]);
   });
 
-  it('removes assistant messages containing only empty text blocks', () => {
+  // Issue #271 — interrupted streams persisted `[{type:'text',text:''}]`
+  // assistant turns that strict providers reject on the next request.
+  it('removes assistant messages backed only by an empty text block', () => {
     const messages: Message[] = [
-      { role: 'user', content: 'hello' },
+      { role: 'user', content: 'first' },
       { role: 'assistant', content: [{ type: 'text', text: '' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'answer' }] },
+      { role: 'user', content: 'second' },
+    ];
+
+    const repaired = repairToolUseAdjacency(messages);
+
+    expect(repaired.report.changed).toBe(true);
+    expect(repaired.report.removedMessages).toBe(1);
+    expect(repaired.messages).toEqual([
+      { role: 'user', content: 'first' },
+      { role: 'user', content: 'second' },
+    ]);
+  });
+
+  it('removes messages backed only by whitespace-only text blocks', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: '  ' },
+          { type: 'text', text: '\n\t ' },
+        ],
+      },
+      { role: 'user', content: 'next' },
     ];
 
     const repaired = repairToolUseAdjacency(messages);
 
     expect(repaired.report.removedMessages).toBe(1);
-    expect(repaired.messages).toEqual([messages[0], messages[2]]);
+    expect(repaired.messages).toEqual([{ role: 'user', content: 'next' }]);
+  });
+
+  it('keeps tool-call-only assistant messages intact', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: '' },
+          { type: 'tool_use', id: 'u1', name: 'read', input: {} },
+        ],
+      },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'u1', content: 'ok' }] },
+    ];
+
+    const repaired = repairToolUseAdjacency(messages);
+
+    expect(repaired.report.changed).toBe(false);
+    expect(repaired.messages).toBe(messages);
+  });
+
+  it('keeps thinking blocks that carry text or a signature', () => {
+    const withText: Message[] = [
+      { role: 'assistant', content: [{ type: 'thinking', thinking: 'reasoning' }] },
+    ];
+    const withSignature: Message[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: '', signature: 'sig-1' }],
+      },
+    ];
+
+    expect(repairToolUseAdjacency(withText).report.changed).toBe(false);
+    expect(repairToolUseAdjacency(withSignature).report.changed).toBe(false);
+  });
+
+  it('keeps partial text produced before an interrupt', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: '' },
+          { type: 'text', text: 'partial answer' },
+        ],
+      },
+    ];
+
+    const repaired = repairToolUseAdjacency(messages);
+
+    expect(repaired.report.changed).toBe(false);
+    expect(repaired.messages).toBe(messages);
+  });
+});
+
+describe('hasMeaningfulContent', () => {
+  it('rejects empty and whitespace-only string content', () => {
+    expect(hasMeaningfulContent('')).toBe(false);
+    expect(hasMeaningfulContent('  \n\t ')).toBe(false);
+    expect(hasMeaningfulContent('answer')).toBe(true);
+  });
+
+  it('rejects empty arrays and arrays of only empty text blocks', () => {
+    expect(hasMeaningfulContent([])).toBe(false);
+    expect(hasMeaningfulContent([{ type: 'text', text: '' }])).toBe(false);
+    expect(hasMeaningfulContent([{ type: 'text', text: ' \n' }])).toBe(false);
+  });
+
+  it('accepts any non-text block and non-empty text', () => {
+    expect(hasMeaningfulContent([{ type: 'text', text: 'hi' }])).toBe(true);
+    expect(
+      hasMeaningfulContent([
+        { type: 'text', text: '' },
+        { type: 'tool_use', id: 'u1', name: 'read', input: {} },
+      ]),
+    ).toBe(true);
+    expect(
+      hasMeaningfulContent([{ type: 'tool_result', tool_use_id: 'u1', content: '' }]),
+    ).toBe(true);
+    expect(hasMeaningfulContent([{ type: 'thinking', thinking: 'plan' }])).toBe(true);
+    expect(hasMeaningfulContent([{ type: 'thinking', thinking: '', signature: 's' }])).toBe(
+      true,
+    );
+    expect(hasMeaningfulContent([{ type: 'thinking', thinking: '' }])).toBe(false);
   });
 });


### PR DESCRIPTION
Rebased and conflict-resolved version of PR #273 (originally by Zasetsu).  
  
## Conflict resolution  
Rebased onto latest main (commit d918bef2) with manual conflict resolution in 4 files:  
- packages/core/src/core/agent-response.ts  
- packages/core/tests/core/agent-response-empty.test.ts  
- packages/core/tests/storage/session-store.test.ts  
- packages/core/tests/utils/message-invariants.test.ts  
  
## Changes  
- prevent semantically empty assistant responses from being appended to context  
- repair existing sessions: empty/whitespace-only text blocks removed on replay  
- preserve meaningful partial text, tool-call-only responses, and valid thinking/signature blocks  
- regression coverage for interrupted streams, repair, and session replay  
