### PR TITLE
fix(lint): resolve Biome errors in session-registry wiring + test

### DIFF
--- a/packages/cli/src/wiring/session-registry.ts
+++ b/packages/cli/src/wiring/session-registry.ts
@@ -29,7 +29,7 @@ export interface SetupSessionRegistryDeps {
 
 export interface SetupSessionRegistryResult {
   /** AgentStatusTracker when the dynamic import and setup succeeded, else undefined. */
-  tracker: any | undefined;
+  tracker: InstanceType<typeof import('@wrongstack/core/storage').AgentStatusTracker> | undefined;
 }
 
 export async function setupSessionRegistry(

--- a/packages/cli/tests/wiring-session-registry.test.ts
+++ b/packages/cli/tests/wiring-session-registry.test.ts
@@ -23,6 +23,7 @@ const t = vi.hoisted(() => {
   const createGracefulShutdownMock = vi.fn(() => ({ install: installMock }));
   const registerMock = vi.fn();
   const markClosingMock = vi.fn();
+  // biome-ignore lint/complexity/useArrowFunction: vi.fn constructor mocks must be function() so `new` works
   const getSessionRegistryMock = vi.fn(function () {
     return {
       register: registerMock,
@@ -31,11 +32,13 @@ const t = vi.hoisted(() => {
   });
   const startMock = vi.fn();
   const stopMock = vi.fn();
+  // biome-ignore lint/complexity/useArrowFunction: vi.fn constructor mocks must be function() so `new` works
   const AgentStatusTrackerMock = vi.fn(function () {
     return { start: startMock, stop: stopMock };
   });
   const notifyMock = vi.fn();
   const disposeMock = vi.fn();
+  // biome-ignore lint/complexity/useArrowFunction: vi.fn constructor mocks must be function() so `new` works
   const FleetNotifierMock = vi.fn(function () {
     return { notify: notifyMock, dispose: disposeMock };
   });
@@ -94,12 +97,15 @@ beforeEach(() => {
   // Re-apply constructor implementations (clearAllMocks resets call history
   // but not mockImplementation — without this, error-case tests that set
   // mockImplementation(() => { throw ... }) would pollute subsequent tests).
+  // biome-ignore lint/complexity/useArrowFunction: vi.fn constructor mocks must be function() so `new` works
   t.getSessionRegistryMock.mockImplementation(function () {
     return { register: t.registerMock, markClosing: t.markClosingMock };
   });
+  // biome-ignore lint/complexity/useArrowFunction: vi.fn constructor mocks must be function() so `new` works
   t.AgentStatusTrackerMock.mockImplementation(function () {
     return { start: t.startMock, stop: t.stopMock };
   });
+  // biome-ignore lint/complexity/useArrowFunction: vi.fn constructor mocks must be function() so `new` works
   t.FleetNotifierMock.mockImplementation(function () {
     return { notify: t.notifyMock, dispose: t.disposeMock };
   });


### PR DESCRIPTION
CI Lint (Biome) was red on files merged via #314/#315:

- packages/cli/src/wiring/session-registry.ts:32 (noExplicitAny):
  SetupSessionRegistryResult.tracker was `any`. Type it as
  InstanceType<typeof import('@wrongstack/core/storage').AgentStatusTracker>
  (type-position dynamic import, erased at runtime) so it carries the real
  tracker type without a runtime import.

- packages/cli/tests/wiring-session-registry.test.ts (useArrowFunction x6):
  The 3 vi.hoisted() constructor mocks (vi.fn(function(){})) and their 3
  beforeEach re-applications (mockImplementation(function(){})) MUST stay
  function expressions — arrow functions passed to vi.fn() cannot be called
  with `new`, which these mocks require. Suppress the (incorrect here)
  useArrowFunction suggestion with justified biome-ignore comments rather
  than applying the breaking auto-fix.

Verified: pnpm biome lint on both files clean (0 warnings), @wrongstack/cli
typecheck 0 errors.
