### PR TITLE
fix(plugins): handle Tool payloads in session recap

### DIFF
--- a/packages/plugins/src/session-recap/index.ts
+++ b/packages/plugins/src/session-recap/index.ts
@@ -395,20 +395,19 @@ const plugin: Plugin = {
       // event bus. We use a wildcard pattern to catch all tool events.
       const offTool = api.onPattern('tool.*', (eventName: string, payload: unknown) => {
         touchActivity();
-        // eventName is `tool.started`, `tool.completed`, etc. The
-        // payload typically has a `tool` field with the tool name.
-        const p = payload as { tool?: string; name?: string } | null;
-        const toolName = p?.tool ?? p?.name ?? eventName;
-        if (typeof toolName === 'string') bumpToolCount(toolName);
-        // Detect commits: the `git_autocommit` tool reports a
-        // successful commit via its result. We treat any `git_*`
-        // tool success as a potential commit; the exact tracking
-        // happens in the tool-result handler.
-        if (toolName === 'git_autocommit' || toolName.startsWith('git ')) {
-          // Most git operations don't create a commit; only the
-          // dedicated git_autocommit tool is treated as such.
-          // We still bump on any git_* tool below.
-        }
+        // eventName is `tool.started`, `tool.completed`, etc. Most payloads
+        // expose the tool name directly, while confirmation events carry the
+        // full Tool object under `tool`.
+        const p = payload as { tool?: string | { name?: unknown }; name?: unknown } | null;
+        const toolName =
+          typeof p?.tool === 'string'
+            ? p.tool
+            : typeof p?.tool?.name === 'string'
+              ? p.tool.name
+              : typeof p?.name === 'string'
+                ? p.name
+                : eventName;
+        bumpToolCount(toolName);
       });
       state.eventUnsubscribers.push(offTool);
 

--- a/packages/plugins/tests/session-recap.test.ts
+++ b/packages/plugins/tests/session-recap.test.ts
@@ -134,6 +134,36 @@ describe('session-recap plugin', () => {
       expect(onPatternCalls).toContain('tool.result');
     });
 
+    it('resolves tool names from Tool objects and legacy event payloads', async () => {
+      const api = createMockAPI({ withMailbox: true });
+      sessionRecapPlugin.setup(api as never);
+      const toolHandler = vi
+        .mocked(api.onPattern)
+        .mock.calls.find((c) => c?.[0] === 'tool.*')?.[1] as
+        | ((eventName: string, payload: unknown) => void)
+        | undefined;
+
+      expect(toolHandler).toBeDefined();
+      expect(() => toolHandler?.('tool.confirm_needed', { tool: { name: 'write' } })).not.toThrow();
+      toolHandler?.('tool.executed', { tool: 'read' });
+      toolHandler?.('tool.completed', { name: 'edit' });
+      toolHandler?.('tool.fallback', null);
+
+      const tool = vi.mocked(api.tools.register).mock.calls[0]?.[0] as {
+        execute: () => Promise<unknown>;
+      };
+      const status = (await tool.execute()) as {
+        metrics: { toolCalls: { total: number; top: Array<[string, number]> } };
+      };
+      expect(status.metrics.toolCalls.total).toBe(4);
+      expect(Object.fromEntries(status.metrics.toolCalls.top)).toEqual({
+        write: 1,
+        read: 1,
+        edit: 1,
+        'tool.fallback': 1,
+      });
+    });
+
     it('configSchema defines enabled, subjectPrefix, includeTranscriptTail, maxBodyChars', () => {
       const schema = sessionRecapPlugin.configSchema as Record<
         string,


### PR DESCRIPTION
## Summary

- resolve tool names from both legacy string payloads and `tool.confirm_needed` payloads that carry a full `Tool` object
- remove the dead `startsWith` branch that threw when `payload.tool` was an object
- add regression coverage for `tool.name`, string `tool`, string `name`, and event-name fallback payloads

## Root cause

`session-recap` subscribed to `tool.*` and assumed `payload.tool` was always a string. `tool.confirm_needed` supplies the full `Tool` object, so the listener called `startsWith()` on an object. `EventBus` isolated the exception, but every confirmation emitted an error and the recap missed the tool name.

## Verification

- `pnpm exec vitest run tests/session-recap.test.ts --config vitest.config.ts` — 24/24 passed
- `pnpm --filter @wrongstack/plugins typecheck` — passed
- `pnpm exec biome check packages/plugins/src/session-recap/index.ts packages/plugins/tests/session-recap.test.ts` — passed
- `git diff HEAD^..HEAD --check` — passed

## Scope

The commit changes only the session-recap implementation and its focused regression test.