### PR TITLE
fix(core): break type-module cycle in config types

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,3 +1,4 @@
+export * from './config/fleet-chat.js';
 export * from './config/runtime.js';
 export * from './config/context.js';
 export * from './config/tools.js';

--- a/packages/core/src/types/config/autonomy.ts
+++ b/packages/core/src/types/config/autonomy.ts
@@ -1,4 +1,4 @@
-import type { FleetChatVerbosity } from './runtime.js';
+import type { FleetChatVerbosity } from './fleet-chat.js';
 
 export interface AutonomyConfig {
   /** Default autonomy mode at startup. Default: "auto". */

--- a/packages/core/src/types/config/fleet-chat.ts
+++ b/packages/core/src/types/config/fleet-chat.ts
@@ -1,0 +1,28 @@
+/**
+ * Verbosity of fleet/subagent activity streamed into the main TUI chat.
+ * See {@link AutonomyConfig.fleetChatVerbosity}.
+ *
+ * This is a dependency-free leaf module: it intentionally does NOT import
+ * `AutonomyConfig` so that both `autonomy.ts` and `runtime.ts` can depend on
+ * it without creating a type-level import cycle.
+ */
+export type FleetChatVerbosity = 'off' | 'full';
+
+export const FLEET_CHAT_VERBOSITY_VALUES: readonly FleetChatVerbosity[] = ['off', 'full'];
+
+/**
+ * Resolve the effective fleet-chat verbosity from autonomy config.
+ * An explicit `fleetChatVerbosity` wins; absence means 'off'.
+ *
+ * Accepts a minimal structural shape rather than `Pick<AutonomyConfig, ...>`
+ * to keep this module free of any `AutonomyConfig` import (cycle-safe).
+ */
+export function resolveFleetChatVerbosity(
+  autonomy?: { fleetChatVerbosity?: FleetChatVerbosity | undefined },
+): FleetChatVerbosity {
+  const explicit = autonomy?.fleetChatVerbosity;
+  if (explicit && (FLEET_CHAT_VERBOSITY_VALUES as readonly string[]).includes(explicit)) {
+    return explicit;
+  }
+  return 'off';
+}

--- a/packages/core/src/types/config/runtime.ts
+++ b/packages/core/src/types/config/runtime.ts
@@ -1,5 +1,4 @@
 import type { CacheTtl, ReasoningEffort } from '../provider.js';
-import type { AutonomyConfig } from './autonomy.js';
 
 export interface ModelRuntimeReasoningConfig {
   /**
@@ -174,27 +173,10 @@ export function resolveTokenSavingTier(
   return normalizeTokenSavingTier(val);
 }
 
-/**
- * Verbosity of fleet/subagent activity streamed into the main TUI chat.
- * See {@link AutonomyConfig.fleetChatVerbosity}.
- */
-export type FleetChatVerbosity = 'off' | 'full';
-
-export const FLEET_CHAT_VERBOSITY_VALUES: readonly FleetChatVerbosity[] = ['off', 'full'];
-
-/**
- * Resolve the effective fleet-chat verbosity from autonomy config.
- * An explicit `fleetChatVerbosity` wins; absence means 'off'.
- */
-export function resolveFleetChatVerbosity(
-  autonomy?: Pick<AutonomyConfig, 'fleetChatVerbosity'>,
-): FleetChatVerbosity {
-  const explicit = autonomy?.fleetChatVerbosity;
-  if (explicit && (FLEET_CHAT_VERBOSITY_VALUES as readonly string[]).includes(explicit)) {
-    return explicit;
-  }
-  return 'off';
-}
+// FleetChatVerbosity, FLEET_CHAT_VERBOSITY_VALUES, and resolveFleetChatVerbosity
+// were moved to the dependency-free leaf module ./fleet-chat.ts to avoid a
+// type-level import cycle with ./autonomy.ts. They are surfaced through the
+// config barrel (../config.ts) which re-exports ./config/fleet-chat.js directly.
 
 export const DEFAULT_TUI_THINKING_WORD = 'thinking';
 export const MAX_TUI_THINKING_WORD_LENGTH = 16;


### PR DESCRIPTION
## Break type-module cycle in core config types

### Problem
Commit `60dca9df1` ("feat(config): extract config types to dedicated files") introduced a **type-level import cycle** between:
- `packages/core/src/types/config/autonomy.ts` — imported `type FleetChatVerbosity` from `./runtime.js`
- `packages/core/src/types/config/runtime.ts` — imported `type AutonomyConfig` from `./autonomy.js` (used only by `resolveFleetChatVerbosity`)

This raised the type-inclusive module-cycle count to **16** vs. the **15**-entry baseline in `architecture/exceptions.json`, so `check:architecture` reports **1 unexcepted module cycle** and fails CI. It currently blocks release PR #312 (0.296.0) from going green.

### Fix (break, not waive)
- New dependency-free leaf module `config/fleet-chat.ts` holds `FleetChatVerbosity`, `FLEET_CHAT_VERBOSITY_VALUES`, and `resolveFleetChatVerbosity`.
- `resolveFleetChatVerbosity` now takes a minimal structural param `{ fleetChatVerbosity?: FleetChatVerbosity }` instead of `Pick<AutonomyConfig, ...>`, so the leaf imports nothing from the config dir.
- `autonomy.ts` and `runtime.ts` both import `FleetChatVerbosity` from `fleet-chat.ts`; `runtime.ts` no longer imports `autonomy.ts`.
- The config barrel (`types/config.ts`) re-exports `./config/fleet-chat.js`, preserving the public surface (`FleetChatVerbosity`, `FLEET_CHAT_VERBOSITY_VALUES`, `resolveFleetChatVerbosity` remain exported from `@wrongstack/core`).

### Verification (isolated worktree off origin/main)
- `pnpm --filter @wrongstack/core typecheck` → **0 errors**
- Architecture health: type cycles **16 → 15**, **unexcepted 0**, no new cycles, no stale exceptions.

### Follow-up
Once merged, `release/0.296.0` (PR #312) can be rebased and its CI architecture check will pass.
