### PR TITLE
fix: TUI date-drift in snapshot tests + vitest core alias helper

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { getVitestMaxWorkers } from '../../vitest.workers.ts';
+import { coreAliases } from '../../scripts/vitest-core-aliases.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -13,12 +14,7 @@ export default defineConfig({
       // CLI tests import both @wrongstack/core and @wrongstack/tools; resolving
       // them from source keeps the test environment independent from prebuilt
       // sibling dist/ artifacts.
-      '@wrongstack/core/agent-catalog': path.resolve(
-        __dirname,
-        '../../packages/core/src/coordination/agents/index.ts',
-      ),
-      '@wrongstack/core/agent': path.resolve(__dirname, '../../packages/core/src/core/index.ts'),
-      '@wrongstack/core': path.resolve(__dirname, '../../packages/core/src'),
+      ...coreAliases(path.resolve(__dirname, '../core')),
       '@wrongstack/tools': path.resolve(__dirname, '../../packages/tools/src'),
     },
   },

--- a/packages/requirement-intake/vitest.config.ts
+++ b/packages/requirement-intake/vitest.config.ts
@@ -2,14 +2,14 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { getVitestMaxWorkers } from '../../vitest.workers.ts';
+import { coreAliases } from '../../scripts/vitest-core-aliases.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@wrongstack/core': path.resolve(__dirname, '../core/src'),
-      '@wrongstack/core/utils': path.resolve(__dirname, '../core/src/utils'),
+      ...coreAliases(path.resolve(__dirname, '../core')),
     },
   },
   test: {

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -2,20 +2,14 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { getVitestMaxWorkers } from '../../vitest.workers';
+import { coreAliases } from '../../scripts/vitest-core-aliases.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: {
     alias: {
-      // @wrongstack/core/agent is a special subpath export that maps to
-      // packages/core/src/core (the agent module), NOT to packages/core/src/agent
-      '@wrongstack/core/agent': path.resolve(__dirname, '../core/src/core'),
-      '@wrongstack/core/agent-catalog': path.resolve(
-        __dirname,
-        '../core/src/coordination/agents/index.ts',
-      ),
-      '@wrongstack/core': path.resolve(__dirname, '../core/src'),
+      ...coreAliases(path.resolve(__dirname, '../core')),
     },
   },
   test: {

--- a/packages/sdd/vitest.config.ts
+++ b/packages/sdd/vitest.config.ts
@@ -2,28 +2,14 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { getVitestMaxWorkers } from '../../vitest.workers.ts';
+import { coreAliases } from '../../scripts/vitest-core-aliases.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@wrongstack/core/agent': path.resolve(__dirname, '../core/src/core'),
-      '@wrongstack/core': path.resolve(__dirname, '../core/src'),
-      '@wrongstack/core/kernel': path.resolve(__dirname, '../core/src/kernel'),
-      '@wrongstack/core/types': path.resolve(__dirname, '../core/src/types'),
-      '@wrongstack/core/coordination': path.resolve(__dirname, '../core/src/coordination'),
-      '@wrongstack/core/execution': path.resolve(__dirname, '../core/src/execution'),
-      '@wrongstack/core/utils': path.resolve(__dirname, '../core/src/utils'),
-      '@wrongstack/core/security': path.resolve(__dirname, '../core/src/security'),
-      '@wrongstack/core/storage': path.resolve(__dirname, '../core/src/storage'),
-      '@wrongstack/core/models': path.resolve(__dirname, '../core/src/models'),
-      '@wrongstack/core/skills': path.resolve(__dirname, '../core/src/skills'),
-      '@wrongstack/core/plugin': path.resolve(__dirname, '../core/src/plugin'),
-      '@wrongstack/core/defaults': path.resolve(__dirname, '../core/src/defaults'),
-      '@wrongstack/core/infrastructure': path.resolve(__dirname, '../core/src/infrastructure'),
-      '@wrongstack/core/tasking': path.resolve(__dirname, '../core/src/tasking'),
-      '@wrongstack/core/worktree': path.resolve(__dirname, '../core/src/worktree'),
+      ...coreAliases(path.resolve(__dirname, '../core')),
     },
   },
   test: {

--- a/packages/security-scanner/vitest.config.ts
+++ b/packages/security-scanner/vitest.config.ts
@@ -2,27 +2,14 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { getVitestMaxWorkers } from '../../vitest.workers.ts';
+import { coreAliases } from '../../scripts/vitest-core-aliases.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@wrongstack/core/agent': path.resolve(__dirname, '../core/src/core'),
-      '@wrongstack/core': path.resolve(__dirname, '../core/src'),
-      '@wrongstack/core/kernel': path.resolve(__dirname, '../core/src/kernel'),
-      '@wrongstack/core/types': path.resolve(__dirname, '../core/src/types'),
-      '@wrongstack/core/coordination': path.resolve(__dirname, '../core/src/coordination'),
-      '@wrongstack/core/execution': path.resolve(__dirname, '../core/src/execution'),
-      '@wrongstack/core/utils': path.resolve(__dirname, '../core/src/utils'),
-      '@wrongstack/core/security': path.resolve(__dirname, '../core/src/security'),
-      '@wrongstack/core/storage': path.resolve(__dirname, '../core/src/storage'),
-      '@wrongstack/core/models': path.resolve(__dirname, '../core/src/models'),
-      '@wrongstack/core/skills': path.resolve(__dirname, '../core/src/skills'),
-      '@wrongstack/core/plugin': path.resolve(__dirname, '../core/src/plugin'),
-      '@wrongstack/core/defaults': path.resolve(__dirname, '../core/src/defaults'),
-      '@wrongstack/core/infrastructure': path.resolve(__dirname, '../core/src/infrastructure'),
-      '@wrongstack/core/worktree': path.resolve(__dirname, '../core/src/worktree'),
+      ...coreAliases(path.resolve(__dirname, '../core')),
     },
   },
   test: {

--- a/packages/techstack/vitest.config.ts
+++ b/packages/techstack/vitest.config.ts
@@ -2,16 +2,16 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { getVitestMaxWorkers } from '../../vitest.workers.ts';
+import { coreAliases } from '../../scripts/vitest-core-aliases.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: {
     alias: {
+      ...coreAliases(path.resolve(__dirname, '../core')),
       '@wrongstack/tools': path.resolve(__dirname, '../tools/src'),
       '@wrongstack/tools/languages': path.resolve(__dirname, '../tools/src/languages'),
-      '@wrongstack/core/agent': path.resolve(__dirname, '../core/src/core'),
-      '@wrongstack/core': path.resolve(__dirname, '../core/src'),
     },
   },
   test: {

--- a/packages/tui/src/components/sidebar-panels.tsx
+++ b/packages/tui/src/components/sidebar-panels.tsx
@@ -99,10 +99,10 @@ function liveSessionColor(status: string): string {
   return theme.textMuted;
 }
 
-/** Short relative time like "3m", "2h". */
-function fmtRelative(iso: string | undefined): string {
+/** Short relative time like "3m", "2h". Accepts an injectable `now` for deterministic rendering. */
+function fmtRelative(iso: string | undefined, now: number = Date.now()): string {
   if (!iso) return '';
-  const diff = Date.now() - new Date(iso).getTime();
+  const diff = now - new Date(iso).getTime();
   const min = Math.floor(diff / 60000);
   if (min < 1) return 'now';
   if (min < 60) return `${min}m`;
@@ -942,6 +942,12 @@ export interface SessionsPanelSidebarProps {
   liveSessions?: readonly LiveSessionEntry[] | undefined;
   resumeSessions?: readonly ResumeSessionEntry[] | undefined;
   currentSessionId?: string | undefined;
+  /**
+   * Reference timestamp for relative-time labels (e.g. "2d"). Defaults to
+   * `Date.now()` at render time. Accepts an injected value so visual snapshots
+   * stay deterministic across calendar-day boundaries.
+   */
+  now?: number | undefined;
   width: number;
 }
 
@@ -949,9 +955,11 @@ export function SessionsPanelSidebar({
   liveSessions,
   resumeSessions,
   currentSessionId,
+  now,
   width,
 }: SessionsPanelSidebarProps): React.ReactElement {
   const inner = Math.max(8, width);
+  const nowRef = now ?? Date.now();
   const live = liveSessions?.slice(0, 3) ?? [];
   const resume = resumeSessions?.slice(0, 3) ?? [];
   const total = (liveSessions?.length ?? 0) + (resumeSessions?.length ?? 0);
@@ -1008,7 +1016,7 @@ export function SessionsPanelSidebar({
           />
           {resume.map((rs) => {
             const showRelativeTime = inner >= 24;
-            const rel = showRelativeTime ? fmtRelative(rs.lastActivityAt ?? rs.endedAt) : '';
+            const rel = showRelativeTime ? fmtRelative(rs.lastActivityAt ?? rs.endedAt, nowRef) : '';
             const title = trunc(
               rs.title || rs.lastUserMessage || rs.id,
               Math.max(4, inner - 2 - (showRelativeTime ? displayWidth(rel) + 1 : 0)),

--- a/packages/tui/src/memory-slash-format.ts
+++ b/packages/tui/src/memory-slash-format.ts
@@ -43,10 +43,10 @@ export function parseDate(ts: string): Date | null {
   return Number.isFinite(d.getTime()) ? d : null;
 }
 
-export function daysAgo(ts: string): number | null {
+export function daysAgo(ts: string, now: number = Date.now()): number | null {
   const d = parseDate(ts);
   if (!d) return null;
-  return (Date.now() - d.getTime()) / (1000 * 60 * 60 * 24);
+  return (now - d.getTime()) / (1000 * 60 * 60 * 24);
 }
 
 export function fmtDate(ts: string): string {

--- a/packages/tui/src/memory-slash.ts
+++ b/packages/tui/src/memory-slash.ts
@@ -90,7 +90,7 @@ interface Stats {
   sources: Set<string>;
 }
 
-function computeStats(entries: MemoryEntry[]): Stats {
+function computeStats(entries: MemoryEntry[], now: number = Date.now()): Stats {
   const stats: Stats = {
     total: entries.length,
     perScope: { 'project-agents': 0, 'project-memory': 0, 'user-memory': 0 },
@@ -118,7 +118,7 @@ function computeStats(entries: MemoryEntry[]): Stats {
       stats.noPriorityCount++;
     }
 
-    const days = daysAgo(e.ts);
+    const days = daysAgo(e.ts, now);
     if (days === null) {
       stats.recency.older++;
     } else if (days < 7) {
@@ -227,7 +227,7 @@ function renderSageStats(
   return lines;
 }
 
-function renderSageEntries(memories: SageLike[], compact?: boolean): string[] {
+function renderSageEntries(memories: SageLike[], compact?: boolean, now: number = Date.now()): string[] {
   if (memories.length === 0) return [];
 
   const lines: string[] = [];
@@ -266,7 +266,7 @@ function renderSageEntries(memories: SageLike[], compact?: boolean): string[] {
                 : '⚪';
 
       const date = fmtDate(mem.createdAt);
-      const recency = recencyLabel(daysAgo(mem.createdAt));
+      const recency = recencyLabel(daysAgo(mem.createdAt, now));
 
       const textPreview = mem.text.length > 100 ? `${mem.text.slice(0, 98)}…` : mem.text;
 
@@ -381,11 +381,11 @@ function renderLegacySummary(stats: Stats): string[] {
   return lines;
 }
 
-function renderLegacyEntry(e: MemoryEntry): string {
+function renderLegacyEntry(e: MemoryEntry, now: number = Date.now()): string {
   const typeEmoji = e.type ? (TYPE_EMOJI[e.type] ?? '•') : '•';
   const prioEmoji = e.priority ? (PRIORITY_EMOJI[e.priority] ?? '') : '';
   const date = fmtDate(e.ts);
-  const recency = recencyLabel(daysAgo(e.ts));
+  const recency = recencyLabel(daysAgo(e.ts, now));
 
   const textFirstLine = e.text.split('\n')[0] ?? '';
   const preview = textFirstLine.length > 100 ? `${textFirstLine.slice(0, 98)}…` : textFirstLine;
@@ -1012,7 +1012,7 @@ export function createMemorySlashCommand(deps: MemorySlashDeps) {
 
           // ── Entries ──
           if (filteredMemories.length > 0) {
-            parts.push(...renderSageEntries(filteredMemories, parsed.compact));
+            parts.push(...renderSageEntries(filteredMemories, parsed.compact, Date.now()));
           } else {
             parts.push('*No entries matched the filter.*');
             parts.push('');
@@ -1081,7 +1081,7 @@ export function createMemorySlashCommand(deps: MemorySlashDeps) {
         // ── Legacy stats (computed from the full filtered set so the bar
         // chart accurately reflects the filter, even if entries are capped
         // for display below).
-        const globalStats = computeStats(filteredEntries);
+        const globalStats = computeStats(filteredEntries, Date.now());
         parts.push(...renderLegacySummary(globalStats));
 
         // Legacy migration hint
@@ -1146,7 +1146,7 @@ export function createMemorySlashCommand(deps: MemorySlashDeps) {
             const budget = scopeBudgets.get(scope) ?? scopeFiltered.length;
             const capped = scopeFiltered.slice(0, budget);
             if (capped.length === 0) continue;
-            parts.push(...renderLegacyScopeSection(scope, capped));
+            parts.push(...renderLegacyScopeSection(scope, capped, Date.now()));
           }
         }
 
@@ -1187,7 +1187,7 @@ export function createMemorySlashCommand(deps: MemorySlashDeps) {
 
 // ── Legacy scope section (extracted for clarity) ────────────────────────────
 
-function renderLegacyScopeSection(scope: MemoryScope, entries: MemoryEntry[]): string[] {
+function renderLegacyScopeSection(scope: MemoryScope, entries: MemoryEntry[], now: number = Date.now()): string[] {
   if (entries.length === 0) return [];
 
   const lines: string[] = [];
@@ -1198,7 +1198,7 @@ function renderLegacyScopeSection(scope: MemoryScope, entries: MemoryEntry[]): s
   lines.push('');
 
   for (const e of entries) {
-    lines.push(renderLegacyEntry(e));
+    lines.push(renderLegacyEntry(e, now));
     lines.push('');
   }
 

--- a/packages/tui/tests/sidebar-variants-visual.test.tsx
+++ b/packages/tui/tests/sidebar-variants-visual.test.tsx
@@ -276,6 +276,7 @@ function panelFor(id: PanelId, width: number): ReactElement {
             },
           ]}
           currentSessionId="current-session"
+          now={NOW}
           width={width}
         />
       );

--- a/packages/tui/vitest.config.ts
+++ b/packages/tui/vitest.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { getVitestMaxWorkers } from '../../vitest.workers.ts';
+import { coreAliases } from '../../scripts/vitest-core-aliases.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -10,8 +11,7 @@ export default defineConfig({
     alias: {
       // Force @wrongstack/core to resolve from source during package-local tests
       // instead of following package exports to dist/.
-      '@wrongstack/core/agent': path.resolve(__dirname, '../../packages/core/src/core'),
-      '@wrongstack/core': path.resolve(__dirname, '../../packages/core/src'),
+      ...coreAliases(path.resolve(__dirname, '../core')),
     },
   },
   test: {

--- a/packages/webui/vitest.config.ts
+++ b/packages/webui/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getVitestMaxWorkers } from '../../vitest.workers';
+import { coreAliases } from '../../scripts/vitest-core-aliases.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -131,12 +132,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
       // Force @wrongstack/core to resolve from source (packages/core/src) instead
       // of going through the package's "exports" field which points to dist/.
-      '@wrongstack/core/agent-catalog': path.resolve(
-        __dirname,
-        '../../packages/core/src/coordination/agents/index.ts',
-      ),
-      '@wrongstack/core/agent': path.resolve(__dirname, '../../packages/core/src/core'),
-      '@wrongstack/core': path.resolve(__dirname, '../../packages/core/src'),
+      ...coreAliases(path.resolve(__dirname, '../core')),
       '@wrongstack/kanban': path.resolve(__dirname, '../../packages/kanban/src'),
       '@wrongstack/sdd': path.resolve(__dirname, '../../packages/sdd/src'),
       // Force @wrongstack/webui-server to resolve from source (its src/) instead

--- a/scripts/vitest-core-aliases.mjs
+++ b/scripts/vitest-core-aliases.mjs
@@ -1,0 +1,67 @@
+/**
+ * Generates vitest `resolve.alias` entries for @wrongstack/core sub-path
+ * exports whose source layout diverges from the export name.
+ *
+ * Most exports resolve correctly through the bare '@wrongstack/core' → 'src/'
+ * prefix alias (e.g. './utils' → src/utils/, './types' → src/types/). But a
+ * few exports have a dist/source path that does NOT match the export name —
+ * these need explicit aliases or they resolve to a nonexistent directory.
+ *
+ * Known divergent exports:
+ *   ./agent          → dist/core/index.js         (not src/agent/)
+ *   ./agent-catalog  → dist/coordination/agents/   (not src/agent-catalog/)
+ *
+ * This helper reads packages/core/package.json at config-load time and
+ * auto-detects divergence so new exceptions are picked up automatically.
+ *
+ * Usage from a sibling package (packages/X/vitest.config.ts):
+ *   ...coreAliases(path.resolve(__dirname, '../core'))
+ * Usage from the repo root (vitest.config.ts):
+ *   ...coreAliases(path.resolve(__dirname, 'packages/core'))
+ *
+ * @param {string} corePackageDir  Absolute path to packages/core/.
+ * @returns {Record<string, string>}  Alias map for resolve.alias.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export function coreAliases(corePackageDir) {
+  const corePkgPath = resolve(corePackageDir, 'package.json');
+  const corePkg = JSON.parse(readFileSync(corePkgPath, 'utf8'));
+  const aliases = /** @type {Record<string, string>} */ ({});
+
+  for (const [exportKey, exportValue] of Object.entries(corePkg.exports)) {
+    if (exportKey === '.' || exportKey === './package.json' || exportKey.includes('*')) continue;
+
+    if (typeof exportValue !== 'object' || exportValue === null) continue;
+    const importPath = /** @type {string | undefined} */ (exportValue.import);
+    if (typeof importPath !== 'string') continue;
+
+    // "./dist/coordination/agents/index.js" → "coordination/agents"
+    const srcRel = importPath
+      .replace(/^\.\/dist\//, '')
+      .replace(/\.js$/, '')
+      .replace(/\/index$/, '');
+
+    // "./agent-catalog" → "agent-catalog"
+    const exportRel = exportKey.slice(2); // strip leading "./"
+
+    // Only alias when the source path diverges from the export name.
+    // Matching exports (e.g. "./utils" → src/utils/) are handled by the
+    // bare '@wrongstack/core' → src/ prefix alias — adding an explicit
+    // alias for them would cause @rollup/plugin-alias prefix conflicts
+    // (e.g. '@wrongstack/core/utils' would shadow
+    // '@wrongstack/core/utils/sage-output-block').
+    if (srcRel === exportRel) continue;
+
+    const aliasKey = `@wrongstack/core/${exportRel}`;
+    aliases[aliasKey] = resolve(corePackageDir, 'src', srcRel);
+  }
+
+  // Bare alias LAST: prefix-matching means '@wrongstack/core' catches any
+  // sub-path that wasn't explicitly aliased above, resolving to
+  // src/<sub-path> which Vite resolves to the .ts file.
+  aliases['@wrongstack/core'] = resolve(corePackageDir, 'src');
+
+  return aliases;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { getVitestMaxWorkers } from './vitest.workers';
+import { coreAliases } from './scripts/vitest-core-aliases.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -16,12 +17,7 @@ export default defineConfig({
       // of going through the package's "exports" field which points to dist/.
       // The dist/ output is only needed for published consumers; local vitest
       // workers (fork pool) need to import from source directly.
-      '@wrongstack/core/agent': path.resolve(__dirname, './packages/core/src/core'),
-      '@wrongstack/core/agent-catalog': path.resolve(
-        __dirname,
-        './packages/core/src/coordination/agents/index.ts',
-      ),
-      '@wrongstack/core': path.resolve(__dirname, './packages/core/src'),
+      ...coreAliases(path.resolve(__dirname, 'packages/core')),
       // Same for @wrongstack/tools: CLI tests import wiring that reaches the
       // tools package, and root Vitest must not require a prebuilt dist/.
       '@wrongstack/tools': path.resolve(__dirname, './packages/tools/src'),


### PR DESCRIPTION
## Summary

Three related fixes that cleared 28+ failing/blocking test suites and prevent recurrence.

### 1. TUI date-drift fix (root cause)

`fmtRelative()` in `sidebar-panels.tsx` and `daysAgo()` in `memory-slash-format.ts` called `Date.now()` directly. The `sidebar-variants-visual` snapshot test pinned `NOW = 2026-08-07` but the formatters ignored it and used the real wall clock, so day-counts drifted by +1 when the calendar advanced — breaking 2 snapshot tests.

**Fix:** Both formatters now accept an injectable `now = Date.now()` parameter (matching the existing codebase convention: `formatRelativeTime`, `fmtAgo`, `elapsedText`). The test passes `now={NOW}`. `now` is threaded through all callers in `memory-slash.ts`.

### 2. Vitest `agent-catalog` alias fix

9 vitest configs alias `@wrongstack/core` → `../core/src` for source-local testing, but the bare prefix alias doesn't match sub-path exports like `@wrongstack/core/agent-catalog`. When the `coordination/agents` export was added, 26 TUI test suites + 5 techstack suites started failing with `Cannot find package '@wrongstack/core/agent-catalog'`.

**Fix:** Added explicit `@wrongstack/core/agent-catalog` → `src/coordination/agents` aliases to all affected configs.

### 3. Shared `coreAliases()` helper (prevents recurrence)

Extracted the alias logic into `scripts/vitest-core-aliases.mjs`. It reads `packages/core/package.json` exports and auto-detects **divergent** sub-paths (where the source path doesn't match the export name). Only those need explicit aliases — the bare `@wrongstack/core → src/` prefix handles everything else.

All 9 affected configs migrated from hand-maintained aliases to `...coreAliases(...)`.

> **Why only divergent paths:** `@rollup/plugin-alias` does prefix matching in insertion order. Aliasing all sub-paths causes shorter aliases to corrupt longer imports (e.g., `@wrongstack/core/utils` matches before `@wrongstack/core/utils/sage-output-block`).

## Changed files (10)

| File | Change |
|------|--------|
| `packages/tui/src/components/sidebar-panels.tsx` | `fmtRelative(ts, now)` + `SessionsPanelSidebar` `now` prop |
| `packages/tui/src/memory-slash-format.ts` | `daysAgo(ts, now)` injectable param |
| `packages/tui/src/memory-slash.ts` | Thread `now` through 4 callers |
| `packages/tui/tests/sidebar-variants-visual.test.tsx` | Pass `now={NOW}` |
| `scripts/vitest-core-aliases.mjs` | **New** — shared alias helper |
| `vitest.config.ts` (root) | Migrate to `coreAliases()` |
| `packages/tui/vitest.config.ts` | Migrate to `coreAliases()` |
| `packages/webui/vitest.config.ts` | Migrate to `coreAliases()` |
| `packages/cli/vitest.config.ts` | Migrate to `coreAliases()` |
| `packages/{techstack,security-scanner,sdd,requirement-intake,runtime}/vitest.config.ts` | Migrate to `coreAliases()` |

## Test results

- **~17,000+ tests passed** across 28 packages — zero regressions
- Previously failing: 2 TUI snapshots ✅, 26 TUI suites ✅, 5 techstack suites ✅
- `tsc --noEmit` clean, `biome format` clean
