### PR TITLE
fix(ci): pin actions/cache to a valid v4 SHA in the E2E job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
 
       # Playwright browsers are cached to avoid re-downloading on every run.
       - name: Cache Playwright browsers
-        uses: actions/cache@d4323d4df104b026a6aa6f6dfbed53dea3b2dfa3 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
The E2E (Playwright) job pinned actions/cache@d4323d4df104b026a6aa6f6dfbed53dea3b2dfa3
(commented "# v4"), but that SHA does not exist in actions/cache — CI failed
setup with "Unable to resolve action actions/cache@d4323d4d..., unable to find
version". This is the sole broken action reference in ci.yml and blocked the
E2E job (and thus the CI Gate) on every PR.

Repin to actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830, the real
commit the v4 tag resolves to (verified via GitHub API
repos/actions/cache/git/refs/tags/v4). All other pinned actions in the file
already resolve correctly and are unchanged.
