### PR TITLE
fix(ci): repair red base — build-before-typecheck, stale arch snapshots, TUI non-TTY guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Build first so cross-package type declarations exist. Several packages
+      # (e.g. @wrongstack/kanban) import workspace deps like
+      # @wrongstack/persistence whose `types` resolve to dist/*.d.ts, which do
+      # not exist until the producing package is built. Without this, tsc in a
+      # clean CI checkout fails with TS2307 "Cannot find module".
+      - name: Build workspace declarations
+        run: pnpm build
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+
       # Workspace typecheck, serially to avoid tsc buildinfo contention.
       # Matches the root package.json script exactly.
       # Each package's `typecheck` script covers BOTH its source tsconfig and

--- a/architecture/core-public-api-snapshot.json
+++ b/architecture/core-public-api-snapshot.json
@@ -1145,8 +1145,8 @@
       "directory": "storage",
       "classification": "storage/repository implementation",
       "intendedOwner": "repositories over dependency-free persistence",
-      "sourceFiles": 43,
-      "sourceLines": 14927
+      "sourceFiles": 59,
+      "sourceLines": 16226
     },
     {
       "directory": "tasking",
@@ -1166,8 +1166,8 @@
       "directory": "types",
       "classification": "agent-domain contract",
       "intendedOwner": "Core type-only subpaths",
-      "sourceFiles": 55,
-      "sourceLines": 9025
+      "sourceFiles": 63,
+      "sourceLines": 9060
     },
     {
       "directory": "utils",

--- a/architecture/core-public-api-usage.json
+++ b/architecture/core-public-api-usage.json
@@ -74,8 +74,8 @@
       "runtimeOrMixed": 36
     },
     "@wrongstack/core/kernel": {
-      "files": 157,
-      "typeOnly": 77,
+      "files": 158,
+      "typeOnly": 78,
       "runtimeOrMixed": 96
     },
     "@wrongstack/core/kernel/events.js": {
@@ -126,7 +126,7 @@
     "@wrongstack/core/storage": {
       "files": 78,
       "typeOnly": 24,
-      "runtimeOrMixed": 87
+      "runtimeOrMixed": 86
     },
     "@wrongstack/core/tasking": {
       "files": 27,
@@ -139,9 +139,9 @@
       "runtimeOrMixed": 3
     },
     "@wrongstack/core/types": {
-      "files": 718,
-      "typeOnly": 691,
-      "runtimeOrMixed": 195
+      "files": 728,
+      "typeOnly": 701,
+      "runtimeOrMixed": 196
     },
     "@wrongstack/core/types/multi-agent.js": {
       "files": 2,
@@ -159,9 +159,9 @@
       "runtimeOrMixed": 1
     },
     "@wrongstack/core/utils": {
-      "files": 403,
+      "files": 413,
       "typeOnly": 36,
-      "runtimeOrMixed": 432
+      "runtimeOrMixed": 443
     },
     "@wrongstack/core/utils/error": {
       "files": 4,
@@ -3673,6 +3673,12 @@
     },
     {
       "specifier": "@wrongstack/core/kernel",
+      "file": "packages/cli/src/wiring/session-registry.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/kernel",
       "file": "packages/cli/src/wiring/session.ts",
       "typeOnly": 0,
       "runtimeOrMixed": 1
@@ -5827,12 +5833,6 @@
     },
     {
       "specifier": "@wrongstack/core/storage",
-      "file": "packages/cli/src/cli-main.ts",
-      "typeOnly": 0,
-      "runtimeOrMixed": 2
-    },
-    {
-      "specifier": "@wrongstack/core/storage",
       "file": "packages/cli/src/cli-recovery-prompt.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 0
@@ -5950,6 +5950,12 @@
       "file": "packages/cli/src/wiring/runtime-controller-deps.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/storage",
+      "file": "packages/cli/src/wiring/session-registry.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
     },
     {
       "specifier": "@wrongstack/core/storage",
@@ -6788,6 +6794,60 @@
     {
       "specifier": "@wrongstack/core/types",
       "file": "packages/cli/src/picker.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/codex.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/live-model-runner.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/live-provider-runner.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/live.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/local-presets.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/model-selection.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/numbered-model.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/numbered-provider.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 0
+    },
+    {
+      "specifier": "@wrongstack/core/types",
+      "file": "packages/cli/src/picker/provider-list.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 0
     },
@@ -10261,6 +10321,12 @@
     },
     {
       "specifier": "@wrongstack/core/types",
+      "file": "packages/webui-server/src/server/agent-roster-handlers.ts",
+      "typeOnly": 1,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/types",
       "file": "packages/webui-server/src/server/backend-services.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 3
@@ -10693,7 +10759,7 @@
     },
     {
       "specifier": "@wrongstack/core/types",
-      "file": "packages/webui/src/types.ts",
+      "file": "packages/webui/src/types/protocol-core.ts",
       "typeOnly": 1,
       "runtimeOrMixed": 0
     },
@@ -11320,6 +11386,66 @@
       "file": "packages/cli/src/picker.ts",
       "typeOnly": 0,
       "runtimeOrMixed": 3
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/codex.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/config-save.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 2
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/frame.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/live-model-runner.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/live-provider-runner.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/live.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/model-selection.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/numbered-model.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/numbered-provider.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
+    },
+    {
+      "specifier": "@wrongstack/core/utils",
+      "file": "packages/cli/src/picker/provider-list.ts",
+      "typeOnly": 0,
+      "runtimeOrMixed": 1
     },
     {
       "specifier": "@wrongstack/core/utils",

--- a/architecture/hotspots.json
+++ b/architecture/hotspots.json
@@ -11,7 +11,7 @@
       "relativeImports": 10
     },
     "packages/cli/src/cli-main.ts": {
-      "lines": 1187,
+      "lines": 1120,
       "relativeImports": 44
     },
     "packages/cli/src/execution.ts": {
@@ -194,10 +194,6 @@
       "lines": 1555,
       "relativeImports": 6
     },
-    "packages/core/src/types/config.ts": {
-      "lines": 1902,
-      "relativeImports": 8
-    },
     "packages/core/src/utils/tool-output-serializer.ts": {
       "lines": 835,
       "relativeImports": 0
@@ -343,7 +339,7 @@
       "relativeImports": 4
     },
     "packages/webui/src/components/AgentRosterView.tsx": {
-      "lines": 2237,
+      "lines": 2338,
       "relativeImports": 0
     },
     "packages/webui/src/components/AgentsPage.tsx": {
@@ -436,10 +432,6 @@
     },
     "packages/webui/src/stores/viz-store.ts": {
       "lines": 878,
-      "relativeImports": 0
-    },
-    "packages/webui/src/types.ts": {
-      "lines": 3445,
       "relativeImports": 0
     },
     "packages/webui-server/src/server/collaboration-ws-handler.ts": {

--- a/packages/cli/src/boot.ts
+++ b/packages/cli/src/boot.ts
@@ -441,6 +441,23 @@ export async function boot(argv: string[]): Promise<BootContext | number> {
     }
   }
 
+  // Early TUI TTY guard. The Ink TUI (run-tui.ts) requires a TTY on both stdin
+  // and stdout and bails with exit 2 if either is piped. That guard runs late
+  // (from execution.ts), so on an unconfigured machine the "No provider or model
+  // configured" check below would fire first — both return 2, but a piped
+  // `--tui` would then emit the wrong message. Hoist the TTY check here so a
+  // non-interactive `--tui` always reports the interactive-terminal guidance
+  // regardless of provider/model config state (see tui-smoke CI job).
+  const wantsTui = flags['tui'] === true && flags['no-tui'] !== true;
+  if (wantsTui && (!process.stdout.isTTY || !process.stdin.isTTY)) {
+    writeErr(
+      'wstack: --tui requires an interactive terminal on both stdin and stdout.\n' +
+        '       Drop the flag (use the plain REPL) or run wstack directly without piping.\n',
+    );
+    await reader.close();
+    return 2;
+  }
+
   // Provider + model selection
   const providerFlag = typeof flags['provider'] === 'string' ? flags['provider'] : undefined;
   const modelFlag = typeof flags['model'] === 'string' ? flags['model'] : undefined;


### PR DESCRIPTION
origin/main was failing CI at the base, independent of any PR (PR #312 and
#313 showed identical failures). Three root causes:

1. TypeCheck job: `pnpm typecheck` ran without a prior build, so packages that
   import workspace deps via dist declarations (e.g. @wrongstack/kanban →
   @wrongstack/persistence, resolved through dist/*.d.ts) failed with TS2307
   "Cannot find module". Add a `pnpm build` step before `pnpm typecheck` in the
   TypeCheck job so cross-package declarations exist.

2. Architecture check: architecture/core-public-api-snapshot.json (+ usage) and
   hotspots.json were stale on main (API + hotspot changes merged without
   regenerating the baselines). Regenerate all three via
   `snapshot-core-public-api.mjs --write` and `check-architecture-health.mjs
   --write-hotspot-baseline`.

3. TUI smoke test: on an unconfigured machine (CI), the "No provider or model
   configured" guard fired before the TUI TTY guard — both exit 2, but the
   smoke test asserts the "interactive terminal" message, which was never
   emitted. Hoist an early --tui non-TTY guard into boot.ts (before the
   provider/model check) so a piped `--tui` always reports the TTY guidance
   regardless of config state.

Verified in an isolated worktree off origin/main:
- @wrongstack/kanban typecheck: 0 errors (after build)
- architecture health: no stale/hotspot errors (only the separate module cycle,
  fixed by PR #313, remains)
- TUI probe in an empty-config env: exit 2 + "interactive terminal" message,
  provider message suppressed

NOTE: the 1 remaining "unexcepted module cycle" is fixed by PR #313
(fix/config-type-cycle); it is intentionally NOT included here to avoid a
duplicate/conflicting change.
