### PR TITLE
fix(opencode-go): send x-opencode-session for deepseek-v4-flash routing

### DIFF
--- a/packages/providers/src/opencode-go.ts
+++ b/packages/providers/src/opencode-go.ts
@@ -35,6 +35,21 @@ const OPENCODE_GO_EFFORTS: Readonly<Record<string, ReadonlySet<ReasoningEffort>>
   'deepseek-v4-flash': new Set(['high', 'max']),
 };
 
+/** OpenCode Go routes some models (e.g. deepseek-v4-flash) via sticky session affinity. */
+function buildOpenCodeGoHeaders(stickySessionId: string): Record<string, string> {
+  return {
+    'x-opencode-session': stickySessionId,
+    'x-opencode-client': 'wrongstack',
+    'HTTP-Referer': 'https://opencode.ai/',
+    'X-Title': 'wrongstack',
+  };
+}
+
+function createOpenCodeGoStickySessionId(): string {
+  const suffix = crypto.randomUUID().replace(/-/g, '').slice(0, 22);
+  return `sess_${suffix}`;
+}
+
 export interface OpenCodeGoProviderOptions {
   apiKey: string;
   baseUrl?: string | undefined;
@@ -65,11 +80,16 @@ export class OpenCodeGoProvider implements Provider {
     this.id = opts.id ?? 'opencode-go';
     this.models = new Map((opts.models ?? []).map((model) => [model.id, model]));
     const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+    const stickySessionId = createOpenCodeGoStickySessionId();
+    const openCodeHeaders = {
+      ...buildOpenCodeGoHeaders(stickySessionId),
+      ...opts.headers,
+    };
     this.chat = new OpenCodeGoChatProvider({
       id: this.id,
       apiKey: opts.apiKey,
       baseUrl,
-      headers: opts.headers,
+      headers: openCodeHeaders,
       fetchImpl: opts.fetchImpl,
       // OpenCode Go's Zen chat-completions surface closes successful streams
       // without a `[DONE]` marker or a final `finish_reason` chunk. Tolerate
@@ -81,6 +101,7 @@ export class OpenCodeGoProvider implements Provider {
       id: this.id,
       apiKey: opts.apiKey,
       baseUrl,
+      headers: openCodeHeaders,
       fetchImpl: opts.fetchImpl,
     }, this.models);
   }
@@ -143,11 +164,23 @@ class OpenCodeGoChatProvider extends OpenAICompatibleProvider {
 }
 
 class OpenCodeGoMessagesProvider extends AnthropicProvider {
+  private readonly extraHeaders?: Record<string, string> | undefined;
+
   constructor(
-    opts: ConstructorParameters<typeof AnthropicProvider>[0],
+    opts: ConstructorParameters<typeof AnthropicProvider>[0] & {
+      headers?: Record<string, string> | undefined;
+    },
     private readonly models: ReadonlyMap<string, ModelsDevModel>,
   ) {
     super(opts);
+    this.extraHeaders = opts.headers;
+  }
+
+  protected override buildHeaders(req: Request): Record<string, string> {
+    return {
+      ...super.buildHeaders(req),
+      ...this.extraHeaders,
+    };
   }
 
   protected override buildBody(req: Request, ctx: BuildBodyContext): Record<string, unknown> {

--- a/packages/providers/tests/opencode-go.test.ts
+++ b/packages/providers/tests/opencode-go.test.ts
@@ -40,11 +40,15 @@ function sseFetch(events: string): typeof fetch {
 
 describe('OpenCodeGoProvider', () => {
   it('routes Chat Completions and Anthropic Messages models behind one provider', async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const calls: Array<{ url: string; body: Record<string, unknown>; headers: Record<string, string> }> = [];
     const fetchImpl = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const headers = Object.fromEntries(
+        Object.entries(init?.headers ?? {}).map(([k, v]) => [k.toLowerCase(), String(v)]),
+      );
       calls.push({
         url: String(input),
         body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+        headers,
       });
       return new Response('', { status: 200 });
     }) as never as typeof fetch;
@@ -55,6 +59,8 @@ describe('OpenCodeGoProvider', () => {
 
     expect(calls[0]?.url).toBe('https://opencode.ai/zen/go/v1/chat/completions');
     expect(calls[1]?.url).toBe('https://opencode.ai/zen/go/v1/messages');
+    expect(calls[0]?.headers['x-opencode-session']).toMatch(/^sess_/);
+    expect(calls[1]?.headers['x-opencode-session']).toBe(calls[0]?.headers['x-opencode-session']);
     expect(provider.id).toBe('opencode-go');
   });
 


### PR DESCRIPTION
## Summary

- OpenCode Go returns `Model is unavailable` for `deepseek-v4-flash` when clients omit `x-opencode-session`, while the OpenCode desktop app always sends it.
- WrongStack now mirrors the OpenCode client contract by attaching sticky session affinity headers on both OpenCode Go surfaces (chat-completions and Anthropic messages).
- Adds regression coverage asserting `x-opencode-session` is present and stable across routed requests.

## Root cause

Direct API repro with the same key:

- without `x-opencode-session` → `Model is unavailable`
- with `x-opencode-session` → success

OpenCode sets this header in `packages/opencode/src/session/llm/request.ts`.

## Test plan

- [x] `npx vitest run packages/providers/tests/opencode-go.test.ts`
- [x] Manual: `wstack --provider opencode-go --model deepseek-v4-flash "merhaba"`
- [ ] CI green