### PR TITLE
feat(agent-roster): headless consolidation with live broadcast and debounced refresh

### DIFF
--- a/packages/webui-server/src/server/agent-roster-handlers.ts
+++ b/packages/webui-server/src/server/agent-roster-handlers.ts
@@ -44,19 +44,119 @@ import {
   updateProjectAgentLearned,
   updateProjectAgentLearningPolicy,
 } from '@wrongstack/core/coordination';
+import { isTextBlock } from '@wrongstack/core/types';
+import type { Provider, Request } from '@wrongstack/core/types';
 import type { WebSocket } from 'ws';
 import type { WSServerMessage } from './types.js';
 
+/**
+ * Resolved LLM handle used for headless (chat-free) consolidation. Both the
+ * embedded and standalone routers can supply this from the active agent
+ * context (`agent.ctx.provider` / `agent.ctx.model`).
+ */
+export interface AgentRosterLlm {
+  provider: Provider;
+  model: string;
+}
+
 export interface AgentRosterHandlerOptions {
   projectRoot: string | (() => string);
+  /**
+   * Resolves the LLM used to synthesize consolidations directly on the server,
+   * without routing the instruction back through the chat loop. When it
+   * returns undefined (no active model), the handler degrades gracefully to
+   * returning the instruction for a caller-driven consolidation.
+   */
+  getLlm?: () => AgentRosterLlm | undefined;
+  /**
+   * Broadcasts a message to every connected client. Used to push
+   * `agent-roster.updated` after a headless consolidation so other open
+   * clients refresh the affected roster card without a manual reload.
+   */
+  broadcast?: (msg: WSServerMessage) => void;
 }
+
+/** Hard cap on synthesized consolidation output. */
+const CONSOLIDATION_MAX_TOKENS = 8000;
+/** Wall-clock budget for a single headless consolidation LLM call. */
+const CONSOLIDATION_TIMEOUT_MS = 120_000;
 
 export class AgentRosterWSHandler {
   private readonly getProjectRoot: () => string;
+  private readonly getLlm: () => AgentRosterLlm | undefined;
+  private readonly broadcast: (msg: WSServerMessage) => void;
 
   constructor(opts: AgentRosterHandlerOptions) {
     this.getProjectRoot =
       typeof opts.projectRoot === 'function' ? opts.projectRoot : () => opts.projectRoot as string;
+    this.getLlm = opts.getLlm ?? (() => undefined);
+    this.broadcast = opts.broadcast ?? (() => {});
+  }
+
+  /**
+   * Run the consolidation LLM synthesis headlessly and return the cleaned
+   * document text. Returns undefined when no LLM is available so the caller
+   * can fall back to the instruction-only path.
+   */
+  private async synthesizeConsolidation(
+    instruction: string,
+  ): Promise<{ content: string; model: string } | undefined> {
+    const llm = this.getLlm();
+    if (!llm) return undefined;
+
+    const req: Request = {
+      model: llm.model,
+      system: [
+        {
+          type: 'text',
+          text:
+            'You are a precise technical editor. You consolidate an AI agent role\'s ' +
+            'captured learning entries into a single, durable, role-scoped instruction ' +
+            'document. Output ONLY the consolidated markdown document — no preamble, no ' +
+            'code fences, no commentary about the consolidation process.',
+        },
+      ],
+      messages: [{ role: 'user', content: instruction }],
+      maxTokens: CONSOLIDATION_MAX_TOKENS,
+    };
+
+    const timer = new AbortController();
+    let timedOut = false;
+    const to = setTimeout(() => {
+      timedOut = true;
+      timer.abort(new Error('consolidation timeout'));
+    }, CONSOLIDATION_TIMEOUT_MS);
+    to.unref();
+    try {
+      const res = await llm.provider.complete(req, { signal: timer.signal });
+      const text = res.content
+        .filter(isTextBlock)
+        .map((block) => block.text)
+        .join('\n')
+        .trim();
+      // Strip an accidental ```markdown / ``` fence wrapper if the model wrapped
+      // the WHOLE document in one. Gate on a single wrapper fence that spans the
+      // entire output so a doc that legitimately starts or ends with a real code
+      // block is not corrupted (that doc has an interior closing/opening fence,
+      // so the whole-document pattern below will not match).
+      const wholeDocFence = /^```(?:markdown|md)?[^\n]*\n([\s\S]*?)\n?```\s*$/i;
+      const wrapped = wholeDocFence.exec(text);
+      const inner = wrapped?.[1];
+      const unfenced = inner !== undefined ? inner.trim() : text;
+      return { content: unfenced, model: llm.model };
+    } catch (err) {
+      // Providers surface an abort as a generic AbortError; translate the
+      // timeout case into a clear, caller-facing message.
+      if (timedOut) {
+        throw new Error(`consolidation timed out after ${CONSOLIDATION_TIMEOUT_MS}ms`);
+      }
+      throw err;
+    } finally {
+      // The AbortController exists solely to cancel the in-flight request on
+      // timeout; the timeout path aborts itself. On the success path there is
+      // nothing left to cancel, so only clear the pending timer here.
+      clearTimeout(to);
+    }
   }
 
   /** Handle an incoming client message. Returns a response payload. */
@@ -164,6 +264,7 @@ export class AgentRosterWSHandler {
 
       case 'agent-roster.read-customization': {
         if (!role) return { type, payload: { error: 'role required' } };
+        const profile = loadProjectAgentProfile(role, projectRoot);
         return {
           type,
           payload: {
@@ -171,9 +272,8 @@ export class AgentRosterWSHandler {
             identity: loadProjectAgentIdentity(role, projectRoot),
             learned: loadProjectAgentLearned(role, projectRoot),
             config: loadProjectAgentConfig(role, projectRoot) ?? {},
-            profile: loadProjectAgentProfile(role, projectRoot),
-            systemProtected:
-              !loadProjectAgentProfile(role, projectRoot) && Boolean(FLEET_ROSTER[role]),
+            profile,
+            systemProtected: !profile && Boolean(FLEET_ROSTER[role]),
           },
         };
       }
@@ -300,20 +400,142 @@ export class AgentRosterWSHandler {
         return { type, payload: { conflicts } };
       }
 
-      // ── Build consolidation instruction (LLM prompt) ──────────────────
+      // ── Consolidate learned entries (headless LLM synthesis) ──────────
+      // Runs the whole optimization on the server: read raw entries →
+      // synthesize with the active model → write consolidated.md +
+      // consolidation.json. No chat round-trip. When no LLM is available the
+      // handler degrades to returning the instruction so a caller (e.g. the
+      // chat agent) can still perform the consolidation manually.
       case 'agent-roster.consolidate': {
         if (!role) return { type, payload: { error: 'role required' } };
         const { instruction, rawEntries, hasExistingConsolidation } =
           buildConsolidationInstruction(role, projectRoot);
-        const currentStats = getProjectAgentLearnStats(role, projectRoot);
+
+        // Nothing to optimize — surface a clear, non-error signal.
+        if (rawEntries.length === 0) {
+          return {
+            type: 'agent-roster.consolidate',
+            payload: {
+              role,
+              consolidated: false,
+              rawEntryCount: 0,
+              hasExistingConsolidation,
+              currentStats: getProjectAgentLearnStats(role, projectRoot),
+            },
+          };
+        }
+
+        // Headless path: synthesize + persist directly on the server.
+        let synth: { content: string; model: string } | undefined;
+        try {
+          synth = await this.synthesizeConsolidation(instruction);
+        } catch (err) {
+          return {
+            type: 'agent-roster.consolidate',
+            payload: {
+              role,
+              consolidated: false,
+              rawEntryCount: rawEntries.length,
+              hasExistingConsolidation,
+              currentStats: getProjectAgentLearnStats(role, projectRoot),
+              error: err instanceof Error ? err.message : 'consolidation failed',
+            },
+          };
+        }
+
+        if (synth && synth.content.length > 0) {
+          let stats: ReturnType<typeof getProjectAgentLearnStats>;
+          let metadata: ReturnType<typeof loadConsolidationMetadata>;
+          try {
+            saveProjectAgentConsolidated(role, synth.content, projectRoot, {
+              trigger: 'manual',
+              model: synth.model,
+            });
+            stats = getProjectAgentLearnStats(role, projectRoot);
+            metadata = loadConsolidationMetadata(role, projectRoot);
+          } catch (err) {
+            // Persisting the consolidated document failed (e.g. filesystem
+            // error). Surface a structured failure instead of rejecting.
+            return {
+              type: 'agent-roster.consolidate',
+              payload: {
+                role,
+                consolidated: false,
+                rawEntryCount: rawEntries.length,
+                hasExistingConsolidation,
+                currentStats: getProjectAgentLearnStats(role, projectRoot),
+                error: err instanceof Error ? err.message : 'failed to persist consolidation',
+              },
+            };
+          }
+          // Push a fresh roster card to every other connected client so they
+          // reflect the new consolidated state without a manual reload. The
+          // document is already persisted, so a broadcast failure (e.g. a
+          // disconnected client iterator) must not reject the handler and
+          // swallow the success response below.
+          try {
+            this.broadcast({
+              type: 'agent-roster.updated',
+              payload: { role, reason: 'consolidated', currentStats: stats, metadata },
+            });
+          } catch (e) {
+            // Best-effort notification only; the consolidation itself succeeded.
+            // Log so a real bug in `broadcast` (TypeError, malformed message) is
+            // surfaced instead of silently swallowed alongside dead-client errors.
+            console.warn(
+              JSON.stringify({
+                level: 'warn',
+                event: 'agent_roster.broadcast_failed',
+                role,
+                message: e instanceof Error ? e.message : String(e),
+                timestamp: new Date().toISOString(),
+              }),
+            );
+          }
+          return {
+            type: 'agent-roster.consolidate',
+            payload: {
+              role,
+              consolidated: true,
+              rawEntryCount: rawEntries.length,
+              content: synth.content,
+              model: synth.model,
+              currentStats: stats,
+              metadata,
+            },
+          };
+        }
+
+        // The model was available and ran, but produced only whitespace /
+        // fencing. This is distinct from "no model available": signal it
+        // explicitly so a caller can tell an empty synthesis apart from the
+        // instruction-fallback path below and avoid corrupting the doc.
+        if (synth) {
+          return {
+            type: 'agent-roster.consolidate',
+            payload: {
+              role,
+              consolidated: false,
+              emptySynthesis: true,
+              model: synth.model,
+              rawEntryCount: rawEntries.length,
+              hasExistingConsolidation,
+              currentStats: getProjectAgentLearnStats(role, projectRoot),
+            },
+          };
+        }
+
+        // Fallback path (no active model): return the instruction so a
+        // caller can drive the consolidation through the chat agent.
         return {
           type: 'agent-roster.consolidate',
           payload: {
             role,
+            consolidated: false,
             instruction,
             rawEntryCount: rawEntries.length,
             hasExistingConsolidation,
-            currentStats,
+            currentStats: getProjectAgentLearnStats(role, projectRoot),
             // Instruction for the leader agent to execute the consolidation
             leaderInstruction:
               `Optimize what the "${role}" agent has learned. Read its raw learned entries, ` +

--- a/packages/webui-server/src/server/embedded-message-router.ts
+++ b/packages/webui-server/src/server/embedded-message-router.ts
@@ -426,7 +426,16 @@ export function createEmbeddedMessageRouter(
       worktree: deps.worktreeHandler,
       kanbanHost: deps.kanbanHostRoutes,
       agentRoster: {
-        rosterHandler: new AgentRosterWSHandler({ projectRoot }),
+        rosterHandler: new AgentRosterWSHandler({
+          projectRoot,
+          getLlm: () => {
+            const ctx = opts.agent.ctx;
+            return ctx.provider && ctx.model
+              ? { provider: ctx.provider, model: ctx.model }
+              : undefined;
+          },
+          broadcast: (m) => deps.providerCtx.broadcast(m),
+        }),
       },
     },
     memory: { getMemoryStore: () => opts.memoryStore, send, sendResult },

--- a/packages/webui-server/src/server/message-dispatcher.ts
+++ b/packages/webui-server/src/server/message-dispatcher.ts
@@ -299,7 +299,16 @@ export function createMessageDispatcher(
       worktree: deps.worktreeHandler,
       kanbanHost: kanbanHostRoutes,
       agentRoster: {
-        rosterHandler: new AgentRosterWSHandler({ projectRoot: state.getProjectRoot }),
+        rosterHandler: new AgentRosterWSHandler({
+          projectRoot: state.getProjectRoot,
+          getLlm: () => {
+            const ctx = deps.agent.ctx;
+            return ctx.provider && ctx.model
+              ? { provider: ctx.provider, model: ctx.model }
+              : undefined;
+          },
+          broadcast: (m) => broadcast(state.getClients(), m),
+        }),
       },
     },
     memory: { getMemoryStore: () => deps.memoryStore, send, sendResult },

--- a/packages/webui-server/tests/agent-roster-handlers.test.ts
+++ b/packages/webui-server/tests/agent-roster-handlers.test.ts
@@ -175,4 +175,276 @@ describe('AgentRosterWSHandler', () => {
     });
     expect(missing.payload).toMatchObject({ error: expect.stringContaining('unknown') });
   });
+
+  it('consolidates headlessly with an active model: synthesizes, persists both files, and broadcasts', async () => {
+    const synthesized = '## Consolidated\n\n- Directive one.\n- Directive two.';
+    let receivedSystem = false;
+    const broadcasts: Array<{ type: string; payload: unknown }> = [];
+    const stubProvider = {
+      capabilities: {},
+      async complete() {
+        return { content: [{ type: 'text', text: synthesized }] };
+      },
+    };
+    const llmHandler = new AgentRosterWSHandler({
+      projectRoot: () => projectRoot,
+      // Assert the instruction actually reaches the provider.
+      getLlm: () => {
+        receivedSystem = true;
+        return { provider: stubProvider as never, model: 'test-model' };
+      },
+      broadcast: (msg) => broadcasts.push(msg as { type: string; payload: unknown }),
+    });
+
+    await llmHandler.handleMessage(ws, 'agent-roster.append-learned', {
+      role: 'executor',
+      content: 'Always run the focused package test before the workspace suite.',
+    });
+
+    const res = await llmHandler.handleMessage(ws, 'agent-roster.consolidate', {
+      role: 'executor',
+    });
+    const payload = res.payload as {
+      consolidated: boolean;
+      content?: string;
+      model?: string;
+      rawEntryCount: number;
+    };
+
+    expect(receivedSystem).toBe(true);
+    expect(payload.consolidated).toBe(true);
+    expect(payload.model).toBe('test-model');
+    expect(payload.content).toContain('Directive one.');
+    expect(payload.rawEntryCount).toBeGreaterThan(0);
+
+    // consolidated.md is written verbatim, consolidation.json metadata alongside.
+    const dir = path.join(projectRoot, '.wrongstack', 'agents', 'executor');
+    expect(fs.readFileSync(path.join(dir, 'consolidated.md'), 'utf8')).toContain('Directive one.');
+    const meta = JSON.parse(fs.readFileSync(path.join(dir, 'consolidation.json'), 'utf8'));
+    expect(meta.trigger).toBe('manual');
+    expect(meta.model).toBe('test-model');
+    expect(meta.sourceEntryCount).toBeGreaterThan(0);
+
+    // Other connected clients are notified via agent-roster.updated.
+    const updated = broadcasts.find((b) => b.type === 'agent-roster.updated');
+    expect(updated).toBeDefined();
+    expect(updated?.payload).toMatchObject({ role: 'executor', reason: 'consolidated' });
+  });
+
+  it('does not broadcast on the no-active-model fallback path', async () => {
+    const broadcasts: object[] = [];
+    const noLlmHandler = new AgentRosterWSHandler({
+      projectRoot: () => projectRoot,
+      broadcast: (msg) => broadcasts.push(msg),
+    });
+    await noLlmHandler.handleMessage(ws, 'agent-roster.append-learned', {
+      role: 'executor',
+      content: 'A rule that will not consolidate without a model.',
+    });
+    const res = await noLlmHandler.handleMessage(ws, 'agent-roster.consolidate', {
+      role: 'executor',
+    });
+    expect((res.payload as { consolidated: boolean }).consolidated).toBe(false);
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  it('strips an accidental code-fence wrapper from the synthesized document', async () => {
+    const stubProvider = {
+      capabilities: {},
+      async complete() {
+        return { content: [{ type: 'text', text: '```markdown\n## Doc\n\n- Rule.\n```' }] };
+      },
+    };
+    const llmHandler = new AgentRosterWSHandler({
+      projectRoot: () => projectRoot,
+      getLlm: () => ({ provider: stubProvider as never, model: 'm' }),
+    });
+    await llmHandler.handleMessage(ws, 'agent-roster.append-learned', {
+      role: 'executor',
+      content: 'A durable rule worth keeping.',
+    });
+    const res = await llmHandler.handleMessage(ws, 'agent-roster.consolidate', { role: 'executor' });
+    const payload = res.payload as { consolidated: boolean; content?: string };
+    expect(payload.consolidated).toBe(true);
+    expect(payload.content?.startsWith('```')).toBe(false);
+    expect(payload.content).toContain('## Doc');
+  });
+
+  it('returns a non-error signal when there are no learned entries to consolidate', async () => {
+    // No append-learned call → the role has zero raw entries.
+    let called = false;
+    const llmHandler = new AgentRosterWSHandler({
+      projectRoot: () => projectRoot,
+      getLlm: () => {
+        called = true;
+        return { provider: { capabilities: {}, async complete() { return { content: [] }; } } as never, model: 'm' };
+      },
+    });
+    const res = await llmHandler.handleMessage(ws, 'agent-roster.consolidate', { role: 'executor' });
+    const payload = res.payload as { consolidated: boolean; rawEntryCount: number; error?: string };
+    expect(payload.consolidated).toBe(false);
+    expect(payload.rawEntryCount).toBe(0);
+    expect(payload.error).toBeUndefined();
+    // Empty-entry path short-circuits before invoking the model.
+    expect(called).toBe(false);
+  });
+
+  it('surfaces a clean error payload when synthesis throws', async () => {
+    const stubProvider = {
+      capabilities: {},
+      async complete(): Promise<never> {
+        throw new Error('provider exploded');
+      },
+    };
+    const llmHandler = new AgentRosterWSHandler({
+      projectRoot: () => projectRoot,
+      getLlm: () => ({ provider: stubProvider as never, model: 'test-model' }),
+    });
+    await llmHandler.handleMessage(ws, 'agent-roster.append-learned', {
+      role: 'executor',
+      content: 'A rule that will fail to consolidate.',
+    });
+    const res = await llmHandler.handleMessage(ws, 'agent-roster.consolidate', { role: 'executor' });
+    const payload = res.payload as {
+      consolidated: boolean;
+      rawEntryCount: number;
+      error?: string;
+    };
+    expect(payload.consolidated).toBe(false);
+    expect(payload.rawEntryCount).toBeGreaterThan(0);
+    expect(payload.error).toBe('provider exploded');
+    // Failed synthesis must not have written a consolidated document.
+    const dir = path.join(projectRoot, '.wrongstack', 'agents', 'executor');
+    expect(fs.existsSync(path.join(dir, 'consolidated.md'))).toBe(false);
+  });
+
+  it('falls back to the instruction when no active model is available', async () => {
+    // Default handler has no getLlm → no active model.
+    await handler.handleMessage(ws, 'agent-roster.append-learned', {
+      role: 'executor',
+      content: 'Prefer surgical edits over full rewrites.',
+    });
+    const res = await handler.handleMessage(ws, 'agent-roster.consolidate', { role: 'executor' });
+    const payload = res.payload as {
+      consolidated: boolean;
+      instruction?: string;
+      leaderInstruction?: string;
+      rawEntryCount: number;
+    };
+    expect(payload.consolidated).toBe(false);
+    expect(payload.rawEntryCount).toBeGreaterThan(0);
+    expect(typeof payload.instruction).toBe('string');
+    expect(payload.instruction).toContain('executor');
+    // No files written on the fallback path.
+    expect(
+      fs.existsSync(path.join(projectRoot, '.wrongstack', 'agents', 'executor', 'consolidated.md')),
+    ).toBe(false);
+  });
+
+  it('reports consolidated:false with no error when there are no raw entries', async () => {
+    const stubProvider = {
+      capabilities: {},
+      async complete() {
+        throw new Error('should not be called for empty entries');
+      },
+    };
+    const llmHandler = new AgentRosterWSHandler({
+      projectRoot: () => projectRoot,
+      getLlm: () => ({ provider: stubProvider as never, model: 'm' }),
+    });
+    const res = await llmHandler.handleMessage(ws, 'agent-roster.consolidate', { role: 'executor' });
+    const payload = res.payload as { consolidated: boolean; rawEntryCount: number; error?: string };
+    expect(payload.consolidated).toBe(false);
+    expect(payload.rawEntryCount).toBe(0);
+    expect(payload.error).toBeUndefined();
+  });
+
+  it('surfaces a provider error as a clean failure payload (no chat misroute)', async () => {
+    const stubProvider = {
+      capabilities: {},
+      async complete() {
+        throw new Error('provider exploded');
+      },
+    };
+    const llmHandler = new AgentRosterWSHandler({
+      projectRoot: () => projectRoot,
+      getLlm: () => ({ provider: stubProvider as never, model: 'm' }),
+    });
+    await llmHandler.handleMessage(ws, 'agent-roster.append-learned', {
+      role: 'executor',
+      content: 'A lesson that will fail to consolidate.',
+    });
+    const res = await llmHandler.handleMessage(ws, 'agent-roster.consolidate', { role: 'executor' });
+    const payload = res.payload as { consolidated: boolean; error?: string; instruction?: string };
+    expect(payload.consolidated).toBe(false);
+    expect(payload.error).toContain('provider exploded');
+    // A real error must NOT be misrouted as the no-model fallback.
+    expect(payload.instruction).toBeUndefined();
+  });
+
+  it('signals emptySynthesis when the model runs but returns only whitespace', async () => {
+    const stubProvider = {
+      capabilities: {},
+      async complete() {
+        // Model was available and ran, but produced only whitespace/fencing.
+        return { content: [{ type: 'text', text: '   \n\n```markdown\n```\n' }] };
+      },
+    };
+    const llmHandler = new AgentRosterWSHandler({
+      projectRoot: () => projectRoot,
+      getLlm: () => ({ provider: stubProvider as never, model: 'empty-model' }),
+    });
+    await llmHandler.handleMessage(ws, 'agent-roster.append-learned', {
+      role: 'executor',
+      content: 'A durable rule the model failed to synthesize.',
+    });
+    const res = await llmHandler.handleMessage(ws, 'agent-roster.consolidate', { role: 'executor' });
+    const payload = res.payload as {
+      consolidated: boolean;
+      emptySynthesis?: boolean;
+      model?: string;
+      instruction?: string;
+      rawEntryCount: number;
+    };
+    expect(payload.consolidated).toBe(false);
+    // Distinct from the no-model fallback: the model ran but produced nothing.
+    expect(payload.emptySynthesis).toBe(true);
+    expect(payload.model).toBe('empty-model');
+    expect(payload.instruction).toBeUndefined();
+    expect(payload.rawEntryCount).toBeGreaterThan(0);
+    // Empty synthesis must NOT write a consolidated document.
+    expect(
+      fs.existsSync(path.join(projectRoot, '.wrongstack', 'agents', 'executor', 'consolidated.md')),
+    ).toBe(false);
+  });
+
+  it('does not swallow the success response when a broadcast throws', async () => {
+    const synthesized = '## Consolidated\n\n- Keep every fact.';
+    const stubProvider = {
+      capabilities: {},
+      async complete() {
+        return { content: [{ type: 'text', text: synthesized }] };
+      },
+    };
+    const llmHandler = new AgentRosterWSHandler({
+      projectRoot: () => projectRoot,
+      getLlm: () => ({ provider: stubProvider as never, model: 'test-model' }),
+      broadcast: () => {
+        throw new Error('client iterator disconnected mid-broadcast');
+      },
+    });
+    await llmHandler.handleMessage(ws, 'agent-roster.append-learned', {
+      role: 'executor',
+      content: 'A rule worth consolidating even if the broadcast fails.',
+    });
+    const res = await llmHandler.handleMessage(ws, 'agent-roster.consolidate', { role: 'executor' });
+    const payload = res.payload as { consolidated: boolean; content?: string };
+    // The document persisted, so the success response must still be returned
+    // even though the post-persist broadcast threw.
+    expect(payload.consolidated).toBe(true);
+    expect(payload.content).toContain('## Consolidated');
+    expect(
+      fs.existsSync(path.join(projectRoot, '.wrongstack', 'agents', 'executor', 'consolidated.md')),
+    ).toBe(true);
+  });
 });

--- a/packages/webui/src/components/AgentRosterView.tsx
+++ b/packages/webui/src/components/AgentRosterView.tsx
@@ -46,6 +46,13 @@ import { toast } from '@/components/Toaster';
 import type { SubagentView } from '@/stores';
 import { useChatStore, useFleetStore, useUIStore } from '@/stores';
 
+/**
+ * Trailing-debounce window for coalescing `agent-roster.updated` broadcasts.
+ * A bulk optimize emits one event per role; without this, each would trigger
+ * its own full roster reload. Reloading once after the burst settles is enough.
+ */
+const ROSTER_UPDATE_DEBOUNCE_MS = 300;
+
 // ── Types ──────────────────────────────────────────────────────────────
 
 interface RosterAgentEntry {
@@ -1047,16 +1054,23 @@ function SelfLearningTab({
     }
   }, []);
 
-  // Optimize learnings — triggers LLM consolidation via the leader agent
+  // Optimize learnings — runs the LLM consolidation headlessly on the server
+  // (read raw entries → synthesize → write consolidated.md + consolidation.json)
+  // and reflects the result inline, with NO chat round-trip. If the server has
+  // no active model it degrades to the legacy chat-driven path.
   const runOptimize = useCallback(
     async (role: string) => {
       setOptimizing(true);
       setTeachFeedback(null);
       try {
         const data = (await sendRosterMessage('agent-roster.consolidate', { role })) as {
+          consolidated?: boolean;
+          emptySynthesis?: boolean;
           instruction?: string;
           leaderInstruction?: string;
           rawEntryCount?: number;
+          content?: string;
+          model?: string;
           error?: string;
         };
         if (data.error) throw new Error(data.error);
@@ -1064,9 +1078,38 @@ function SelfLearningTab({
           setTeachFeedback({ ok: false, msg: 'No raw entries to optimize yet.' });
           return;
         }
-        // Send the full instruction (with raw entries embedded) so the leader
-        // agent has the actual learning data to synthesize — the short
-        // leaderInstruction promises data it does not carry.
+
+        // ── Headless success: the server already synthesized + persisted. ──
+        if (data.consolidated) {
+          await onRefresh();
+          // Reconcile the visible document from the server; this supersedes any
+          // optimistic set of `data.content` (which would otherwise be dead work).
+          // Always reload — `loadConsolidated` self-guards via `setConsolidatedContent`,
+          // so gating on a possibly-stale `selectedRole` closure is unnecessary and
+          // could leave the freshly-optimized document out of sync.
+          await loadConsolidated(role);
+          setTeachFeedback({ ok: true, msg: 'Optimized. Consolidated knowledge updated.' });
+          toast.success(
+            data.model
+              ? `Learnings consolidated with ${data.model}.`
+              : 'Learnings consolidated.',
+          );
+          return;
+        }
+
+        // ── Empty synthesis: the model ran but produced nothing usable. The
+        // existing document is left untouched; surface a retryable message. ──
+        if (data.emptySynthesis) {
+          setTeachFeedback({
+            ok: false,
+            msg: 'The model returned an empty result. Nothing was changed — try again.',
+          });
+          toast.error('Optimization produced an empty result. Try again.');
+          return;
+        }
+
+        // ── Fallback: no active model on the server. Route the full
+        // instruction through the chat agent so the work still completes. ──
         const prompt = data.instruction;
         if (!prompt) throw new Error('No consolidation instruction generated');
         const chat = useChatStore.getState();
@@ -1076,8 +1119,11 @@ function SelfLearningTab({
         const ui = useUIStore.getState();
         ui.setSidebarOpen(false);
         ui.setCurrentView('chat');
-        setTeachFeedback({ ok: true, msg: 'Optimization sent to agent. Check chat for progress.' });
-        toast.info('Optimization sent. Refresh the roster after the agent finishes to see the consolidated result.');
+        setTeachFeedback({
+          ok: true,
+          msg: 'No active model on server — optimization sent to chat agent instead.',
+        });
+        toast.info('No active model on server. Optimization sent to the chat agent.');
       } catch (err) {
         setTeachFeedback({
           ok: false,
@@ -1088,11 +1134,13 @@ function SelfLearningTab({
         setOptimizing(false);
       }
     },
-    [],
+    [onRefresh, loadConsolidated],
   );
 
-  // Bulk optimize — collects all agents needing optimization and sends a
-  // single combined consolidation prompt to the leader agent.
+  // Bulk optimize — consolidates each agent headlessly on the server. Agents
+  // that the server could consolidate directly are done inline; only agents
+  // that fall back (no active model) are collected and routed through the chat
+  // agent as a single combined prompt.
   const runBulkOptimize = useCallback(
     async (roles: string[]) => {
       if (roles.length === 0) return;
@@ -1101,74 +1149,108 @@ function SelfLearningTab({
       try {
         // Serialize requests to avoid the per-type gate in sendRosterMessage
         // ("Roster request 'agent-roster.consolidate' superseded by new request").
-        // Each individual failure is caught and pushed as null so the rest
-        // of the batch is not lost.
-        const results: Array<{ role: string; instruction: string } | null> = [];
+        // Each individual failure is isolated so the rest of the batch survives.
+        const consolidatedRoles: string[] = [];
+        let skippedCount = 0;
         let failedCount = 0;
         let lastErrorMsg = '';
+        const fallback: Array<{ role: string; instruction: string }> = [];
         for (const r of roles) {
           try {
             const data = (await sendRosterMessage('agent-roster.consolidate', {
               role: r,
             })) as {
+              consolidated?: boolean;
+              emptySynthesis?: boolean;
               instruction?: string;
               rawEntryCount?: number;
               error?: string;
             };
-            if (data.error || !data.instruction) {
-              // Server error or missing instruction — count as a failure
+            if (data.error) {
               failedCount++;
-              lastErrorMsg = data.error || 'No consolidation instruction';
-              results.push(null);
+              lastErrorMsg = data.error;
+            } else if (data.consolidated) {
+              // Server synthesized + persisted this one directly.
+              consolidatedRoles.push(r);
             } else if (data.rawEntryCount === 0) {
-              // No entries to optimize — legitimate skip, not a failure
-              results.push(null);
+              // No entries to optimize — legitimate skip, not a failure.
+              skippedCount++;
+            } else if (data.emptySynthesis) {
+              // Model ran but produced nothing usable — count as a failure
+              // with a clear reason; the existing document is untouched.
+              failedCount++;
+              lastErrorMsg = 'Model returned an empty result';
+            } else if (data.instruction) {
+              // No active model on the server — needs the chat fallback.
+              fallback.push({ role: r, instruction: data.instruction });
             } else {
-              results.push({ role: r, instruction: data.instruction });
+              failedCount++;
+              lastErrorMsg = 'No consolidation produced';
             }
           } catch (err) {
             failedCount++;
-            const msg = err instanceof Error ? err.message : String(err);
-            lastErrorMsg = msg;
-            results.push(null);
+            lastErrorMsg = err instanceof Error ? err.message : String(err);
           }
         }
-        const valid = results.filter(
-          (r): r is { role: string; instruction: string } => r !== null,
-        );
-        if (valid.length === 0) {
-          const diagnostic =
-            failedCount > 0
-              ? `Bulk consolidate failed for ${failedCount} of ${roles.length} agent${roles.length > 1 ? 's' : ''}.${lastErrorMsg ? ` Last error: ${lastErrorMsg}` : ''}`
+
+        // No explicit roster refresh here: each server-side consolidation emits
+        // an `agent-roster.updated` broadcast, and the debounced listener
+        // coalesces the whole burst into a single `loadRoster()` — avoiding an
+        // N+1 reload. The broadcast refreshes the roster *list*, but not the
+        // currently-open consolidated *document*, so reload that explicitly for
+        // the selected role if it was one of the consolidated ones — parity with
+        // the single-role `runOptimize` path.
+        if (selectedRole && consolidatedRoles.includes(selectedRole)) {
+          await loadConsolidated(selectedRole);
+        }
+
+        // Route only the fallback agents through chat, as one combined prompt.
+        if (fallback.length > 0) {
+          const prompt =
+            `Optimize the learned data for ${fallback.length} agent${fallback.length > 1 ? 's' : ''}. ` +
+            `For each agent below, read its raw learned entries, synthesize them into a single narrowly-scoped ` +
+            `document preserving every fact, and save the result to its consolidated.md file.\n\n` +
+            fallback.map((r) => `## Agent: ${r.role}\n\n${r.instruction}`).join('\n\n---\n\n');
+          const chat = useChatStore.getState();
+          chat.addMessage({ role: 'user', content: prompt });
+          chat.setLoading(true);
+          getWSClient().sendMessage(prompt);
+          const ui = useUIStore.getState();
+          ui.setSidebarOpen(false);
+          ui.setCurrentView('chat');
+        }
+
+        // Summarize the batch outcome.
+        if (consolidatedRoles.length === 0 && fallback.length === 0) {
+          if (failedCount > 0) {
+            const skipSuffix = skippedCount > 0 ? ` ${skippedCount} skipped.` : '';
+            const diagnostic = `Bulk consolidate failed for ${failedCount} of ${roles.length} agent${roles.length > 1 ? 's' : ''}.${lastErrorMsg ? ` Last error: ${lastErrorMsg}` : ''}${skipSuffix}`;
+            setTeachFeedback({ ok: false, msg: diagnostic });
+            return;
+          }
+          // Skipped-only outcome (no entries to optimize) is a normal no-op,
+          // not a failure — report it as info.
+          const info =
+            skippedCount > 0
+              ? `Bulk optimize: ${skippedCount} skipped (no entries to optimize).`
               : 'No agents had optimizable entries.';
-          setTeachFeedback({ ok: false, msg: diagnostic });
+          setTeachFeedback({ ok: true, msg: info });
+          toast.info(info, 6000);
           return;
         }
-        const prompt =
-          `Optimize the learned data for ${valid.length} agent${valid.length > 1 ? 's' : ''} that exceed the soft limit. ` +
-          `For each agent below, read its raw learned entries, synthesize them into a single narrowly-scoped ` +
-          `document preserving every fact, and save the result to its consolidated.md file.\n\n` +
-          valid
-            .map(
-              (r) =>
-                `## Agent: ${r.role}\n\n${r.instruction}`,
-            )
-            .join('\n\n---\n\n');
-        const chat = useChatStore.getState();
-        chat.addMessage({ role: 'user', content: prompt });
-        chat.setLoading(true);
-        getWSClient().sendMessage(prompt);
-        const ui = useUIStore.getState();
-        ui.setSidebarOpen(false);
-        ui.setCurrentView('chat');
-        setTeachFeedback({
-          ok: true,
-          msg: `Bulk optimization sent for ${valid.length} agent${valid.length > 1 ? 's' : ''}. Check chat for progress.`,
-        });
-        toast.success(
-          `Bulk optimization sent for ${valid.length} agent${valid.length > 1 ? 's' : ''}.\nRefresh the roster after the agent finishes to see consolidated results.`,
-          6000,
-        );
+
+        const parts: string[] = [];
+        if (consolidatedRoles.length > 0) parts.push(`${consolidatedRoles.length} consolidated`);
+        if (fallback.length > 0) parts.push(`${fallback.length} sent to chat`);
+        if (skippedCount > 0) parts.push(`${skippedCount} skipped`);
+        if (failedCount > 0) parts.push(`${failedCount} failed`);
+        const summary = `Bulk optimize: ${parts.join(', ')}.`;
+        setTeachFeedback({ ok: failedCount === 0, msg: summary });
+        if (consolidatedRoles.length > 0 && fallback.length === 0) {
+          toast.success(summary, 6000);
+        } else {
+          toast.info(summary, 6000);
+        }
       } catch (err) {
         setTeachFeedback({
           ok: false,
@@ -1179,7 +1261,7 @@ function SelfLearningTab({
         setBulkOptimizing(false);
       }
     },
-    [],
+    [selectedRole, loadConsolidated],
   );
 
   if (populated.length === 0) {
@@ -2151,6 +2233,25 @@ export function AgentRosterView({ className }: { className?: string | undefined 
 
   useEffect(() => {
     loadRoster();
+  }, [loadRoster]);
+
+  // Refresh the roster when another client (or a background headless
+  // consolidation) reports an update — no manual reload needed. Bursts of
+  // updates (e.g. a bulk optimize that emits one event per role) are coalesced
+  // into a single reload via a short trailing debounce.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsub = getWSClient().on('agent-roster.updated', () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        loadRoster();
+      }, ROSTER_UPDATE_DEBOUNCE_MS);
+    });
+    return () => {
+      if (timer) clearTimeout(timer);
+      unsub();
+    };
   }, [loadRoster]);
 
   return (

--- a/packages/webui/tests/components/agent-roster-view.test.tsx
+++ b/packages/webui/tests/components/agent-roster-view.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock the external seams the component touches ──────────────────────────
+// `sendRosterMessage` is the single WS round-trip helper. `loadConsolidated`
+// (the unit under test) is an internal useCallback whose only observable effect
+// is a `sendRosterMessage('agent-roster.read-consolidated', { role })` call, so
+// we assert against this mock. `vi.hoisted` makes the spy available inside the
+// hoisted `vi.mock` factory.
+const { sendRosterMessage } = vi.hoisted(() => ({ sendRosterMessage: vi.fn() }));
+
+vi.mock('@/lib/roster-ws', () => ({
+  sendRosterMessage: (...args: unknown[]) => sendRosterMessage(...args),
+}));
+
+vi.mock('@/lib/ws-client', () => ({
+  getWSClient: () => ({
+    on: () => () => {},
+    sendMessage: () => {},
+  }),
+}));
+
+vi.mock('@/components/Toaster', () => ({
+  toast: { success: () => {}, error: () => {}, info: () => {} },
+}));
+
+// Stores are used as selector hooks and via `.getState()`; provide inert stubs.
+// The factory is self-contained (no top-level references) to satisfy hoisting.
+vi.mock('@/stores', () => {
+  const makeStore = (state: Record<string, unknown>) => {
+    const fn = (selector?: (s: Record<string, unknown>) => unknown) =>
+      selector ? selector(state) : state;
+    (fn as unknown as { getState: () => Record<string, unknown> }).getState = () => state;
+    return fn;
+  };
+  return {
+    useFleetStore: makeStore({ agents: [], leaderId: null, clearFinishedAgents: () => {} }),
+    useUIStore: makeStore({ setSidebarOpen: () => {}, setCurrentView: () => {} }),
+    useChatStore: makeStore({ addMessage: () => {}, setLoading: () => {} }),
+  };
+});
+
+import { AgentRosterView } from '@/components/AgentRosterView';
+
+const ROLE = 'executor';
+
+function makeStat(role: string) {
+  return {
+    role,
+    exists: true,
+    entryCount: 40,
+    totalBytes: 9000,
+    lastCapture: null,
+    cooldownRemainingMs: 0,
+    sessionCaptureCount: 0,
+    needsSummarization: true, // gates the "Optimize All" bulk button
+    hasIdentity: false,
+    hasConfig: false,
+    hasKnowledge: true,
+    learningEnabled: true,
+    lifetimeCaptureCount: 40,
+    lastCaptureSource: 'automatic' as const,
+    isConsolidated: false,
+  };
+}
+
+describe('AgentRosterView — bulk optimize refreshes the selected consolidated doc', () => {
+  beforeEach(() => {
+    sendRosterMessage.mockReset();
+    sendRosterMessage.mockImplementation(async (type: string) => {
+      switch (type) {
+        case 'agent-roster.list':
+          return { roles: [ROLE], stats: [makeStat(ROLE)], catalog: [] };
+        case 'agent-roster.consolidate':
+          // Server synthesized + persisted this role headlessly.
+          return { consolidated: true, model: 'test-model', rawEntryCount: 40 };
+        case 'agent-roster.read-consolidated':
+          return { content: '## Consolidated', isConsolidated: true };
+        default:
+          return {};
+      }
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+  });
+
+  it('calls loadConsolidated(selectedRole) exactly once after a bulk optimize that includes it', async () => {
+    render(<AgentRosterView />);
+
+    // Wait for the initial roster load (agent-roster.list) to seed stats.
+    await waitFor(() => {
+      expect(sendRosterMessage).toHaveBeenCalledWith('agent-roster.list', {});
+    });
+
+    // Navigate to the Self-Learning tab.
+    fireEvent.click(screen.getByText('Self-Learning'));
+
+    // The "needs optimization" banner + "review →" appear once stats with
+    // needsSummarization are present. Click "review →" to set selectedRole.
+    const reviewBtn = await screen.findByText('review →');
+    fireEvent.click(reviewBtn);
+
+    // Click "Optimize All (1)" to run the bulk consolidation.
+    const bulkBtn = await screen.findByText(/Optimize All/);
+    fireEvent.click(bulkBtn);
+
+    // After the bulk run, the selected role's consolidated document must be
+    // reloaded exactly once via agent-roster.read-consolidated.
+    await waitFor(() => {
+      const readConsolidatedCalls = sendRosterMessage.mock.calls.filter(
+        (c) => c[0] === 'agent-roster.read-consolidated',
+      );
+      expect(readConsolidatedCalls.length).toBe(1);
+      expect(readConsolidatedCalls[0][1]).toEqual({ role: ROLE });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Runs the Agent Roster **Optimize** button's LLM consolidation directly on the server instead of routing it through the chat loop, then keeps every connected client's roster in sync via a broadcast.

## Changes

**Server (`packages/webui-server`)**
- `agent-roster.consolidate` now synthesizes headlessly via the active provider (`getLlm`) and writes `consolidated.md` + `consolidation.json`.
- Graceful fallback to the instruction path when no model is available.
- Structured error payloads for synthesis / persist / empty-result failures, plus a timeout-normalized abort.
- Emits an `agent-roster.updated` broadcast to all connected clients after a successful consolidation.
- `getLlm` + `broadcast` wired through both the standalone (`message-dispatcher`) and embedded (`embedded-message-router`) routers.

**Client (`packages/webui`)**
- `runOptimize` completes inline (no chat round-trip) and handles the `emptySynthesis` and no-model cases.
- `runBulkOptimize` reports a proper batch summary and reloads the selected role's consolidated document (parity with `runOptimize`).
- A debounced `agent-roster.updated` listener coalesces bulk update bursts into a single `loadRoster()`.

**Tests**
- Server handler coverage: headless success, broadcast, fallback, empty-entries, empty-synthesis, provider-error.
- First `packages/webui` component test (RTL + jsdom) asserting the bulk-optimize consolidated-doc refresh fires exactly once for the selected role.

## Verification

- `webui` + `webui-server` `tsc --noEmit` exit 0
- Biome lint 0 errors / 0 warnings
- `agent-roster-handlers` 18/18, webui component test 1/1
- `git diff --check` clean; pre-commit corruption/lint-console/import guards all passed

## Notes

- 6 files changed, 797 insertions(+), 64 deletions(-).
- Opened as a PR so the required **CI Gate** runs before merge (direct pushes to `main` are branch-protected).
