### PR TITLE
feat(core): complete permission lifecycle receipts

### DIFF
--- a/packages/core/src/chronicle/tool-adapter.ts
+++ b/packages/core/src/chronicle/tool-adapter.ts
@@ -28,6 +28,20 @@ export function wireToolsToChronicle(options: ChronicleToolAdapterOptions): () =
         },
       });
     }),
+    options.events.on('permission.bypassed', (event) => {
+      persist(options, event, {
+        eventType: 'permission.bypassed',
+        outcome: 'denied',
+        attributes: {
+          toolName: event.name,
+          inputHash: event.inputHash,
+          effectiveDecision: event.effectiveDecision,
+          bypassSource: event.bypassSource,
+          reason: event.reason ? options.scrubber.scrub(event.reason) : undefined,
+          riskTier: event.riskTier,
+        },
+      });
+    }),
     options.events.on('permission.evaluated', (event) => {
       persist(options, event, {
         eventType: 'permission.evaluated',
@@ -46,6 +60,28 @@ export function wireToolsToChronicle(options: ChronicleToolAdapterOptions): () =
             ? options.scrubber.scrub(event.boundaryReason)
             : undefined,
           capabilityDowngraded: event.capabilityDowngraded,
+        },
+      });
+    }),
+    options.events.on('permission.confirmation_resolved', (event) => {
+      persist(options, event, {
+        eventType: 'permission.confirmation_resolved',
+        outcome:
+          event.resolution === 'approved'
+            ? 'success'
+            : event.resolution === 'cancelled'
+              ? 'cancelled'
+              : 'denied',
+        attributes: {
+          toolName: event.name,
+          choice: event.choice,
+          resolution: event.resolution,
+          resolver: event.resolver,
+          decisionSource: event.decisionSource,
+          riskTier: event.riskTier,
+          boundaryReason: event.boundaryReason
+            ? options.scrubber.scrub(event.boundaryReason)
+            : undefined,
         },
       });
     }),

--- a/packages/core/src/chronicle/tool-adapter.ts
+++ b/packages/core/src/chronicle/tool-adapter.ts
@@ -28,15 +28,15 @@ export function wireToolsToChronicle(options: ChronicleToolAdapterOptions): () =
         },
       });
     }),
-    options.events.on('permission.bypassed', (event) => {
+    options.events.on('permission.boundary_denied', (event) => {
       persist(options, event, {
-        eventType: 'permission.bypassed',
+        eventType: 'permission.boundary_denied',
         outcome: 'denied',
         attributes: {
           toolName: event.name,
           inputHash: event.inputHash,
           effectiveDecision: event.effectiveDecision,
-          bypassSource: event.bypassSource,
+          boundarySource: event.boundarySource,
           reason: event.reason ? options.scrubber.scrub(event.reason) : undefined,
           riskTier: event.riskTier,
         },

--- a/packages/core/src/core/agent-tools.ts
+++ b/packages/core/src/core/agent-tools.ts
@@ -4,8 +4,9 @@
  * pipeline/session/event emission.
  */
 import type { ContentBlock, ToolResultBlock, ToolUseBlock } from '../types/blocks.js';
+import type { PermissionDecision } from '../types/permission.js';
 import type { SessionEvent } from '../types/session.js';
-import type { Tool } from '../types/tool.js';
+import type { RiskTier, Tool } from '../types/tool.js';
 import { recordToolOutputEvidence } from '../utils/context-evidence.js';
 import { toErrorMessage } from '../utils/error.js';
 import { sizeSignals, truncateForEvent } from '../utils/tool-output-serializer.js';
@@ -22,6 +23,18 @@ import type { AgentInternals } from './agent-internals.js';
  */
 const DIFF_TOOL_NAMES = new Set(['edit', 'write', 'replace', 'patch', 'diff']);
 const DIFF_TOOL_EVENT_PREVIEW_MAX = 16_000;
+
+type ConfirmationChoice = 'yes' | 'no' | 'always' | 'deny' | 'abort';
+type ConfirmationResolver = 'user' | 'headless' | 'abort';
+interface PendingConfirmationInfo {
+  tool: Tool;
+  input: unknown;
+  toolUseId: string;
+  suggestedPattern: string;
+  decisionSource?: PermissionDecision['source'] | undefined;
+  riskTier?: RiskTier | undefined;
+  boundaryReason?: string | undefined;
+}
 
 export interface AgentToolHandler {
   executeTools(toolUses: ToolUseBlock[]): Promise<ToolResultBlock[]>;
@@ -73,15 +86,32 @@ export function createAgentToolHandler(a: AgentInternals): AgentToolHandler {
     }
   }
 
-  function waitForConfirm(info: {
-    tool: Tool;
-    input: unknown;
-    toolUseId: string;
-    suggestedPattern: string;
-    decisionSource?: import('../types/permission.js').PermissionDecision['source'] | undefined;
-    riskTier?: import('../types/tool.js').RiskTier | undefined;
-    boundaryReason?: string | undefined;
-  }): Promise<'yes' | 'no' | 'always' | 'deny' | 'abort'> {
+  function emitConfirmationResolved(
+    info: PendingConfirmationInfo,
+    choice: ConfirmationChoice,
+    resolver: ConfirmationResolver,
+  ): void {
+    a.events.emit('permission.confirmation_resolved', {
+      sessionId: a.ctx.session.id,
+      ...(a.ctx.traceId ? { traceId: a.ctx.traceId } : {}),
+      ...(a.ctx.agentId ? { agentId: a.ctx.agentId } : {}),
+      name: info.tool.name,
+      id: info.toolUseId,
+      choice,
+      resolution:
+        choice === 'yes' || choice === 'always'
+          ? 'approved'
+          : choice === 'abort'
+            ? 'cancelled'
+            : 'denied',
+      resolver,
+      decisionSource: info.decisionSource,
+      riskTier: info.riskTier,
+      boundaryReason: info.boundaryReason,
+    });
+  }
+
+  function waitForConfirm(info: PendingConfirmationInfo): Promise<ConfirmationChoice> {
     // Headless deadlock guard (P1 #4, before-release.md): if no UI layer has
     // subscribed to `tool.confirm_needed`, emitting the event leaves the
     // resolver promise pending forever — the tool neither executes nor fails
@@ -102,19 +132,28 @@ export function createAgentToolHandler(a: AgentInternals): AgentToolHandler {
           message: `No tool.confirm_needed listener — auto-denying "${info.tool.name}" to avoid headless deadlock.`,
         }),
       );
+      emitConfirmationResolved(info, 'deny', 'headless');
       return Promise.resolve('deny' as const);
     }
-    return new Promise((resolve) => {
+    return new Promise<ConfirmationChoice>((resolve) => {
       // Abort-awareness: /interrupt, Esc, or a parent abort must not leave the
       // run blocked on a confirmation nobody will answer. Resolve as 'abort'
       // — NOT 'no' — so the caller skips the denyOnce side effect (a
       // session-scoped deny minted by an interrupt would silently block this
-      // tool+pattern for the rest of the session). Resolving twice is a
-      // harmless no-op, so a late UI answer after abort is safely ignored.
+      // tool+pattern for the rest of the session). The settlement guard also
+      // prevents a late UI answer from emitting a second resolution event.
       const signal = a.ctx.signal;
-      const onAbort = () => resolve('abort');
+      let settled = false;
+      const settle = (choice: ConfirmationChoice, resolver: ConfirmationResolver): void => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener('abort', onAbort);
+        emitConfirmationResolved(info, choice, resolver);
+        resolve(choice);
+      };
+      const onAbort = () => settle('abort', 'abort');
       if (signal.aborted) {
-        resolve('abort');
+        settle('abort', 'abort');
         return;
       }
       signal.addEventListener('abort', onAbort, { once: true });
@@ -127,10 +166,7 @@ export function createAgentToolHandler(a: AgentInternals): AgentToolHandler {
         decisionSource: info.decisionSource,
         riskTier: info.riskTier,
         boundaryReason: info.boundaryReason,
-        resolve: (choice) => {
-          signal.removeEventListener('abort', onAbort);
-          resolve(choice);
-        },
+        resolve: (choice) => settle(choice, 'user'),
       });
     });
   }

--- a/packages/core/src/execution/tool-executor.ts
+++ b/packages/core/src/execution/tool-executor.ts
@@ -340,6 +340,18 @@ export class ToolExecutor {
       // take effect during an already-running agent assignment.
       const boundary = await evaluateToolKanbanBoundary(tool, use.input, ctx);
       if (boundary.decision === 'block') {
+        this.opts.events?.emit('permission.bypassed', {
+          sessionId: ctx.session.id,
+          ...(ctx.traceId ? { traceId: ctx.traceId } : {}),
+          ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
+          name: tool.name,
+          id: use.id,
+          inputHash: hashPermissionInput(use.input, this.opts.secretScrubber),
+          effectiveDecision: 'deny',
+          bypassSource: 'kanban',
+          ...(boundary.reason ? { reason: boundary.reason } : {}),
+          ...(tool.riskTier ? { riskTier: tool.riskTier } : {}),
+        });
         const result = {
           type: 'tool_result' as const,
           tool_use_id: use.id,
@@ -454,6 +466,26 @@ export class ToolExecutor {
               );
             },
           );
+          this.opts.events?.emit('permission.confirmation_resolved', {
+            sessionId: ctx.session.id,
+            ...(ctx.traceId ? { traceId: ctx.traceId } : {}),
+            ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
+            name: tool.name,
+            id: use.id,
+            choice,
+            resolution:
+              choice === 'yes' || choice === 'always'
+                ? 'approved'
+                : choice === 'abort'
+                  ? 'cancelled'
+                  : 'denied',
+            resolver: choice === 'abort' ? 'abort' : 'user',
+            decisionSource: decision.source,
+            ...(decision.riskTier ?? tool.riskTier
+              ? { riskTier: decision.riskTier ?? tool.riskTier }
+              : {}),
+            ...(boundary.reason ? { boundaryReason: boundary.reason } : {}),
+          });
           if (choice !== 'yes' && choice !== 'always') {
             const result = {
               type: 'tool_result' as const,

--- a/packages/core/src/execution/tool-executor.ts
+++ b/packages/core/src/execution/tool-executor.ts
@@ -340,7 +340,7 @@ export class ToolExecutor {
       // take effect during an already-running agent assignment.
       const boundary = await evaluateToolKanbanBoundary(tool, use.input, ctx);
       if (boundary.decision === 'block') {
-        this.opts.events?.emit('permission.bypassed', {
+        this.opts.events?.emit('permission.boundary_denied', {
           sessionId: ctx.session.id,
           ...(ctx.traceId ? { traceId: ctx.traceId } : {}),
           ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
@@ -348,7 +348,7 @@ export class ToolExecutor {
           id: use.id,
           inputHash: hashPermissionInput(use.input, this.opts.secretScrubber),
           effectiveDecision: 'deny',
-          bypassSource: 'kanban',
+          boundarySource: 'kanban',
           ...(boundary.reason ? { reason: boundary.reason } : {}),
           ...(tool.riskTier ? { riskTier: tool.riskTier } : {}),
         });

--- a/packages/core/src/kernel/events/tool-events.ts
+++ b/packages/core/src/kernel/events/tool-events.ts
@@ -61,7 +61,7 @@ export interface ToolEventMap {
    * Fired when an executor-level hard guard denies a valid tool call before
    * the permission policy runs. Raw tool input is deliberately excluded.
    */
-  'permission.bypassed': {
+  'permission.boundary_denied': {
     sessionId?: string | undefined;
     traceId?: string | undefined;
     agentId?: string | undefined;
@@ -69,7 +69,7 @@ export interface ToolEventMap {
     id: string;
     inputHash: string;
     effectiveDecision: 'deny';
-    bypassSource: 'kanban';
+    boundarySource: 'kanban';
     reason?: string | undefined;
     riskTier?: RiskTier | undefined;
   };

--- a/packages/core/src/kernel/events/tool-events.ts
+++ b/packages/core/src/kernel/events/tool-events.ts
@@ -58,6 +58,22 @@ export interface ToolEventMap {
     event: ToolProgressEvent;
   };
   /**
+   * Fired when an executor-level hard guard denies a valid tool call before
+   * the permission policy runs. Raw tool input is deliberately excluded.
+   */
+  'permission.bypassed': {
+    sessionId?: string | undefined;
+    traceId?: string | undefined;
+    agentId?: string | undefined;
+    name: string;
+    id: string;
+    inputHash: string;
+    effectiveDecision: 'deny';
+    bypassSource: 'kanban';
+    reason?: string | undefined;
+    riskTier?: RiskTier | undefined;
+  };
+  /**
    * Fired once the permission policy and executor-level safety ceilings have
    * produced the effective authorization decision for a valid tool call.
    * Raw tool input is deliberately excluded; inputHash is computed after
@@ -80,6 +96,23 @@ export interface ToolEventMap {
     boundaryDecision?: 'allow' | 'confirm' | 'block' | undefined;
     boundaryReason?: string | undefined;
     capabilityDowngraded: boolean;
+  };
+  /**
+   * Fired exactly once when a pending confirmation is approved, denied, or
+   * cancelled. Raw tool input and the suggested trust pattern are excluded.
+   */
+  'permission.confirmation_resolved': {
+    sessionId?: string | undefined;
+    traceId?: string | undefined;
+    agentId?: string | undefined;
+    name: string;
+    id: string;
+    choice: 'yes' | 'no' | 'always' | 'deny' | 'abort';
+    resolution: 'approved' | 'denied' | 'cancelled';
+    resolver: 'user' | 'headless' | 'abort';
+    decisionSource?: PermissionDecision['source'] | undefined;
+    riskTier?: RiskTier | undefined;
+    boundaryReason?: string | undefined;
   };
   /**
    * Fired when a tool call needs confirmation

--- a/packages/core/tests/chronicle/tool-adapter.test.ts
+++ b/packages/core/tests/chronicle/tool-adapter.test.ts
@@ -151,15 +151,15 @@ describe('wireToolsToChronicle', () => {
       boundaryReason: 'SECRET boundary',
       capabilityDowngraded: true,
     });
-    events.emit('permission.bypassed', {
+    events.emit('permission.boundary_denied', {
       sessionId: 'session',
       traceId: 'trace',
       agentId: 'leader',
       name: 'write',
-      id: 'tool-bypassed',
+      id: 'tool-boundary-denied',
       inputHash: 'b'.repeat(64),
       effectiveDecision: 'deny',
-      bypassSource: 'kanban',
+      boundarySource: 'kanban',
       reason: 'SECRET boundary blocked',
       riskTier: 'destructive',
     });
@@ -176,19 +176,41 @@ describe('wireToolsToChronicle', () => {
       riskTier: 'destructive',
       boundaryReason: 'SECRET boundary',
     });
+    events.emit('permission.confirmation_resolved', {
+      sessionId: 'session',
+      traceId: 'trace',
+      agentId: 'leader',
+      name: 'bash',
+      id: 'tool-approved',
+      choice: 'always',
+      resolution: 'approved',
+      resolver: 'user',
+      decisionSource: 'trust',
+    });
+    events.emit('permission.confirmation_resolved', {
+      sessionId: 'session',
+      traceId: 'trace',
+      agentId: 'leader',
+      name: 'bash',
+      id: 'tool-cancelled',
+      choice: 'abort',
+      resolution: 'cancelled',
+      resolver: 'abort',
+      decisionSource: 'trust',
+    });
 
     const recorded = await journal.readAll();
     const query = await ChronicleQueryEngine.fromDirectory(dir);
     const summary = (await query.query({
       eventTypes: [
         'permission.evaluated',
-        'permission.bypassed',
+        'permission.boundary_denied',
         'permission.confirmation_resolved',
       ],
     })).summary;
     unsubscribe();
 
-    expect(recorded).toHaveLength(3);
+    expect(recorded).toHaveLength(5);
     expect(recorded[0]).toMatchObject({
       eventType: 'permission.evaluated',
       outcome: 'success',
@@ -208,14 +230,14 @@ describe('wireToolsToChronicle', () => {
       },
     });
     expect(recorded[1]).toMatchObject({
-      eventType: 'permission.bypassed',
+      eventType: 'permission.boundary_denied',
       outcome: 'denied',
-      correlation: { toolCallId: 'tool-bypassed' },
+      correlation: { toolCallId: 'tool-boundary-denied' },
       attributes: {
         toolName: 'write',
         inputHash: 'b'.repeat(64),
         effectiveDecision: 'deny',
-        bypassSource: 'kanban',
+        boundarySource: 'kanban',
         reason: '[REDACTED] boundary blocked',
         riskTier: 'destructive',
       },
@@ -234,7 +256,27 @@ describe('wireToolsToChronicle', () => {
         boundaryReason: '[REDACTED] boundary',
       },
     });
+    expect(recorded[3]).toMatchObject({
+      eventType: 'permission.confirmation_resolved',
+      outcome: 'success',
+      correlation: { toolCallId: 'tool-approved' },
+      attributes: {
+        choice: 'always',
+        resolution: 'approved',
+        resolver: 'user',
+      },
+    });
+    expect(recorded[4]).toMatchObject({
+      eventType: 'permission.confirmation_resolved',
+      outcome: 'cancelled',
+      correlation: { toolCallId: 'tool-cancelled' },
+      attributes: {
+        choice: 'abort',
+        resolution: 'cancelled',
+        resolver: 'abort',
+      },
+    });
     expect(JSON.stringify(recorded)).not.toContain('SECRET');
-    expect(summary.families.decision).toBe(3);
+    expect(summary.families.decision).toBe(5);
   });
 });

--- a/packages/core/tests/chronicle/tool-adapter.test.ts
+++ b/packages/core/tests/chronicle/tool-adapter.test.ts
@@ -151,13 +151,44 @@ describe('wireToolsToChronicle', () => {
       boundaryReason: 'SECRET boundary',
       capabilityDowngraded: true,
     });
+    events.emit('permission.bypassed', {
+      sessionId: 'session',
+      traceId: 'trace',
+      agentId: 'leader',
+      name: 'write',
+      id: 'tool-bypassed',
+      inputHash: 'b'.repeat(64),
+      effectiveDecision: 'deny',
+      bypassSource: 'kanban',
+      reason: 'SECRET boundary blocked',
+      riskTier: 'destructive',
+    });
+    events.emit('permission.confirmation_resolved', {
+      sessionId: 'session',
+      traceId: 'trace',
+      agentId: 'leader',
+      name: 'bash',
+      id: 'tool-permission',
+      choice: 'deny',
+      resolution: 'denied',
+      resolver: 'user',
+      decisionSource: 'trust',
+      riskTier: 'destructive',
+      boundaryReason: 'SECRET boundary',
+    });
 
     const recorded = await journal.readAll();
     const query = await ChronicleQueryEngine.fromDirectory(dir);
-    const summary = (await query.query({ eventTypes: ['permission.evaluated'] })).summary;
+    const summary = (await query.query({
+      eventTypes: [
+        'permission.evaluated',
+        'permission.bypassed',
+        'permission.confirmation_resolved',
+      ],
+    })).summary;
     unsubscribe();
 
-    expect(recorded).toHaveLength(1);
+    expect(recorded).toHaveLength(3);
     expect(recorded[0]).toMatchObject({
       eventType: 'permission.evaluated',
       outcome: 'success',
@@ -176,7 +207,34 @@ describe('wireToolsToChronicle', () => {
         capabilityDowngraded: true,
       },
     });
-    expect(JSON.stringify(recorded[0])).not.toContain('SECRET');
-    expect(summary.families.decision).toBe(1);
+    expect(recorded[1]).toMatchObject({
+      eventType: 'permission.bypassed',
+      outcome: 'denied',
+      correlation: { toolCallId: 'tool-bypassed' },
+      attributes: {
+        toolName: 'write',
+        inputHash: 'b'.repeat(64),
+        effectiveDecision: 'deny',
+        bypassSource: 'kanban',
+        reason: '[REDACTED] boundary blocked',
+        riskTier: 'destructive',
+      },
+    });
+    expect(recorded[2]).toMatchObject({
+      eventType: 'permission.confirmation_resolved',
+      outcome: 'denied',
+      correlation: { toolCallId: 'tool-permission' },
+      attributes: {
+        toolName: 'bash',
+        choice: 'deny',
+        resolution: 'denied',
+        resolver: 'user',
+        decisionSource: 'trust',
+        riskTier: 'destructive',
+        boundaryReason: '[REDACTED] boundary',
+      },
+    });
+    expect(JSON.stringify(recorded)).not.toContain('SECRET');
+    expect(summary.families.decision).toBe(3);
   });
 });

--- a/packages/core/tests/core/headless-confirm.test.ts
+++ b/packages/core/tests/core/headless-confirm.test.ts
@@ -10,7 +10,7 @@ import { ToolExecutor } from '../../src/execution/tool-executor.js';
 import { DefaultLogger } from '../../src/infrastructure/logger.js';
 import { DefaultTokenCounter } from '../../src/infrastructure/token-counter.js';
 import { Container } from '../../src/kernel/container.js';
-import { EventBus } from '../../src/kernel/events.js';
+import { EventBus, type EventMap } from '../../src/kernel/events.js';
 import { TOKENS } from '../../src/kernel/tokens.js';
 import { ProviderRegistry } from '../../src/registry/provider-registry.js';
 import { ToolRegistry } from '../../src/registry/tool-registry.js';
@@ -128,6 +128,8 @@ describe('Headless confirm fallback (P1 #4)', () => {
       { content: [{ type: 'text', text: 'recovered after denial' }], stopReason: 'end_turn' },
     ]);
     const { agent, events, tmp } = await buildHeadlessAgent(provider, [danger]);
+    const resolutions: EventMap['permission.confirmation_resolved'][] = [];
+    events.on('permission.confirmation_resolved', (event) => resolutions.push(event));
     cleanupDirs.push(tmp);
 
     // Headless precondition: no listener for tool.confirm_needed.
@@ -140,6 +142,15 @@ describe('Headless confirm fallback (P1 #4)', () => {
 
     // The tool was never executed (denied before execute()).
     expect(provider.calls).toBe(2);
+    expect(resolutions).toEqual([
+      expect.objectContaining({
+        name: 'danger',
+        id: 'u1',
+        choice: 'deny',
+        resolution: 'denied',
+        resolver: 'headless',
+      }),
+    ]);
   }, 10_000);
 
   it('still resolves via the event when a listener IS attached (regression guard)', async () => {
@@ -163,6 +174,8 @@ describe('Headless confirm fallback (P1 #4)', () => {
     ]);
     const { agent, events, tmp } = await buildHeadlessAgent(provider, [danger]);
     cleanupDirs.push(tmp);
+    const resolutions: EventMap['permission.confirmation_resolved'][] = [];
+    events.on('permission.confirmation_resolved', (event) => resolutions.push(event));
 
     // Attach a listener that approves — simulates a TUI/WebUI confirm handler.
     events.on('tool.confirm_needed', (e: { resolve: (d: 'yes' | 'no' | 'always' | 'deny') => void }) =>
@@ -174,6 +187,15 @@ describe('Headless confirm fallback (P1 #4)', () => {
     expect(result.status).toBe('done');
     // Tool executed because the listener approved.
     expect(result.finalText).toBe('ok');
+    expect(resolutions).toEqual([
+      expect.objectContaining({
+        name: 'danger',
+        id: 'u1',
+        choice: 'yes',
+        resolution: 'approved',
+        resolver: 'user',
+      }),
+    ]);
   }, 10_000);
 
   it('unblocks a pending confirm when the run is aborted (/interrupt path)', async () => {
@@ -204,8 +226,14 @@ describe('Headless confirm fallback (P1 #4)', () => {
     // screen" while the user reaches for /interrupt instead. Before the
     // abort-awareness fix in waitForConfirm this awaited forever.
     let sawConfirm = false;
-    events.on('tool.confirm_needed', () => {
+    let lateResolve:
+      | ((decision: 'yes' | 'no' | 'always' | 'deny') => void)
+      | undefined;
+    const resolutions: EventMap['permission.confirmation_resolved'][] = [];
+    events.on('permission.confirmation_resolved', (event) => resolutions.push(event));
+    events.on('tool.confirm_needed', (event) => {
       sawConfirm = true;
+      lateResolve = event.resolve;
     });
 
     const ctrl = new AbortController();
@@ -217,5 +245,15 @@ describe('Headless confirm fallback (P1 #4)', () => {
     expect(result.status).toBe('aborted');
     // The tool must never have executed — the confirm was aborted, not approved.
     expect(executed).toBe(false);
+    lateResolve?.('yes');
+    expect(resolutions).toEqual([
+      expect.objectContaining({
+        name: 'danger',
+        id: 'u1',
+        choice: 'abort',
+        resolution: 'cancelled',
+        resolver: 'abort',
+      }),
+    ]);
   }, 10_000);
 });

--- a/packages/core/tests/execution/tool-executor-extra.test.ts
+++ b/packages/core/tests/execution/tool-executor-extra.test.ts
@@ -457,6 +457,8 @@ describe('ToolExecutor — additional coverage', () => {
       const events = new EventBus();
       const decisions: EventMap['permission.evaluated'][] = [];
       events.on('permission.evaluated', (event) => decisions.push(event));
+      const resolutions: EventMap['permission.confirmation_resolved'][] = [];
+      events.on('permission.confirmation_resolved', (event) => resolutions.push(event));
       const input = { command: 'echo SECRET' };
       const permissionPolicy = {
         evaluate: vi.fn().mockResolvedValue({
@@ -504,9 +506,62 @@ describe('ToolExecutor — additional coverage', () => {
         }),
       ]);
       expect(JSON.stringify(decisions[0])).not.toContain('SECRET');
+      expect(resolutions).toEqual([
+        expect.objectContaining({
+          name: 'bash',
+          id: 'id_bash',
+          choice: 'yes',
+          resolution: 'approved',
+          resolver: 'user',
+          decisionSource: 'trust',
+          riskTier: 'destructive',
+        }),
+      ]);
       expect(confirmAwaiter).toHaveBeenCalledOnce();
       expect(tool.execute).toHaveBeenCalledOnce();
     });
+
+    it.each([
+      ['no', 'denied', false],
+      ['always', 'approved', true],
+      ['deny', 'denied', false],
+    ] as const)(
+      'records the final %s confirmation outcome',
+      async (choice, resolution, shouldExecute) => {
+        policy.evaluate.mockResolvedValue({ permission: 'confirm', source: 'trust' });
+        const events = new EventBus();
+        const resolutions: EventMap['permission.confirmation_resolved'][] = [];
+        events.on('permission.confirmation_resolved', (event) => resolutions.push(event));
+        const tool = makeTool({ name: 'write' });
+        const executor = makeExecutor([tool], {
+          events,
+          confirmAwaiter: vi.fn().mockResolvedValue(choice),
+        });
+
+        await executor.executeBatch(
+          [makeUse('write', { path: 'SECRET-path' })],
+          makeCtx(),
+          'sequential',
+        );
+
+        expect(resolutions).toEqual([
+          expect.objectContaining({
+            name: 'write',
+            id: 'id_write',
+            choice,
+            resolution,
+            resolver: 'user',
+            decisionSource: 'trust',
+          }),
+        ]);
+        expect(JSON.stringify(resolutions[0])).not.toContain('SECRET-path');
+        if (shouldExecute) {
+          expect(tool.execute).toHaveBeenCalledOnce();
+        } else {
+          expect(tool.execute).not.toHaveBeenCalled();
+        }
+      },
+    );
 
     it('preserves authoritative YOLO auto-approval for dangerous capabilities', async () => {
       const events = new EventBus();
@@ -557,11 +612,19 @@ describe('ToolExecutor — additional coverage', () => {
       const awaiter = vi.fn<(...args: unknown[]) => Promise<string>>().mockImplementation(
         () => new Promise(() => {}), // never resolves
       );
-      const executor = makeExecutor([tool], { confirmAwaiter: awaiter });
+      const events = new EventBus();
+      const resolutions: EventMap['permission.confirmation_resolved'][] = [];
+      events.on('permission.confirmation_resolved', (event) => resolutions.push(event));
+      const executor = makeExecutor([tool], { confirmAwaiter: awaiter, events });
       const promise = executor.executeBatch([makeUse('bash', { command: 'echo' })], ctx, 'sequential');
       ctrl.abort('user interrupt');
       const result = await promise;
       expect((result.outputs[0]!.result as ToolResultBlock).content).toContain('aborted');
+      expect(resolutions[0]).toMatchObject({
+        choice: 'abort',
+        resolution: 'cancelled',
+        resolver: 'abort',
+      });
     });
 
     it('handles aborted signal before confirm awaiter starts', async () => {

--- a/packages/core/tests/security/kanban-boundary.test.ts
+++ b/packages/core/tests/security/kanban-boundary.test.ts
@@ -158,8 +158,8 @@ describe('tool Kanban boundary integration', () => {
       execute,
     } as Tool;
     const events = new EventBus();
-    const bypassed: EventMap['permission.bypassed'][] = [];
-    events.on('permission.bypassed', (event) => bypassed.push(event));
+    const denials: EventMap['permission.boundary_denied'][] = [];
+    events.on('permission.boundary_denied', (event) => denials.push(event));
     const permissionEvaluate = vi.fn(async () => ({ permission: 'auto', source: 'yolo' }));
     const executor = new ToolExecutor(
       { get: (name) => (name === tool.name ? tool : undefined), list: () => [tool] },
@@ -207,16 +207,16 @@ describe('tool Kanban boundary integration', () => {
     );
     expect(execute).not.toHaveBeenCalled();
     expect(permissionEvaluate).not.toHaveBeenCalled();
-    expect(bypassed[0]).toMatchObject({
+    expect(denials[0]).toMatchObject({
       sessionId: 'boundary-test',
       agentId: 'worker',
       name: 'write',
       id: 'write-outside',
       effectiveDecision: 'deny',
-      bypassSource: 'kanban',
+      boundarySource: 'kanban',
     });
-    expect(bypassed[0]?.inputHash).toMatch(/^[a-f0-9]{64}$/);
-    expect(JSON.stringify(bypassed[0])).not.toContain('nope');
+    expect(denials[0]?.inputHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(denials[0])).not.toContain('nope');
   });
 
   it('records a boundary-forced confirmation as the effective decision', async () => {

--- a/packages/core/tests/security/kanban-boundary.test.ts
+++ b/packages/core/tests/security/kanban-boundary.test.ts
@@ -157,13 +157,18 @@ describe('tool Kanban boundary integration', () => {
       },
       execute,
     } as Tool;
+    const events = new EventBus();
+    const bypassed: EventMap['permission.bypassed'][] = [];
+    events.on('permission.bypassed', (event) => bypassed.push(event));
+    const permissionEvaluate = vi.fn(async () => ({ permission: 'auto', source: 'yolo' }));
     const executor = new ToolExecutor(
       { get: (name) => (name === tool.name ? tool : undefined), list: () => [tool] },
       {
         permissionPolicy: {
-          evaluate: async () => ({ permission: 'auto', source: 'yolo' }),
+          evaluate: permissionEvaluate,
         },
         secretScrubber: { scrub: (value: string) => value },
+        events,
       } as never,
     );
     const ctx = {
@@ -201,6 +206,17 @@ describe('tool Kanban boundary integration', () => {
       'blocked by Kanban boundary',
     );
     expect(execute).not.toHaveBeenCalled();
+    expect(permissionEvaluate).not.toHaveBeenCalled();
+    expect(bypassed[0]).toMatchObject({
+      sessionId: 'boundary-test',
+      agentId: 'worker',
+      name: 'write',
+      id: 'write-outside',
+      effectiveDecision: 'deny',
+      bypassSource: 'kanban',
+    });
+    expect(bypassed[0]?.inputHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(bypassed[0])).not.toContain('nope');
   });
 
   it('records a boundary-forced confirmation as the effective decision', async () => {


### PR DESCRIPTION
## Summary

- Emit `permission.boundary_denied` when the hard Kanban guard denies a valid tool call before permission-policy evaluation.
- Emit exactly one `permission.confirmation_resolved` receipt for interactive `yes`/`no`/`always`/`deny`, headless denial, and abort cancellation.
- Persist both events through Chronicle with stable tool-call correlation and outcome mapping.

## Receipt invariants

- Hard-boundary receipts contain only a post-scrub input hash—never raw tool input.
- Confirmation receipts exclude raw input and suggested trust patterns.
- The first terminal confirmation result wins; a late UI callback after abort cannot emit a second receipt or resume approval bookkeeping.
- Chronicle maps approved, denied, and cancelled confirmation resolutions to distinct outcomes.

## Focused verification

- `pnpm exec vitest run packages/core/tests/execution/tool-executor-extra.test.ts packages/core/tests/security/kanban-boundary.test.ts packages/core/tests/core/headless-confirm.test.ts packages/core/tests/chronicle/tool-adapter.test.ts` — **67 passed**.
- Biome lint across all eight changed files — **clean**.
- Coverage includes every interactive choice, all Chronicle outcome mappings, headless denial, abort cancellation, and a late approval callback after abort.

## Baseline CI

This PR is based on `main` commit `30defec9`. The [upstream `main` workflow for that exact commit](https://github.com/WrongStack/WrongStack/actions/runs/29664542800) already fails the same job matrix shown on this PR: lint, typecheck, build, Vitest, E2E, TUI smoke, and the aggregate gate. Only the security audit passes.

The failures include duplicate `hasMeaningfulContent` declarations/exports, a broken `actions/cache` revision, unresolved workspace declarations, and unrelated repository-wide lint/test failures. This PR intentionally does not mix those baseline repairs into the authorization receipt change.

Follow-up to #282. Related to #281.