### PR TITLE
chore(release): bump version to 0.296.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.296.0] — 2026-07-25
+
 ### Added
 
 - **Chronicle: derived metrics store.** A disposable SQLite projection (`<chronicle>/metrics.db`, node:sqlite/WAL) turns the raw journal into queryable aggregates — `provider_daily` (per provider×model×day attempt/success/failure/retry/fallback counts, tokens, duration stats), `task_outcomes` (status, timing, retries, board/run/session lineage, files touched), `file_lineage` (each mutation with full session/agent/task/board/tool/model attribution), and `token_cost` (latest cumulative cost per scope). Ingest is incremental via per-partition byte offsets, so raw partitions can be purged by retention without losing metrics. `wstack chronicle metrics [providers|tasks|files|summary]` and the `chronicle.metrics` WebUI message expose it; the Coding Intelligence dashboard gains Model-reliability and Task-outcomes strips fed from the store instead of re-scanning the journal.
 - **Chronicle: task/kanban file lineage.** `file.event` mutations are now persisted with `scope.kanbanBoardId` and task attribution, and `kanban.*` events join the durable coding-signal set, so "which session, board, and task caused this file change" is answerable directly from scope filters.
 - **Chronicle: journal retention.** `chronicle.retentionDays` (default 30, floored at 7, `0` disables) arms the existing checkpoint-safe auto-purge, which previously had no configuration surface.
+- **CLI: dedicated session-registry wiring module.** Session-registry setup was extracted from `cli-main.ts` into `./wiring/session-registry.ts` (`setupSessionRegistry`) for a clearer startup composition. (`99e6d83aa`)
+- **Agent roster: headless consolidation.** Role learning entries can be consolidated headlessly via an LLM synthesis pass, with live WebSocket broadcast and a debounced roster refresh. (`29ebd6a5d`)
+- **Config: dedicated config-type modules.** Config types were split into focused files, and new `ModelRuntimeConfig` exports were added. (`60dca9df1`)
+- **Goal: duration-realism assessor.** A new assessor evaluates whether a goal's estimated duration is realistic. (`d469c5483`)
+- **Goal WS handler: chimera auto-review.** Completed goal tasks now trigger an automatic chimera review pass. (`3e19e7276`)
+- **Docs: full README rewrite** covering architecture, scale, and comparison sections. (`4fc05b70d`)
 
 ### Changed
 
 - **Directory rules: explicit empty tool allowlists now deny all tools.** A rule in `.wrongstack/directory-rules.json` with `allowOnlyTools: []` is treated as an intentional deny-all constraint. Remove `allowOnlyTools` from a rule to impose no allowlist constraint; use a non-empty list to permit only the named tools.
 - **Kanban decomposition: empty command markers remain manual checks.** Success criteria containing only a dollar-sign marker, `run:`, `verify:`, or `cmd:` (with optional whitespace) are no longer classified as executable command checks; command markers must be followed by command text.
+- **WebUI i18n: full SettingsPanel locale parity.** All SettingsPanel locale files were restructured to 456/456 key parity, Spanish features/subtitle and German locale strings were translated, and `PluginToggleList` was wired into the context tab. (`bc020d035`, `d232e53c6`, `dbd0ecf22`, `215b9e3f9`, `fa5bfce52`)
 
 ### Fixed
 
@@ -29,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WebUI Chimera toggle defaults to disabled.** `context-meta.ts` now uses `chimeraExt?.['enabled'] === true` (strict opt-in) instead of `!== false`, matching the plugin's `defaultState: 'inactive'`. (#307)
 - **`--desktop` no longer crashes with `ERR_INVALID_URL`.** `rendererIndexPath()` now returns a `file://` URL (via `new URL(...).href`) instead of a bare filesystem path, fixing Electron's `loadURL()` requirement. (#293)
 - **TUI long-prompt input supports vertical scrolling.** Added `MAX_VISIBLE_ROWS=10` cap with scroll-offset tracking that auto-follows cursor position, a scroll indicator in the bottom frame, and Home/End navigation support. (#295)
+- **WebUI-server prefs validation.** Added missing display-only prefs to the validation whitelist, fixed `modelAvailabilitySchedule` typing, moved `groupToolCalls` / `showThinkingLogs` into `BOOLEAN_PREF_KEYS`, and moved `modelAvailabilitySchedule` into `ARRAY_PREF_KEYS`. (`b2a03f2fc`, `98464199d`)
+- **WebUI settings tabs.** Fixed nested `TabsContent` in `BasicSettingsTabs`, corrected accent-color i18n keys, and removed an unused `TabsContent` import. (`dbd0ecf22`, `215b9e3f9`)
+- **Tests: WebSocket handshake in `handleMessage` calls.** `handleMessage` calls now pass a `WebSocket`, with protocol counts and mock syntax updated to match. (`e6716108b`)
 
 ## [0.295.0] — 2026-07-23
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/desktop",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack Desktop - Electron shell for managing multiple local WrongStack runtimes.",
   "keywords": [

--- a/apps/wrongstack/package.json
+++ b/apps/wrongstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wrongstack",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack — terminal AI coding agent. Installs `wrongstack` and `wstack` binaries (re-export of @wrongstack/cli).",
   "keywords": [

--- a/architecture/core-public-api-snapshot.json
+++ b/architecture/core-public-api-snapshot.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "package": "@wrongstack/core",
-  "packageVersion": "0.295.3",
+  "packageVersion": "0.296.0",
   "policy": "Root is compatibility-only; new imports use owned domain subpaths.",
   "subpaths": [
     {
@@ -1145,8 +1145,8 @@
       "directory": "storage",
       "classification": "storage/repository implementation",
       "intendedOwner": "repositories over dependency-free persistence",
-      "sourceFiles": 43,
-      "sourceLines": 14927
+      "sourceFiles": 59,
+      "sourceLines": 16226
     },
     {
       "directory": "tasking",
@@ -1166,8 +1166,8 @@
       "directory": "types",
       "classification": "agent-domain contract",
       "intendedOwner": "Core type-only subpaths",
-      "sourceFiles": 55,
-      "sourceLines": 9025
+      "sourceFiles": 63,
+      "sourceLines": 9060
     },
     {
       "directory": "utils",

--- a/architecture/core-public-api-usage.json
+++ b/architecture/core-public-api-usage.json
@@ -74,8 +74,8 @@
       "runtimeOrMixed": 36
     },
     "@wrongstack/core/kernel": {
-      "files": 157,
-      "typeOnly": 77,
+      "files": 158,
+      "typeOnly": 78,
       "runtimeOrMixed": 96
     },
     "@wrongstack/core/kernel/events.js": {
@@ -126,7 +126,7 @@
     "@wrongstack/core/storage": {
       "files": 78,
       "typeOnly": 24,
-      "runtimeOrMixed": 87
+      "runtimeOrMixed": 86
     },
     "@wrongstack/core/tasking": {
       "files": 27,
@@ -139,9 +139,9 @@
       "runtimeOrMixed": 3
     },
     "@wrongstack/core/types": {
-      "files": 718,
-      "typeOnly": 691,
-      "runtimeOrMixed": 195
+      "files": 728,
+      "typeOnly": 701,
+      "runtimeOrMixed": 196
     },
     "@wrongstack/core/types/multi-agent.js": {
       "files": 2,
@@ -159,9 +159,9 @@
       "runtimeOrMixed": 1
     },
     "@wrongstack/core/utils": {
-      "files": 403,
+      "files": 413,
       "typeOnly": 36,
-      "runtimeOrMixed": 432
+      "runtimeOrMixed": 443
     },
     "@wrongstack/core/utils/error": {
       "files": 4,
@@ -3673,6 +3673,12 @@
     },
     {
       "specifier": "@wrongstack/core/kernel",
+      "file": "packages/cli/src/wiring/session-registry.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/kernel",
       "file": "packages/cli/src/wiring/session.ts",
       "typeOnly": 0,
       "runtimeOrMixed": 1
@@ -5827,12 +5833,6 @@
     },
     {
       "specifier": "@wrongstack/core/storage",
-      "file": "packages/cli/src/cli-main.ts",
-      "typeOnly": 0,
-      "runtimeOrMixed": 2
-    },
-    {
-      "specifier": "@wrongstack/core/storage",
       "file": "packages/cli/src/cli-recovery-prompt.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 0
@@ -5950,6 +5950,12 @@
       "file": "packages/cli/src/wiring/runtime-controller-deps.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/storage",
+      "file": "packages/cli/src/wiring/session-registry.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
     },
     {
       "specifier": "@wrongstack/core/storage",
@@ -6788,6 +6794,60 @@
     {
       "specifier": "@wrongstack/core/types",
       "file": "packages/cli/src/picker.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/codex.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/live-model-runner.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/live-provider-runner.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/live.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/local-presets.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/model-selection.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/numbered-model.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/numbered-provider.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/provider-list.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 0
     },
@@ -10261,6 +10321,12 @@
     },
     {
       "specifier": "@wrongstack/core/types",
+      "file": "packages/webui-server/src/server/agent-roster-handlers.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/types",
       "file": "packages/webui-server/src/server/backend-services.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 3
@@ -10693,7 +10759,7 @@
     },
     {
       "specifier": "@wrongstack/core/types",
-      "file": "packages/webui/src/types.ts",
+      "file": "packages/webui/src/types/protocol-core.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 0
     },
@@ -11320,6 +11386,66 @@
       "file": "packages/cli/src/picker.ts",
       "typeOnly": 0,
       "runtimeOrMixed": 3
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/codex.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/config-save.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 2
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/frame.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/live-model-runner.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/live-provider-runner.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/live.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/model-selection.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/numbered-model.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/numbered-provider.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/provider-list.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
     },
     {
       "specifier": "@wrongstack/core/utils",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wrongstack-monorepo",
   "private": true,
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed",

--- a/packages/acp/package.json
+++ b/packages/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/acp",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "ACP (Agent Client Protocol) integration for WrongStack — client + agent support",
   "keywords": [

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/bench",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "Model-independent agentic benchmark harness for WrongStack (Aider polyglot + SWE-bench Verified) with deterministic graders and harness fingerprinting.",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/cli",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack CLI — terminal AI coding agent with provider catalog from models.dev. Provides `wrongstack` and `wstack` binaries.",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/core",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack core: kernel, types, defaults, and shared utilities for the WrongStack CLI agent.",
   "repository": {

--- a/packages/kanban/package.json
+++ b/packages/kanban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/kanban",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack kanban board manager — standalone package extracted from @wrongstack/core. Provides the deterministic file-based multi-kanban data model with CRUD, assignment, recovery, and queue health monitoring.",
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/mcp",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack Model Context Protocol client and registry: stdio, SSE, and streamable HTTP transports.",
   "repository": {

--- a/packages/persistence/package.json
+++ b/packages/persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/persistence",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "Dependency-free filesystem persistence primitives shared across WrongStack packages.",
   "repository": {

--- a/packages/plug-lsp/package.json
+++ b/packages/plug-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/plug-lsp",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack plugin that exposes Language Server Protocol tools.",
   "repository": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/plugins",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "description": "Official WrongStack collection of focused plugins for code quality, security, observability, planning, and agent coordination",
   "license": "MIT",
   "author": "ECOSTACK TECHNOLOGY OÜ",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/providers",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack LLM provider adapters (Anthropic, OpenAI, Google) built on declarative WireFormatConfig.",
   "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/runtime",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack default runtime implementations and host-level composition helpers built on @wrongstack/core.",
   "repository": {

--- a/packages/sage/package.json
+++ b/packages/sage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/sage",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack SAGE: project-local SQLite memory, graph-ready anchors, retrieval, and hygiene primitives.",
   "repository": {

--- a/packages/sdd/package.json
+++ b/packages/sdd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/sdd",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack Spec-Driven Development engine — standalone package extracted from @wrongstack/core. Task graph generation, tracking, execution, lifecycle management, and AI-driven spec building for SDD workflows.",
   "repository": {

--- a/packages/security-scanner/package.json
+++ b/packages/security-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/security-scanner",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack security scanner — standalone package extracted from @wrongstack/core. Tech-stack detector, secret scanner, report generator, and interactive slash-command for on-demand security scans.",
   "repository": {

--- a/packages/simpleui/package.json
+++ b/packages/simpleui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/simpleui",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "A deliberately minimal WrongStack browser chat surface.",
   "type": "module",

--- a/packages/techstack/package.json
+++ b/packages/techstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/techstack",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack TechStack — cross-language dependency intelligence for the active target project: discover, inventory, enrich, analyze, and report.",
   "repository": {

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/telegram",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack plugin — Telegram bridge: send messages, receive prompts, get notified.",
   "repository": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/tools",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack built-in tools: read/write/edit, bash/exec, grep/glob, git, fetch, test, lint, and more.",
   "repository": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/tui",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack terminal UI: Ink-based interactive renderer with history, pickers, and slash menus.",
   "repository": {

--- a/packages/webui-hq/package.json
+++ b/packages/webui-hq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/webui-hq",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "HQ Command Center dashboard — offline React app for the cross-machine coordination surface (port 3499).",
   "type": "module",

--- a/packages/webui-server/package.json
+++ b/packages/webui-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/webui-server",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "WrongStack WebUI HTTP/WebSocket server module — extracted from @wrongstack/webui in PR #243/244 to remove the CLI -> @wrongstack/webui/server cross-package edge (audit §3.1.1). Pure backend: HTTP routes, WebSocket handlers, MCP tool wrappers, HTML serving. The web frontend lives in @wrongstack/webui; this package is the standalone server it can run on.",
   "keywords": [

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrongstack/webui",
-  "version": "0.295.3",
+  "version": "0.296.0",
   "license": "MIT",
   "description": "Browser-based WebUI for WrongStack — React + Vite frontend. The WebSocket backend lives in the separate @wrongstack/webui-server package (extracted in PR #018b to remove the CLI -> @wrongstack/webui/server cross-package edge).",
   "keywords": [

--- a/website/index.html
+++ b/website/index.html
@@ -39,8 +39,8 @@
         "operatingSystem": "macOS, Linux, Windows",
         "description": "A free and open-source terminal-native AI coding agent with autonomous goals, multi-agent fleets, 58 built-in tools, 73 managed plugins, 25 bundled skills, 92 documented slash commands, six interfaces and explicit permission control.",
         "url": "https://wrongstack.com",
-        "softwareVersion": "0.295.3",
-        "dateModified": "2026-07-23",
+        "softwareVersion": "0.296.0",
+        "dateModified": "2026-07-25",
         "license": "https://opensource.org/licenses/MIT",
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
         "codeRepository": "https://github.com/WrongStack/WrongStack"

--- a/website/src/lib/utils.ts
+++ b/website/src/lib/utils.ts
@@ -12,7 +12,7 @@ export function cn(...inputs: ClassValue[]) {
    ========================================================================= */
 
 export const META = {
-  version: '0.295.3',
+  version: '0.296.0',
   repo: 'https://github.com/WrongStack/WrongStack',
   npm: 'wrongstack',
   node: '22',
@@ -296,9 +296,22 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.296.0',
+    date: '2026-07-25',
+    latest: true,
+    tagline: 'Chronicle metrics store, headless roster consolidation, and cleaner CLI startup wiring',
+    highlights: [
+      'Chronicle gains a disposable SQLite metrics store (provider reliability, task outcomes, file lineage, token cost) with incremental ingest, journal retention (chronicle.retentionDays), and task/kanban file-lineage attribution',
+      'Agent roster supports headless LLM consolidation of role learning entries with live WebSocket broadcast and debounced refresh',
+      'CLI startup is cleaner: session-registry setup extracted into a dedicated wiring module, and config types split into focused files with new ModelRuntimeConfig exports',
+      'Goal engine adds a duration-realism assessor and chimera auto-review on completed tasks',
+      'WebUI SettingsPanel reaches full 456/456 locale parity with Spanish and German translations and PluginToggleList wired into the context tab',
+      'Fixes: WebUI-server prefs validation whitelist and typing, nested settings tabs, and WebSocket handshake in handleMessage tests',
+    ],
+  },
+  {
     version: '0.295.0',
     date: '2026-07-23',
-    latest: true,
     tagline: 'Stable project identity, shared HQ Kanban, replayable Brain decisions, and indexed SAGE',
     highlights: [
       'A committed .wrongstack/project.json proj_<ULID> keeps project identity stable across clones, worktrees, forks, and machines, with explicit id/init/rekey lifecycle commands',


### PR DESCRIPTION
## Release 0.296.0

Bumps the monorepo version from `0.295.3` to `0.296.0` (minor) and reconciles all version + changelog surfaces.

### Changes
- **Version bump** across all 24 workspace `package.json` files (root + `packages/*` + `apps/*`) via `scripts/bump-version.mjs minor`.
- **`CHANGELOG.md`**: cut the accumulated `[Unreleased]` entries into `## [0.296.0] — 2026-07-25` (Keep a Changelog format); empty `[Unreleased]` header retained.
- **Website surfaces** the bump script does not fully cover:
  - `website/src/lib/utils.ts`: new `0.296.0` changelog entry (`latest: true`), prior `0.295.0` demoted.
  - `website/index.html`: JSON-LD `dateModified` refreshed to `2026-07-25`.

### Highlights
- Chronicle disposable SQLite metrics store, journal retention, task/kanban file lineage.
- Agent roster headless LLM consolidation with live broadcast + debounced refresh.
- CLI startup: session-registry wiring extracted; config types split; `ModelRuntimeConfig` exports.
- Goal engine: duration-realism assessor + chimera auto-review on completed tasks.
- WebUI SettingsPanel full 456/456 locale parity (Spanish + German).
- Fixes: WebUI-server prefs validation/typing, nested settings tabs, WebSocket handshake in `handleMessage` tests.

### Verification
- `pnpm release:check` — passed (audit, build, catalog/manifest/contract checks, architecture sync, typecheck across 25 projects, full coverage suite).
- `pnpm release:dry` — all publishable packages pack cleanly at `0.296.0`.

The required **CI Gate** will run automatically on this PR before merge.
