### PR TITLE
fix(ci): restore clean-checkout quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Internal packages publish declarations from dist/. A fresh checkout has
+      # no workspace declarations until the topological build completes.
+      - name: Build workspace declarations
+        run: pnpm build
+
       # Workspace typecheck, serially to avoid tsc buildinfo contention.
       # Matches the root package.json script exactly.
       - name: TypeCheck
@@ -108,6 +113,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Vitest resolves internal package exports through dist/ in a clean clone.
+      - name: Build workspace packages
+        run: pnpm build
+
+      # BrowserSessionManager integration tests launch real Chromium.
+      - name: Cache Playwright browsers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
       # The root vitest run excludes webui (jsdom/globals environment)
       # and hq-dashboard (jsdom via forks pool) — those have their own
       # vitest configs and are tested separately below.
@@ -127,7 +146,7 @@ jobs:
       # hq-dashboard needs jsdom which the root forks pool can't resolve.
       # Run it from its package context so its own vitest config applies.
       - name: Test (hq-dashboard)
-        run: pnpm --filter @wrongstack/cli exec vitest run tests/hq-dashboard.test.ts
+        run: pnpm --filter @wrongstack/cli exec vitest run --config vitest.hqdash.config.ts
         env:
           NODE_OPTIONS: --max-old-space-size=4096
 
@@ -159,7 +178,7 @@ jobs:
 
       # Playwright browsers are cached to avoid re-downloading on every run.
       - name: Cache Playwright browsers
-        uses: actions/cache@d4323d4df104b026a6aa6f6dfbed53dea3b2dfa3 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -198,6 +198,14 @@ export function shouldPrintYoloNotice(
   return !lastChoices && yoloPinned === undefined && yolo;
 }
 
+export function shouldRejectNonInteractiveTui(
+  flags: Readonly<Record<string, string | boolean>>,
+  stdinIsTty: boolean,
+  stdoutIsTty: boolean,
+): boolean {
+  return flags['tui'] === true && (!stdinIsTty || !stdoutIsTty);
+}
+
 /**
  * Boot the CLI: parse args, load config, handle subcommand dispatch
  * (early exit), run interactive prompts (project check, provider picker,
@@ -257,6 +265,17 @@ export async function boot(argv: string[]): Promise<BootContext | number> {
         console.debug(`[wrongstack:quick] plugin: ${name}${enabled}`);
       }
     }
+  }
+
+  // Reject an explicit TUI request before provider discovery or validation.
+  // Otherwise piped invocations can fail for unrelated configuration reasons
+  // before runTui() reaches its own terminal guard.
+  if (shouldRejectNonInteractiveTui(flags, isStdinTTY(), process.stdout.isTTY === true)) {
+    writeErr(
+      'wstack: --tui requires an interactive terminal on both stdin and stdout.\n' +
+        '       Drop the flag (use the plain REPL) or run wstack directly without piping.\n',
+    );
+    return 2;
   }
 
   const logger = new DefaultLogger({

--- a/packages/cli/tests/boot-tui-guard.test.ts
+++ b/packages/cli/tests/boot-tui-guard.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRejectNonInteractiveTui } from '../src/boot.js';
+
+describe('explicit TUI terminal guard', () => {
+  it.each([
+    ['piped stdin', true, false, true, true],
+    ['redirected stdout', true, true, false, true],
+    ['both streams redirected', true, false, false, true],
+    ['interactive streams', true, true, true, false],
+    ['non-TUI invocation', false, false, false, false],
+  ] as const)('%s', (_label, tui, stdinIsTty, stdoutIsTty, expected) => {
+    expect(shouldRejectNonInteractiveTui({ tui }, stdinIsTty, stdoutIsTty)).toBe(expected);
+  });
+});

--- a/packages/core/src/worktree/worktree-manager.ts
+++ b/packages/core/src/worktree/worktree-manager.ts
@@ -1,9 +1,11 @@
 import { spawn } from 'node:child_process';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import type { EventBus } from '../kernel/events.js';
 import { buildChildEnv } from '../utils/child-env.js';
 import { toErrorMessage } from '../utils/error.js';
+
+const CONFLICT_MARKER_LINE = /^(?:<{7,}(?: .*)?|={7,}|>{7,}(?: .*)?|\|{7,}(?: .*)?)\r?$/m;
 
 /**
  * Lifecycle of a single worktree handle.
@@ -708,10 +710,13 @@ export class WorktreeManager {
     }
     if (!resolved) return null;
 
-    // Stage the resolver's edits, then refuse to commit if any conflict marker
-    // survived (a half-resolved file is worse than a clean abort).
+    // Git can report an empty unmerged-file list after a failed squash merge.
+    // In that case, the branch delta is the deterministic set of files the
+    // merge could have marked.
+    const markerFiles =
+      conflictFiles.length > 0 ? conflictFiles : await this.branchChangedFiles(handle);
     await this.runGit(['add', '-A'], this.projectRoot);
-    if (await this.hasConflictMarkers(conflictFiles)) return null;
+    if (await this.hasConflictMarkers(markerFiles)) return null;
 
     const idArgs = await this.identityArgs(this.projectRoot);
     const msg = opts.message ?? `merge ${handle.branch} (squash, conflict resolved)`;
@@ -733,21 +738,29 @@ export class WorktreeManager {
   }
 
   /**
-   * True when staged content still carries conflict markers.
+   * True when resolved or staged content still carries conflict markers.
    *
-   * Primary probe: `git grep --cached` scans the STAGED blobs directly for a
-   * full marker line (`<<<<<<< `, `=======`, `>>>>>>> `, `||||||| `) — exit 0
-   * means found. This is byte-level and independent of git version, locale,
-   * and human-output phrasing. When the caller knows which files conflicted,
-   * the scan is restricted to them so an unrelated `=======` underline in
-   * some document can't false-positive.
+   * Primary probe: read the files Git reported as conflicted and inspect their
+   * working-tree content directly. This remains reliable when a newer Git
+   * version accepts `git add` but its cached grep/check probes miss the staged
+   * marker lines.
    *
-   * Fallback probe: `git diff --cached --check` prints a "leftover conflict
-   * marker" line per survivor. Kept as belt-and-braces — it was the original
-   * sole probe, but CI runners were observed to miss markers through it
-   * (output parsing), which let a half-resolved merge commit.
+   * Fallback probes inspect the staged blobs with `git grep --cached` and
+   * `git diff --cached --check`. When the caller knows which files conflicted,
+   * grep stays restricted to them so an unrelated `=======` underline in some
+   * document cannot false-positive.
    */
   private async hasConflictMarkers(files?: string[]): Promise<boolean> {
+    for (const file of files ?? []) {
+      try {
+        const content = await readFile(resolve(this.projectRoot, file), 'utf8');
+        if (CONFLICT_MARKER_LINE.test(content)) return true;
+      } catch {
+        // A resolver may legitimately delete a conflicted file. The staged
+        // probes below remain authoritative for every surviving path.
+      }
+    }
+
     const pathspec = files && files.length > 0 ? ['--', ...files] : [];
     const grep = await this.runGit(
       ['grep', '--cached', '-q', '-E', '^(<{7} |={7}$|>{7} |\\|{7} )', ...pathspec],
@@ -863,6 +876,15 @@ export class WorktreeManager {
       .split('\n')
       .map((s) => s.trim())
       .filter(Boolean);
+  }
+
+  private async branchChangedFiles(handle: WorktreeHandle): Promise<string[]> {
+    const res = await this.runGit(
+      ['diff', '--name-only', '-z', `${handle.baseBranch}...${handle.branch}`],
+      this.projectRoot,
+    );
+    if (res.code !== 0) return [];
+    return res.stdout.split('\0').filter((file) => file.length > 0);
   }
 
   private emitCommitted(handle: WorktreeHandle, committed: boolean): void {

--- a/packages/core/tests/chronicle/identity.test.ts
+++ b/packages/core/tests/chronicle/identity.test.ts
@@ -18,6 +18,7 @@ describe('resolveChronicleRuntimeLocation', () => {
     expect(first.machineId).toMatch(/^machine_[a-f0-9]{24}$/);
     expect(first.projectId).toBe('project-abc');
     expect(first.journalPath).toBe(path.join(input.projectDir, 'chronicle', '2026-07-18.events.jsonl'));
-    expect(JSON.stringify(first)).not.toContain(input.globalRoot);
+    expect(first.installationId).not.toContain(input.globalRoot);
+    expect(first.machineId).not.toContain(input.globalRoot);
   });
 });

--- a/packages/core/tests/storage/session-store.test.ts
+++ b/packages/core/tests/storage/session-store.test.ts
@@ -45,6 +45,7 @@ describe('DefaultSessionStore — basic lifecycle', () => {
   });
 
   it('replay excludes empty assistant turns persisted by interrupted streams (#271)', async () => {
+    const store = new DefaultSessionStore({ dir: tmpDir });
     const w = await store.create({ id: 'poisoned', model: 'm', provider: 'p' });
     await w.append({
       type: 'user_input',
@@ -101,6 +102,7 @@ describe('DefaultSessionStore — basic lifecycle', () => {
   });
 
   it('loads and replays user_input + llm_response events', async () => {
+    const store = new DefaultSessionStore({ dir: tmpDir });
     const w = await store.create({ id: 's1', model: 'm', provider: 'p' });
     await w.append({
       type: 'user_input',

--- a/packages/core/tests/worktree/worktree-manager.test.ts
+++ b/packages/core/tests/worktree/worktree-manager.test.ts
@@ -365,6 +365,49 @@ describe('WorktreeManager (stubbed git)', () => {
     expect(calls.some((c) => c.args[0] === 'reset' && c.args.includes('--hard'))).toBe(true);
   });
 
+  it('merge() scans branch paths when Git reports no conflict files', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'wm-marker-fallback-'));
+    try {
+      await fs.writeFile(
+        path.join(projectRoot, 'seed.txt'),
+        '<<<<<<< HEAD\nBASE\n=======\nWORKTREE\n>>>>>>> topic\n',
+      );
+      const { calls, run } = stubRunner((args) => {
+        if (args[0] === 'rev-parse') {
+          return { code: 0, stdout: 'main\n', stderr: '' };
+        }
+        if (args[0] === 'merge') {
+          return { code: 1, stdout: 'Automatic merge failed\n', stderr: '' };
+        }
+        if (args[0] === 'diff' && args.includes('--diff-filter=U')) {
+          return { code: 0, stdout: '', stderr: '' };
+        }
+        if (args[0] === 'diff' && args.includes('-z')) {
+          return { code: 0, stdout: 'seed.txt\0', stderr: '' };
+        }
+        return { code: 0, stdout: '', stderr: '' };
+      });
+      const wm = new WorktreeManager({ projectRoot, run });
+      const h = await wm.allocate('p', { slugHint: 'marker-fallback' });
+
+      const res = await wm.merge(h, { squash: true, resolve: async () => true });
+
+      expect(res.ok).toBe(false);
+      expect(res.conflict).toBe(true);
+      expect(h.status).toBe('needs-review');
+      expect(
+        calls.some(
+          ({ args }) =>
+            args[0] === 'diff' &&
+            args.includes('-z') &&
+            args.includes(`${h.baseBranch}...${h.branch}`),
+        ),
+      ).toBe(true);
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   it('diffSummary() parses numstat + commit count', async () => {
     const { run } = stubRunner((args) => {
       if (args[0] === 'diff' && args.includes('--numstat')) {
@@ -643,8 +686,19 @@ describe.skipIf(!gitAvailable)('WorktreeManager (real repo)', () => {
         env: GIT_ENV,
       });
 
-      // Resolver claims success but leaves the conflict markers in place.
-      const m = await wm.merge(h, { squash: true, resolve: async () => true });
+      // Re-create unresolved content explicitly. Git versions differ in how a
+      // failed squash merge materializes the worktree file, so a no-op callback
+      // does not reliably mean that marker lines remain.
+      const m = await wm.merge(h, {
+        squash: true,
+        resolve: async ({ cwd }) => {
+          await fs.writeFile(
+            path.join(cwd, 'seed.txt'),
+            '<<<<<<< HEAD\nBASE\n=======\nWORKTREE\n>>>>>>> topic\n',
+          );
+          return true;
+        },
+      });
 
       expect(m.ok).toBe(false);
       expect(m.conflict).toBe(true);


### PR DESCRIPTION
## Problem

The current `main` workflow fails before it can provide a reliable quality signal. The failures combine clean-checkout prerequisites with several direct regressions exposed by the latest Linux run:

- TypeCheck and root Vitest consume internal workspace build output before it exists.
- BrowserSessionManager tests launch Chromium, but the test job installs no Playwright browser.
- E2E pins an invalid `actions/cache` revision.
- Explicit `--tui` validates providers before rejecting non-interactive terminals.
- Two session-store replay tests reference an undeclared store.
- The Chronicle identity test treats its expected local journal path as leaked opaque identity data.
- Git 2.54 can leave conflict markers that the cached-index probes miss after a resolver callback.

Failing baseline: https://github.com/WrongStack/WrongStack/actions/runs/29665585558

## Changes

- Build workspace packages before TypeCheck and root Vitest.
- Cache and install Playwright Chromium before root Vitest.
- Pin `actions/cache` to the valid v4 commit `0057852bfaa89a56745cba8c7296529d2fc39830`.
- Reject explicit non-TTY TUI mode before logger, model, and provider setup.
- Restore the missing session-store fixtures.
- Limit Chronicle privacy assertions to opaque identity fields.
- Scan conflicted files directly for unresolved marker lines before accepting resolver success.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm biome lint packages/core/src/worktree/worktree-manager.ts packages/core/tests/worktree/worktree-manager.test.ts packages/core/tests/storage/session-store.test.ts packages/core/tests/chronicle/identity.test.ts packages/cli/src/boot.ts packages/cli/tests/boot-tui-guard.test.ts`
- `pnpm vitest run packages/core/tests/worktree/worktree-manager.test.ts packages/cli/tests/wiring-plugins.test.ts packages/core/tests/chronicle/identity.test.ts packages/core/tests/storage/session-store.test.ts packages/cli/tests/boot-tui-guard.test.ts` — 84 tests passed
- `node packages/cli/dist/index.js --tui --project .` — returned the documented terminal guard with exit code 2